### PR TITLE
Clone submodules shallowly

### DIFF
--- a/.github/workflows/static-analysis-pr.yml
+++ b/.github/workflows/static-analysis-pr.yml
@@ -9,8 +9,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Update submodules
-      run: git submodule update --init --recursive
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -36,8 +34,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Update submodules
-      run: git submodule update --init --recursive
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following parallel programming technologies are considered in practice:
 
 ## 0. Download all submodules
   ```
-  git submodule update --init --recursive
+  git submodule update --init --recursive --depth=1
   ```
 ## 1. Set up your environment
 ### Static analysis of project (optional)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - python -m pip install xlsxwriter
 
 build_script:
-  - cmd: git submodule update --init --recursive
+  - cmd: git submodule update --init --recursive --depth=1
   - cmd: mkdir build
   - cmd: cmake -S . -B build   ^
                -D USE_SEQ=ON   ^


### PR DESCRIPTION
Cloning git submodules without history saves up almost 1,2GB storage space (~700MB vs 1,9GB on NTFS) and reduces the duration and size of the download.

This is the default behavior of [GitHub Checkout Action](https://github.com/actions/checkout#:~:text=Only%20a%20single%20commit%20is%20fetched%20by%20default%2C%20for%20the%20ref/SHA%20that%20triggered%20the%20workflow.) when submodules cloning is enabled. There's a mistakenly added extra step in `static-analysis-pr.yml` which does the same thing one more time, slowing the pipeline.