### PR TITLE
Васильев Сергей. Задача 1. Вариант 7. Нахождение наиболее близких соседних элементов вектора.

### DIFF
--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
@@ -22,9 +22,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_small_vector) {
   }
 
   vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(task_parallel.validation(), true);
-  }
+  ASSERT_EQ(task_parallel.validation(), true);
   task_parallel.pre_processing();
   task_parallel.run();
   task_parallel.post_processing();
@@ -66,9 +64,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_random_vector) {
   }
 
   vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(task_parallel.validation(), true);
-  }
+  ASSERT_EQ(task_parallel.validation(), true);
   task_parallel.pre_processing();
   task_parallel.run();
   task_parallel.post_processing();
@@ -109,9 +105,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
   }
 
   vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(task_parallel.validation(), true);
-  }
+  ASSERT_EQ(task_parallel.validation(), true);
   task_parallel.pre_processing();
   task_parallel.run();
   task_parallel.post_processing();
@@ -125,7 +119,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
     taskDataSeq->outputs_count.emplace_back(expected_result.size());
 
     vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI task_sequential(taskDataSeq);
-    ASSERT_EQ(task_sequential.validation(), true);
+    task_sequential.validation();
     task_sequential.pre_processing();
     task_sequential.run();
     task_sequential.post_processing();
@@ -133,27 +127,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
     ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
     ASSERT_EQ(global_result[1], expected_result[1]);  // index1
     ASSERT_EQ(global_result[2], expected_result[2]);  // index2
-  }
-}
-
-TEST(vasilev_s_nearest_neighbor_elements_mpi, test_single_element_Vector) {
-  boost::mpi::communicator world;
-  std::vector<int> global_vec;
-  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
-
-  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-
-  if (world.rank() == 0) {
-    global_vec = {42};
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
-    taskDataPar->inputs_count.emplace_back(global_vec.size());
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
-    taskDataPar->outputs_count.emplace_back(global_result.size());
-  }
-
-  vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(task_parallel.validation(), false);
   }
 }
 
@@ -173,9 +146,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_negative_numbers) {
   }
 
   vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(task_parallel.validation(), true);
-  }
+  task_parallel.validation();
   task_parallel.pre_processing();
   task_parallel.run();
   task_parallel.post_processing();
@@ -198,4 +169,15 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_negative_numbers) {
     ASSERT_EQ(global_result[1], expected_result[1]);  // index1
     ASSERT_EQ(global_result[2], expected_result[2]);  // index2
   }
+}
+
+TEST(LocalResultTest, OperatorLessThan) {
+  vasilev_s_nearest_neighbor_elements_mpi::LocalResult a{5, 10, 11};
+  vasilev_s_nearest_neighbor_elements_mpi::LocalResult b{10, 5, 6};
+  vasilev_s_nearest_neighbor_elements_mpi::LocalResult c{5, 9, 10};
+
+  EXPECT_TRUE(a < b);   // a.min_diff < b.min_diff, должно быть true
+  EXPECT_FALSE(b < a);  // b.min_diff > a.min_diff, должно быть false
+  EXPECT_FALSE(a < c);  // a.min_diff == c.min_diff, но a.index1 < c.index1, должно быть true
+  EXPECT_TRUE(c < a);   // c.min_diff == a.min_diff, но c.index1 > a.index1, должно быть false
 }

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
@@ -11,7 +11,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_small_vector) {
   std::vector<int> global_vec;
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
-  // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
@@ -31,7 +30,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_small_vector) {
   task_parallel.post_processing();
 
   if (world.rank() == 0) {
-    // Создание ожидаемого результата с использованием последовательной версии
     std::vector<int> expected_result(3, 0);
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
@@ -45,7 +43,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_small_vector) {
     task_sequential.run();
     task_sequential.post_processing();
 
-    // Проверка результатов
     ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
     ASSERT_EQ(global_result[1], expected_result[1]);  // index1
     ASSERT_EQ(global_result[2], expected_result[2]);  // index2
@@ -57,7 +54,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_random_vector) {
   std::vector<int> global_vec;
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
-  // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
@@ -78,7 +74,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_random_vector) {
   task_parallel.post_processing();
 
   if (world.rank() == 0) {
-    // Создание ожидаемого результата с использованием последовательной версии
     std::vector<int> expected_result(3, 0);
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
@@ -92,7 +87,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_random_vector) {
     task_sequential.run();
     task_sequential.post_processing();
 
-    // Проверка результатов
     ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
     ASSERT_EQ(global_result[1], expected_result[1]);  // index1
     ASSERT_EQ(global_result[2], expected_result[2]);  // index2
@@ -104,7 +98,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
   std::vector<int> global_vec;
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
-  // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
@@ -124,7 +117,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
   task_parallel.post_processing();
 
   if (world.rank() == 0) {
-    // Создание ожидаемого результата с использованием последовательной версии
     std::vector<int> expected_result(3, 0);
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
@@ -138,8 +130,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
     task_sequential.run();
     task_sequential.post_processing();
 
-    // Проверка результатов
-    ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff (должно быть 0)
+    ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
     ASSERT_EQ(global_result[1], expected_result[1]);  // index1
     ASSERT_EQ(global_result[2], expected_result[2]);  // index2
   }
@@ -150,11 +141,10 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_single_element_Vector) {
   std::vector<int> global_vec;
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
-  // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
-    global_vec = {42};  // Вектор из одного элемента
+    global_vec = {42};
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
     taskDataPar->inputs_count.emplace_back(global_vec.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
@@ -163,7 +153,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_single_element_Vector) {
 
   vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
   if (world.rank() == 0) {
-    // Валидация должна вернуть false, так как недостаточно элементов для сравнения
     ASSERT_EQ(task_parallel.validation(), false);
   }
 }
@@ -173,7 +162,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_negative_numbers) {
   std::vector<int> global_vec;
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
-  // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
@@ -193,7 +181,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_negative_numbers) {
   task_parallel.post_processing();
 
   if (world.rank() == 0) {
-    // Создание ожидаемого результата с использованием последовательной версии
     std::vector<int> expected_result(3, 0);
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
@@ -207,7 +194,6 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_negative_numbers) {
     task_sequential.run();
     task_sequential.post_processing();
 
-    // Проверка результатов
     ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
     ASSERT_EQ(global_result[1], expected_result[1]);  // index1
     ASSERT_EQ(global_result[2], expected_result[2]);  // index2

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
@@ -1,0 +1,215 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+
+#include "mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp"
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_small_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_vec = {5, 3, 8, 7, 2};
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
+  if (world.rank() == 0) {
+    ASSERT_EQ(task_parallel.validation(), true);
+  }
+  task_parallel.pre_processing();
+  task_parallel.run();
+  task_parallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Создание ожидаемого результата с использованием последовательной версии
+    std::vector<int> expected_result(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_result.data()));
+    taskDataSeq->outputs_count.emplace_back(expected_result.size());
+
+    vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI task_sequential(taskDataSeq);
+    ASSERT_EQ(task_sequential.validation(), true);
+    task_sequential.pre_processing();
+    task_sequential.run();
+    task_sequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
+    ASSERT_EQ(global_result[1], expected_result[1]);  // index1
+    ASSERT_EQ(global_result[2], expected_result[2]);  // index2
+  }
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_random_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = 1000;
+    global_vec = vasilev_s_nearest_neighbor_elements_mpi::getRandomVector(count_size_vector);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
+  if (world.rank() == 0) {
+    ASSERT_EQ(task_parallel.validation(), true);
+  }
+  task_parallel.pre_processing();
+  task_parallel.run();
+  task_parallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Создание ожидаемого результата с использованием последовательной версии
+    std::vector<int> expected_result(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_result.data()));
+    taskDataSeq->outputs_count.emplace_back(expected_result.size());
+
+    vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI task_sequential(taskDataSeq);
+    ASSERT_EQ(task_sequential.validation(), true);
+    task_sequential.pre_processing();
+    task_sequential.run();
+    task_sequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
+    ASSERT_EQ(global_result[1], expected_result[1]);  // index1
+    ASSERT_EQ(global_result[2], expected_result[2]);  // index2
+  }
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_equal_elements) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_vec = {7, 7, 7, 7, 7};
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
+  if (world.rank() == 0) {
+    ASSERT_EQ(task_parallel.validation(), true);
+  }
+  task_parallel.pre_processing();
+  task_parallel.run();
+  task_parallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Создание ожидаемого результата с использованием последовательной версии
+    std::vector<int> expected_result(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_result.data()));
+    taskDataSeq->outputs_count.emplace_back(expected_result.size());
+
+    vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI task_sequential(taskDataSeq);
+    ASSERT_EQ(task_sequential.validation(), true);
+    task_sequential.pre_processing();
+    task_sequential.run();
+    task_sequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff (должно быть 0)
+    ASSERT_EQ(global_result[1], expected_result[1]);  // index1
+    ASSERT_EQ(global_result[2], expected_result[2]);  // index2
+  }
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_single_element_Vector) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_vec = {42};  // Вектор из одного элемента
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
+  if (world.rank() == 0) {
+    // Валидация должна вернуть false, так как недостаточно элементов для сравнения
+    ASSERT_EQ(task_parallel.validation(), false);
+  }
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_negative_numbers) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_vec = {-10, -20, -15, -30, -25};
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI task_parallel(taskDataPar);
+  if (world.rank() == 0) {
+    ASSERT_EQ(task_parallel.validation(), true);
+  }
+  task_parallel.pre_processing();
+  task_parallel.run();
+  task_parallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Создание ожидаемого результата с использованием последовательной версии
+    std::vector<int> expected_result(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_result.data()));
+    taskDataSeq->outputs_count.emplace_back(expected_result.size());
+
+    vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI task_sequential(taskDataSeq);
+    ASSERT_EQ(task_sequential.validation(), true);
+    task_sequential.pre_processing();
+    task_sequential.run();
+    task_sequential.post_processing();
+
+    // Проверка результатов
+    ASSERT_EQ(global_result[0], expected_result[0]);  // min_diff
+    ASSERT_EQ(global_result[1], expected_result[1]);  // index1
+    ASSERT_EQ(global_result[2], expected_result[2]);  // index2
+  }
+}

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
@@ -176,8 +176,8 @@ TEST(LocalResultTest, OperatorLessThan) {
   vasilev_s_nearest_neighbor_elements_mpi::LocalResult b{10, 5, 6};
   vasilev_s_nearest_neighbor_elements_mpi::LocalResult c{5, 9, 10};
 
-  EXPECT_TRUE(a < b);   // a.min_diff < b.min_diff, должно быть true
-  EXPECT_FALSE(b < a);  // b.min_diff > a.min_diff, должно быть false
-  EXPECT_FALSE(a < c);  // a.min_diff == c.min_diff, но a.index1 < c.index1, должно быть true
-  EXPECT_TRUE(c < a);   // c.min_diff == a.min_diff, но c.index1 > a.index1, должно быть false
+  EXPECT_TRUE(a < b);
+  EXPECT_FALSE(b < a);
+  EXPECT_FALSE(a < c);
+  EXPECT_TRUE(c < a);
 }

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
@@ -21,9 +21,9 @@ struct LocalResult {
   // Функция сериализации для Boost.Serialization
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version) {
-    ar& min_diff;
-    ar& index1;
-    ar& index2;
+    ar & min_diff;
+    ar & index1;
+    ar & index2;
   }
 };
 

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace vasilev_s_nearest_neighbor_elements_mpi {
+
+struct LocalResult {
+  int min_diff;
+  int index1;
+  int index2;
+
+  // Функция сериализации для Boost.Serialization
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar & min_diff;
+    ar & index1;
+    ar & index2;
+  }
+};
+
+std::vector<int> getRandomVector(int sz);
+
+class FindClosestNeighborsSequentialMPI : public ppc::core::Task {
+ public:
+  explicit FindClosestNeighborsSequentialMPI(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> input_;
+  int min_diff_{};
+  int index1_{};
+  int index2_{};
+};
+
+class FindClosestNeighborsParallelMPI : public ppc::core::Task {
+ public:
+  explicit FindClosestNeighborsParallelMPI(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> local_input_;
+  int min_diff_{};
+  int index1_{};
+  int index2_{};
+  int local_offset_{};
+  boost::mpi::communicator world;
+};
+
+}  // namespace vasilev_s_nearest_neighbor_elements_mpi

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
@@ -18,16 +18,13 @@ struct LocalResult {
   int index1;
   int index2;
 
-  // Оператор сравнения для all_reduce
   bool operator<(const LocalResult& other) const {
     if (min_diff != other.min_diff) {
       return min_diff < other.min_diff;
     }
-    // Если min_diff равны, приоритет отдаем меньшему index1
     return index1 < other.index1;
   }
 
-  // Функция сериализации для Boost.Serialization
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version) {
     ar & min_diff;

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
@@ -18,6 +18,15 @@ struct LocalResult {
   int index1;
   int index2;
 
+  // Оператор сравнения для all_reduce
+  bool operator<(const LocalResult& other) const {
+    if (min_diff != other.min_diff) {
+      return min_diff < other.min_diff;
+    }
+    // Если min_diff равны, приоритет отдаем меньшему index1
+    return index1 < other.index1;
+  }
+
   // Функция сериализации для Boost.Serialization
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version) {
@@ -28,6 +37,7 @@ struct LocalResult {
 };
 
 std::vector<int> getRandomVector(int sz);
+std::pair<std::vector<int>, std::vector<int>> partitionArray(int amount, int num_partitions);
 
 class FindClosestNeighborsSequentialMPI : public ppc::core::Task {
  public:
@@ -56,11 +66,12 @@ class FindClosestNeighborsParallelMPI : public ppc::core::Task {
 
  private:
   std::vector<int> input_;
-  std::vector<int> local_input_;
-  int min_diff_{};
-  int index1_{};
-  int index2_{};
-  int local_offset_{};
+  int rank_offset_;
+  int min_diff_ = std::numeric_limits<int>::max();
+  int index1_ = -1;
+  int index2_ = -1;
+  std::vector<int> distribution;
+  std::vector<int> displacement;
   boost::mpi::communicator world;
 };
 

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp
@@ -21,9 +21,9 @@ struct LocalResult {
   // Функция сериализации для Boost.Serialization
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version) {
-    ar & min_diff;
-    ar & index1;
-    ar & index2;
+    ar& min_diff;
+    ar& index1;
+    ar& index2;
   }
 };
 

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
@@ -3,18 +3,33 @@
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
 #include <boost/mpi/timer.hpp>
+#include <random>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp"
 
+std::vector<int> getRandomVector(int sz) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_int_distribution<> dist(0, 1000);
+  std::vector<int> vec(sz);
+  for (int i = 0; i < sz; i++) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+
 TEST(vasilev_s_nearest_neighbor_elements_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
-  std::vector<int> global_vec = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  std::vector<int> global_vec;
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  int count_size_vector;
   if (world.rank() == 0) {
+    count_size_vector = 1000000;
+    global_vec = getRandomVector(count_size_vector);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
     taskDataPar->inputs_count.emplace_back(global_vec.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
@@ -70,7 +85,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_task_run) {
   int count_size_vector;
   if (world.rank() == 0) {
     count_size_vector = 1000000;
-    global_vec = vasilev_s_nearest_neighbor_elements_mpi::getRandomVector(count_size_vector);
+    global_vec = getRandomVector(count_size_vector);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
     taskDataPar->inputs_count.emplace_back(global_vec.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
@@ -10,14 +10,11 @@
 
 TEST(vasilev_s_nearest_neighbor_elements_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
-  std::vector<int> global_vec;
+  std::vector<int> global_vec = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   std::vector<int> global_result(3, 0);  // min_diff, index1, index2
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-  int count_size_vector;
   if (world.rank() == 0) {
-    count_size_vector = 100000;
-    global_vec = vasilev_s_nearest_neighbor_elements_mpi::getRandomVector(count_size_vector);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
     taskDataPar->inputs_count.emplace_back(global_vec.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
@@ -26,9 +23,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_pipeline_run) {
 
   auto taskParallel =
       std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(taskParallel->validation(), true);
-  }
+  ASSERT_EQ(taskParallel->validation(), true);
   taskParallel->pre_processing();
   taskParallel->run();
   taskParallel->post_processing();
@@ -84,9 +79,7 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_task_run) {
 
   auto taskParallel =
       std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
-  if (world.rank() == 0) {
-    ASSERT_EQ(taskParallel->validation(), true);
-  }
+  ASSERT_EQ(taskParallel->validation(), true);
   taskParallel->pre_processing();
   taskParallel->run();
   taskParallel->post_processing();

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/timer.hpp>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp"
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  int count_size_vector;
+  if (world.rank() == 0) {
+    count_size_vector = 100000;
+    global_vec = vasilev_s_nearest_neighbor_elements_mpi::getRandomVector(count_size_vector);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  auto taskParallel = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
+  if (world.rank() == 0) {
+    ASSERT_EQ(taskParallel->validation(), true);
+  }
+  taskParallel->pre_processing();
+  taskParallel->run();
+  taskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+
+    std::vector<int> reference_result(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI>(taskDataSeq);
+    ASSERT_EQ(taskSequential->validation(), true);
+    taskSequential->pre_processing();
+    taskSequential->run();
+    taskSequential->post_processing();
+
+    ASSERT_EQ(global_result[0], reference_result[0]);  // min_diff
+    ASSERT_EQ(global_result[1], reference_result[1]);  // index1
+    ASSERT_EQ(global_result[2], reference_result[2]);  // index2
+  }
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  std::vector<int> global_vec;
+  std::vector<int> global_result(3, 0);  // min_diff, index1, index2
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  int count_size_vector;
+  if (world.rank() == 0) {
+    count_size_vector = 1000000;
+    global_vec = vasilev_s_nearest_neighbor_elements_mpi::getRandomVector(count_size_vector);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+    taskDataPar->outputs_count.emplace_back(global_result.size());
+  }
+
+  auto taskParallel = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
+  if (world.rank() == 0) {
+    ASSERT_EQ(taskParallel->validation(), true);
+  }
+  taskParallel->pre_processing();
+  taskParallel->run();
+  taskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+
+    std::vector<int> reference_result(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_result.size());
+
+    auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI>(taskDataSeq);
+    ASSERT_EQ(taskSequential->validation(), true);
+    taskSequential->pre_processing();
+    taskSequential->run();
+    taskSequential->post_processing();
+
+    ASSERT_EQ(global_result[0], reference_result[0]);  // min_diff
+    ASSERT_EQ(global_result[1], reference_result[1]);  // index1
+    ASSERT_EQ(global_result[2], reference_result[2]);  // index2
+  }
+}

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
@@ -24,7 +24,8 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_pipeline_run) {
     taskDataPar->outputs_count.emplace_back(global_result.size());
   }
 
-  auto taskParallel = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
+  auto taskParallel =
+      std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
   if (world.rank() == 0) {
     ASSERT_EQ(taskParallel->validation(), true);
   }
@@ -52,7 +53,8 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_pipeline_run) {
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
     taskDataSeq->outputs_count.emplace_back(reference_result.size());
 
-    auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI>(taskDataSeq);
+    auto taskSequential =
+        std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI>(taskDataSeq);
     ASSERT_EQ(taskSequential->validation(), true);
     taskSequential->pre_processing();
     taskSequential->run();
@@ -80,7 +82,8 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_task_run) {
     taskDataPar->outputs_count.emplace_back(global_result.size());
   }
 
-  auto taskParallel = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
+  auto taskParallel =
+      std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI>(taskDataPar);
   if (world.rank() == 0) {
     ASSERT_EQ(taskParallel->validation(), true);
   }
@@ -108,7 +111,8 @@ TEST(vasilev_s_nearest_neighbor_elements_mpi, test_task_run) {
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
     taskDataSeq->outputs_count.emplace_back(reference_result.size());
 
-    auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI>(taskDataSeq);
+    auto taskSequential =
+        std::make_shared<vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI>(taskDataSeq);
     ASSERT_EQ(taskSequential->validation(), true);
     taskSequential->pre_processing();
     taskSequential->run();

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/src/ops_mpi.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/src/ops_mpi.cpp
@@ -61,12 +61,10 @@ bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI:
   return true;
 }
 
-//------------------------------------------------------------------------------------------
-
 std::pair<std::vector<int>, std::vector<int>> vasilev_s_nearest_neighbor_elements_mpi::partitionArray(
     int amount, int num_partitions) {
-  std::vector<int> displs(num_partitions);  // смещения
-  std::vector<int> sizes(num_partitions);   // размеры каждого подмассива
+  std::vector<int> displs(num_partitions);
+  std::vector<int> sizes(num_partitions);
   int total_elements = amount + num_partitions - 1;
   int base_size = total_elements / num_partitions;
   int extra_elements = total_elements % num_partitions;
@@ -149,7 +147,6 @@ bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::r
       int current_index1 = static_cast<int>(rank_offset_ + i);
       int current_index2 = static_cast<int>(rank_offset_ + i + 1);
 
-      // Обновляем, если нашли меньшее значение diff или при равенстве diff — меньший индекс
       if (diff < local_result.min_diff || (diff == local_result.min_diff && current_index1 < local_result.index1)) {
         local_result.min_diff = diff;
         local_result.index1 = current_index1;
@@ -158,7 +155,6 @@ bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::r
     }
   }
 
-  // Собираем минимальные значения с помощью all_reduce
   LocalResult global_result;
   boost::mpi::reduce(world, local_result, global_result, boost::mpi::minimum<LocalResult>(), 0);
 

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/src/ops_mpi.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/src/ops_mpi.cpp
@@ -155,7 +155,7 @@ bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::r
     }
   }
 
-  LocalResult global_result;
+  LocalResult global_result{std::numeric_limits<int>::max(), -1, -1};
   boost::mpi::reduce(world, local_result, global_result, boost::mpi::minimum<LocalResult>(), 0);
 
   if (world.rank() == 0) {

--- a/tasks/mpi/vasilev_s_nearest_neighbor_elements/src/ops_mpi.cpp
+++ b/tasks/mpi/vasilev_s_nearest_neighbor_elements/src/ops_mpi.cpp
@@ -1,0 +1,178 @@
+#include "mpi/vasilev_s_nearest_neighbor_elements/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+#include <vector>
+
+std::vector<int> vasilev_s_nearest_neighbor_elements_mpi::getRandomVector(int sz) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_int_distribution<> dist(0, 1000);
+  std::vector<int> vec(sz);
+  for (int i = 0; i < sz; i++) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI::pre_processing() {
+  internal_order_test();
+  input_.resize(taskData->inputs_count[0]);
+  auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+  for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
+    input_[i] = tmp_ptr[i];
+  }
+  min_diff_ = std::numeric_limits<int>::max();
+  index1_ = -1;
+  index2_ = -1;
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI::validation() {
+  internal_order_test();
+  if (taskData->inputs_count.empty() || taskData->inputs_count[0] < 2) {
+    return false;
+  }
+  return taskData->outputs_count[0] == 3;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI::run() {
+  internal_order_test();
+  for (size_t i = 0; i < input_.size() - 1; ++i) {
+    int diff = std::abs(input_[i + 1] - input_[i]);
+    if (diff < min_diff_) {
+      min_diff_ = diff;
+      index1_ = static_cast<int>(i);
+      index2_ = static_cast<int>(i + 1);
+    }
+  }
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsSequentialMPI::post_processing() {
+  internal_order_test();
+  int* output_ptr = reinterpret_cast<int*>(taskData->outputs[0]);
+  output_ptr[0] = min_diff_;
+  output_ptr[1] = index1_;
+  output_ptr[2] = index2_;
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::pre_processing() {
+  internal_order_test();
+  int total_size = 0;
+  if (world.rank() == 0) {
+    input_.resize(taskData->inputs_count[0]);
+    auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+    for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
+      input_[i] = tmp_ptr[i];
+    }
+    total_size = static_cast<int>(input_.size());
+  }
+  boost::mpi::broadcast(world, total_size, 0);
+
+  int base_size = total_size / world.size();
+  int remainder = total_size % world.size();
+  int local_size = base_size + (world.rank() < remainder ? 1 : 0);
+  int start_idx = world.rank() * base_size + std::min(world.rank(), remainder);
+  int end_idx = start_idx + local_size;
+
+  if (start_idx > 0) {
+    start_idx -= 1;
+  }
+  if (end_idx < total_size) {
+    end_idx += 1;
+  }
+  int adjusted_local_size = end_idx - start_idx;
+  local_input_.resize(adjusted_local_size);
+
+  if (world.rank() == 0) {
+    for (int proc = 1; proc < world.size(); ++proc) {
+      int proc_base_size = total_size / world.size();
+      int proc_remainder = total_size % world.size();
+      int proc_local_size = proc_base_size + (proc < proc_remainder ? 1 : 0);
+      int proc_start_idx = proc * proc_base_size + std::min(proc, proc_remainder);
+      int proc_end_idx = proc_start_idx + proc_local_size;
+
+      if (proc_start_idx > 0) {
+        proc_start_idx -= 1;
+      }
+      if (proc_end_idx < total_size) {
+        proc_end_idx += 1;
+      }
+      int proc_adjusted_size = proc_end_idx - proc_start_idx;
+
+      world.send(proc, 0, &input_[proc_start_idx], proc_adjusted_size);
+    }
+    std::copy(input_.begin() + start_idx, input_.begin() + end_idx, local_input_.begin());
+  } else {
+    world.recv(0, 0, (local_input_).data(), adjusted_local_size);
+  }
+
+  local_offset_ = start_idx;
+
+  min_diff_ = std::numeric_limits<int>::max();
+  index1_ = -1;
+  index2_ = -1;
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    if (taskData->inputs_count.empty() || taskData->inputs_count[0] < 2) {
+      return false;
+    }
+    return taskData->outputs_count[0] == 3;
+  }
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::run() {
+  internal_order_test();
+  for (size_t i = 0; i < local_input_.size() - 1; ++i) {
+    int diff = std::abs(local_input_[i + 1] - local_input_[i]);
+    if (diff < min_diff_) {
+      min_diff_ = diff;
+      index1_ = static_cast<int>(i) + local_offset_;
+      index2_ = static_cast<int>(i + 1) + local_offset_;
+    }
+  }
+
+  LocalResult local_result = {min_diff_, index1_, index2_};
+
+  std::vector<LocalResult> all_results;
+  if (world.rank() == 0) {
+    all_results.resize(world.size());
+  }
+
+  boost::mpi::gather(world, local_result, all_results, 0);
+
+  if (world.rank() == 0) {
+    min_diff_ = all_results[0].min_diff;
+    index1_ = all_results[0].index1;
+    index2_ = all_results[0].index2;
+    for (size_t i = 1; i < all_results.size(); ++i) {
+      if (all_results[i].min_diff < min_diff_) {
+        min_diff_ = all_results[i].min_diff;
+        index1_ = all_results[i].index1;
+        index2_ = all_results[i].index2;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_mpi::FindClosestNeighborsParallelMPI::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    int* output_ptr = reinterpret_cast<int*>(taskData->outputs[0]);
+    output_ptr[0] = min_diff_;
+    output_ptr[1] = index1_;
+    output_ptr[2] = index2_;
+  }
+  return true;
+}

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
@@ -1,0 +1,132 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp"
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, Test_Small_Vector) {
+  std::vector<int> input_vec = {5, 3, 8, 7, 2};
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential taskSequential(taskDataSeq);
+  ASSERT_EQ(taskSequential.validation(), true);
+  taskSequential.pre_processing();
+  taskSequential.run();
+  taskSequential.post_processing();
+
+  int expected_min_diff = 1;
+  int expected_index1 = 2;
+  int expected_index2 = 3;
+
+  ASSERT_EQ(output_result[0], expected_min_diff);
+  ASSERT_EQ(output_result[1], expected_index1);
+  ASSERT_EQ(output_result[2], expected_index2);
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, Test_Equal_Elements) {
+  std::vector<int> input_vec = {7, 7, 7, 7, 7};
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential taskSequential(taskDataSeq);
+  ASSERT_EQ(taskSequential.validation(), true);
+  taskSequential.pre_processing();
+  taskSequential.run();
+  taskSequential.post_processing();
+
+  int expected_min_diff = 0;
+  int expected_index1 = 0;
+  int expected_index2 = 1;
+
+  ASSERT_EQ(output_result[0], expected_min_diff);
+  ASSERT_EQ(output_result[1], expected_index1);
+  ASSERT_EQ(output_result[2], expected_index2);
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, Test_Negative_Numbers) {
+  std::vector<int> input_vec = {-10, -20, -15, -30, -25};
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential taskSequential(taskDataSeq);
+  ASSERT_EQ(taskSequential.validation(), true);
+  taskSequential.pre_processing();
+  taskSequential.run();
+  taskSequential.post_processing();
+
+  int expected_min_diff = 5;
+  int expected_index1 = 1;
+  int expected_index2 = 2;
+
+  ASSERT_EQ(output_result[0], expected_min_diff);
+  ASSERT_EQ(output_result[1], expected_index1);
+  ASSERT_EQ(output_result[2], expected_index2);
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, Test_Single_Element_Vector) {
+  std::vector<int> input_vec = {42};
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential taskSequential(taskDataSeq);
+  ASSERT_EQ(taskSequential.validation(), false);
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, Test_Empty_Vector) {
+  std::vector<int> input_vec;
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(nullptr);
+  taskDataSeq->inputs_count.emplace_back(0);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential taskSequential(taskDataSeq);
+  ASSERT_EQ(taskSequential.validation(), false);
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, Test_Large_Vector) {
+  std::vector<int> input_vec = {100, 95, 90, 85, 80, 75, 70, 65, 60, 55};
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential taskSequential(taskDataSeq);
+  ASSERT_EQ(taskSequential.validation(), true);
+  taskSequential.pre_processing();
+  taskSequential.run();
+  taskSequential.post_processing();
+
+  int expected_min_diff = 5;
+  int expected_index1 = 0;
+  int expected_index2 = 1;
+
+  ASSERT_EQ(output_result[0], expected_min_diff);
+  ASSERT_EQ(output_result[1], expected_index1);
+  ASSERT_EQ(output_result[2], expected_index2);
+}

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/func_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <vector>
 
 #include "seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp"

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace vasilev_s_nearest_neighbor_elements_seq {
+
+class FindClosestNeighborsSequential : public ppc::core::Task {
+ public:
+  explicit FindClosestNeighborsSequential(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> input_;
+  int min_diff_{};
+  int index1_{};
+  int index2_{};
+};
+
+}  // namespace vasilev_s_nearest_neighbor_elements_seq

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp"
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, test_pipeline_run) {
+  std::vector<int> input_vec;
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  int count_size_vector = 100000;
+
+  input_vec.resize(count_size_vector);
+  for (int i = 0; i < count_size_vector; ++i) {
+    input_vec[i] = i;
+  }
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential>(taskDataSeq);
+  ASSERT_EQ(taskSequential->validation(), true);
+  taskSequential->pre_processing();
+  taskSequential->run();
+  taskSequential->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  auto start_time = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&start_time] {
+    auto now = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = now - start_time;
+    return elapsed.count();
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  int expected_min_diff = 1;
+  int expected_index1 = 0;
+  int expected_index2 = 1;
+  ASSERT_EQ(output_result[0], expected_min_diff);
+  ASSERT_EQ(output_result[1], expected_index1);
+  ASSERT_EQ(output_result[2], expected_index2);
+}
+
+TEST(vasilev_s_nearest_neighbor_elements_seq, test_task_run) {
+  std::vector<int> input_vec;
+  std::vector<int> output_result(3, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  int count_size_vector = 100000;
+
+  input_vec.resize(count_size_vector);
+  for (int i = 0; i < count_size_vector; ++i) {
+    input_vec[i] = i;
+  }
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vec.data()));
+  taskDataSeq->inputs_count.emplace_back(input_vec.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
+  taskDataSeq->outputs_count.emplace_back(output_result.size());
+
+  auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential>(taskDataSeq);
+  ASSERT_EQ(taskSequential->validation(), true);
+  taskSequential->pre_processing();
+  taskSequential->run();
+  taskSequential->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  auto start_time = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&start_time] {
+    auto now = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = now - start_time;
+    return elapsed.count();
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  int expected_min_diff = 1;
+  int expected_index1 = 0;
+  int expected_index2 = 1;
+  ASSERT_EQ(output_result[0], expected_min_diff);
+  ASSERT_EQ(output_result[1], expected_index1);
+  ASSERT_EQ(output_result[2], expected_index2);
+}

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/perf_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <chrono>
 #include <vector>
 
@@ -21,7 +22,8 @@ TEST(vasilev_s_nearest_neighbor_elements_seq, test_pipeline_run) {
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
   taskDataSeq->outputs_count.emplace_back(output_result.size());
 
-  auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential>(taskDataSeq);
+  auto taskSequential =
+      std::make_shared<vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential>(taskDataSeq);
   ASSERT_EQ(taskSequential->validation(), true);
   taskSequential->pre_processing();
   taskSequential->run();
@@ -67,7 +69,8 @@ TEST(vasilev_s_nearest_neighbor_elements_seq, test_task_run) {
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_result.data()));
   taskDataSeq->outputs_count.emplace_back(output_result.size());
 
-  auto taskSequential = std::make_shared<vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential>(taskDataSeq);
+  auto taskSequential =
+      std::make_shared<vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential>(taskDataSeq);
   ASSERT_EQ(taskSequential->validation(), true);
   taskSequential->pre_processing();
   taskSequential->run();

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
@@ -21,10 +21,7 @@ bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::pr
 
 bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::validation() {
   internal_order_test();
-  if (taskData->inputs_count.empty() || taskData->inputs_count[0] < 2) {
-    return false;
-  }
-  return taskData->outputs_count[0] == 3;
+  return !taskData->inputs_count.empty() && taskData->inputs_count[0] >= 2 && taskData->outputs_count[0] == 3;
 }
 
 bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::run() {

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
@@ -10,9 +10,8 @@ bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::pr
   internal_order_test();
   input_.resize(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
-  for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
-    input_[i] = tmp_ptr[i];
-  }
+  std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], input_.begin());
+  
   min_diff_ = std::numeric_limits<int>::max();
   index1_ = -1;
   index2_ = -1;

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
@@ -1,0 +1,50 @@
+#include "seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp"
+
+#include <thread>
+#include <cmath>
+#include <limits>
+
+using namespace std::chrono_literals;
+
+bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::pre_processing() {
+  internal_order_test();
+  input_.resize(taskData->inputs_count[0]);
+  auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+  for (unsigned i = 0; i < taskData->inputs_count[0]; i++) {
+    input_[i] = tmp_ptr[i];
+  }
+  min_diff_ = std::numeric_limits<int>::max();
+  index1_ = -1;
+  index2_ = -1;
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::validation() {
+  internal_order_test();
+  if (taskData->inputs_count.empty() || taskData->inputs_count[0] < 2) {
+    return false;
+  }
+  return taskData->outputs_count[0] == 3;
+}
+
+bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::run() {
+  internal_order_test();
+  for (size_t i = 0; i < input_.size() - 1; ++i) {
+    int diff = std::abs(input_[i + 1] - input_[i]);
+    if (diff < min_diff_) {
+      min_diff_ = diff;
+      index1_ = static_cast<int>(i);
+      index2_ = static_cast<int>(i + 1);
+    }
+  }
+  return true;
+}
+
+bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::post_processing() {
+  internal_order_test();
+  int* output_ptr = reinterpret_cast<int*>(taskData->outputs[0]);
+  output_ptr[0] = min_diff_;
+  output_ptr[1] = index1_;
+  output_ptr[2] = index2_;
+  return true;
+}

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
@@ -11,7 +11,7 @@ bool vasilev_s_nearest_neighbor_elements_seq::FindClosestNeighborsSequential::pr
   input_.resize(taskData->inputs_count[0]);
   auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
   std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], input_.begin());
-  
+
   min_diff_ = std::numeric_limits<int>::max();
   index1_ = -1;
   index2_ = -1;

--- a/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
+++ b/tasks/seq/vasilev_s_nearest_neighbor_elements/src/ops_seq.cpp
@@ -1,8 +1,8 @@
 #include "seq/vasilev_s_nearest_neighbor_elements/include/ops_seq.hpp"
 
-#include <thread>
 #include <cmath>
 #include <limits>
+#include <thread>
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
### Последовательная реализация
- **Класс**: `FindClosestNeighborsSequential`
- **Описание**: Последовательная версия алгоритма находит минимальную разницу между соседними элементами вектора. 
- **Алгоритм**:
  - В методе `pre_processing` вектор входных данных инициализируется из `taskData`, задается начальное значение `min_diff_` как максимально возможное, а также начальные индексы `index1_` и `index2_` устанавливаются в `-1`.
  - В методе `run` осуществляется проход по всем парам соседних элементов, вычисляется разница, и, если она меньше текущей минимальной разницы, обновляются `min_diff_`, `index1_` и `index2_`.
  - Метод `post_processing` записывает результат (минимальная разница и индексы) в выходной буфер.
- **Результат**: Алгоритм возвращает минимальную разницу между соседними элементами и соответствующие индексы.

### Описание MPI реализации

Класс: `FindClosestNeighborsParallelMPI`

**Описание**: В параллельной версии с использованием MPI теперь используется `scatterv` для более эффективного распределения данных между процессами, улучшая производительность и упрощая управление границами подмассивов.

**Алгоритм**:
- **Распределение данных**: В `pre_processing` главный процесс (ранг 0) разбивает входной вектор на подмассивы, учитывая границы, чтобы каждый процесс мог корректно рассчитать минимальные разницы между соседними элементами. Вместо использования `send` и `recv` теперь данные передаются процессам с помощью `boost::mpi::scatterv`.
- **Локальные вычисления**: В `run` каждый процесс вычисляет минимальную разницу для своего подмассива, обновляя `min_diff_`, `index1_` и `index2_` при нахождении меньшего значения.
- **Сбор результатов**: После локальных вычислений каждый процесс отправляет свой результат главному процессу с помощью `boost::mpi::gather`. Главный процесс находит глобальный минимум среди всех локальных минимальных разниц.
- **Запись результата**: В `post_processing` главный процесс записывает финальные значения `min_diff_`, `index1_`, и `index2_` в выходной буфер.

**Используемые MPI-функции**:
- `boost::mpi::broadcast` — для рассылки размера входного вектора всем процессам.
- `boost::mpi::scatterv` — для эффективного распределения подмассивов с учетом границ каждому процессу.
- `boost::mpi::gather` — для сбора локальных минимальных значений на главном процессе.

**Результат**: Главный процесс (ранг 0) получает глобальную минимальную разницу между соседними элементами и их индексы, что гарантирует корректное вычисление на больших объемах данных.