### PR TITLE
Малышев Антон. Задача 1. Вариант 11. Сумма значений по строкам матрицы

### DIFF
--- a/tasks/mpi/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -25,7 +25,7 @@ std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
 
 }  // namespace malyshev_a_sum_rows_matrix_test_function
 
-TEST(malyshev_a_sum_rows_matrix_mpi, rectangular_matrix_stretched_horizontally_7х17) {
+TEST(malyshev_a_sum_rows_matrix_mpi, rectangular_matrix_stretched_horizontally_7x17) {
   uint32_t rows = 7;
   uint32_t cols = 17;
 

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -1,0 +1,222 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <climits>
+#include <random>
+#include <vector>
+
+#include "mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp"
+
+namespace malyshev_a_sum_rows_matrix_test_function {
+
+std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<std::vector<int32_t>> data(rows, std::vector<int32_t>(cols));
+
+  for (auto &row : data) {
+    for (auto &el : row) {
+      el = -200 + gen() % (300 + 200 + 1);
+    }
+  }
+
+  return data;
+}
+
+}  // namespace malyshev_a_sum_rows_matrix_test_function
+
+TEST(malyshev_a_sum_rows_matrix_mpi, test_run_1) {
+  uint32_t rows = 7;
+  uint32_t cols = 17;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(rows);
+  }
+
+  ASSERT_TRUE(taskMPI.validation());
+  ASSERT_TRUE(taskMPI.pre_processing());
+  ASSERT_TRUE(taskMPI.run());
+  ASSERT_TRUE(taskMPI.post_processing());
+
+  if (world.rank() == 0) {
+    std::vector<int32_t> seqSum(rows);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    malyshev_a_sum_rows_matrix_mpi::TestTaskSequential taskSeq(taskDataSeq);
+
+    for (auto &row : randomData) {
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataSeq->inputs_count.push_back(rows);
+    taskDataSeq->inputs_count.push_back(cols);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+    taskDataSeq->outputs_count.push_back(seqSum.size());
+
+    ASSERT_TRUE(taskSeq.validation());
+    ASSERT_TRUE(taskSeq.pre_processing());
+    ASSERT_TRUE(taskSeq.run());
+    ASSERT_TRUE(taskSeq.post_processing());
+
+    for (uint32_t i = 0; i < mpiSum.size(); i++) {
+      ASSERT_EQ(seqSum[i], mpiSum[i]);
+    }
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_mpi, test_run_2) {
+  uint32_t rows = 100;
+  uint32_t cols = 75;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(rows);
+  }
+
+  ASSERT_TRUE(taskMPI.validation());
+  ASSERT_TRUE(taskMPI.pre_processing());
+  ASSERT_TRUE(taskMPI.run());
+  ASSERT_TRUE(taskMPI.post_processing());
+
+  if (world.rank() == 0) {
+    std::vector<int32_t> seqSum(rows);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    malyshev_a_sum_rows_matrix_mpi::TestTaskSequential taskSeq(taskDataSeq);
+
+    for (auto &row : randomData) {
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataSeq->inputs_count.push_back(rows);
+    taskDataSeq->inputs_count.push_back(cols);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+    taskDataSeq->outputs_count.push_back(seqSum.size());
+
+    ASSERT_TRUE(taskSeq.validation());
+    ASSERT_TRUE(taskSeq.pre_processing());
+    ASSERT_TRUE(taskSeq.run());
+    ASSERT_TRUE(taskSeq.post_processing());
+
+    for (uint32_t i = 0; i < mpiSum.size(); i++) {
+      ASSERT_EQ(seqSum[i], mpiSum[i]);
+    }
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_mpi, test_run_3) {
+  uint32_t rows = 100;
+  uint32_t cols = 100;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(rows);
+  }
+
+  ASSERT_TRUE(taskMPI.validation());
+  ASSERT_TRUE(taskMPI.pre_processing());
+  ASSERT_TRUE(taskMPI.run());
+  ASSERT_TRUE(taskMPI.post_processing());
+
+  if (world.rank() == 0) {
+    std::vector<int32_t> seqSum(rows);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    malyshev_a_sum_rows_matrix_mpi::TestTaskSequential taskSeq(taskDataSeq);
+
+    for (auto &row : randomData) {
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataSeq->inputs_count.push_back(rows);
+    taskDataSeq->inputs_count.push_back(cols);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+    taskDataSeq->outputs_count.push_back(seqSum.size());
+
+    ASSERT_TRUE(taskSeq.validation());
+    ASSERT_TRUE(taskSeq.pre_processing());
+    ASSERT_TRUE(taskSeq.run());
+    ASSERT_TRUE(taskSeq.post_processing());
+
+    for (uint32_t i = 0; i < mpiSum.size(); i++) {
+      ASSERT_EQ(seqSum[i], mpiSum[i]);
+    }
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_mpi, test_validation) {
+  uint32_t rows = 7;
+  uint32_t cols = 17;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(0);
+
+    ASSERT_FALSE(taskMPI.validation());
+  }
+}

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -25,7 +25,7 @@ std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
 
 }  // namespace malyshev_a_sum_rows_matrix_test_function
 
-TEST(malyshev_a_sum_rows_matrix_mpi, test_run_1) {
+TEST(malyshev_a_sum_rows_matrix_mpi, rectangular_matrix_stretched_horizontally_7х17) {
   uint32_t rows = 7;
   uint32_t cols = 17;
 
@@ -81,7 +81,7 @@ TEST(malyshev_a_sum_rows_matrix_mpi, test_run_1) {
   }
 }
 
-TEST(malyshev_a_sum_rows_matrix_mpi, test_run_2) {
+TEST(malyshev_a_sum_rows_matrix_mpi, rectangular_matrix_stretched_verticaly_100x75) {
   uint32_t rows = 100;
   uint32_t cols = 75;
 
@@ -137,9 +137,65 @@ TEST(malyshev_a_sum_rows_matrix_mpi, test_run_2) {
   }
 }
 
-TEST(malyshev_a_sum_rows_matrix_mpi, test_run_3) {
+TEST(malyshev_a_sum_rows_matrix_mpi, squere_matrix_100x100) {
   uint32_t rows = 100;
   uint32_t cols = 100;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(rows);
+  }
+
+  ASSERT_TRUE(taskMPI.validation());
+  ASSERT_TRUE(taskMPI.pre_processing());
+  ASSERT_TRUE(taskMPI.run());
+  ASSERT_TRUE(taskMPI.post_processing());
+
+  if (world.rank() == 0) {
+    std::vector<int32_t> seqSum(rows);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    malyshev_a_sum_rows_matrix_mpi::TestTaskSequential taskSeq(taskDataSeq);
+
+    for (auto &row : randomData) {
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataSeq->inputs_count.push_back(rows);
+    taskDataSeq->inputs_count.push_back(cols);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+    taskDataSeq->outputs_count.push_back(seqSum.size());
+
+    ASSERT_TRUE(taskSeq.validation());
+    ASSERT_TRUE(taskSeq.pre_processing());
+    ASSERT_TRUE(taskSeq.run());
+    ASSERT_TRUE(taskSeq.post_processing());
+
+    for (uint32_t i = 0; i < mpiSum.size(); i++) {
+      ASSERT_EQ(seqSum[i], mpiSum[i]);
+    }
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_mpi, matrix_1x1) {
+  uint32_t rows = 1;
+  uint32_t cols = 1;
 
   boost::mpi::communicator world;
   std::vector<std::vector<int32_t>> randomData;

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp
@@ -34,7 +34,7 @@ class TestTaskParallel : public ppc::core::Task {
  private:
   std::vector<std::vector<int32_t>> input_, local_input_;
   std::vector<int32_t> res_, local_res_;
-  uint32_t rows_, cols_;
+  uint32_t delta_, ext_;
 
   boost::mpi::communicator world;
 };

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace malyshev_a_sum_rows_matrix_mpi {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<std::vector<int32_t>> input_;
+  std::vector<int32_t> res_;
+};
+
+class TestTaskParallel : public ppc::core::Task {
+ public:
+  explicit TestTaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<std::vector<int32_t>> input_, local_input_;
+  std::vector<int32_t> res_, local_res_;
+  uint32_t rows_, cols_;
+
+  boost::mpi::communicator world;
+};
+
+}  // namespace malyshev_a_sum_rows_matrix_mpi

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/perf_tests/main.cpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/perf_tests/main.cpp
@@ -1,0 +1,117 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp"
+
+namespace malyshev_a_sum_rows_matrix_test_function {
+
+std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<std::vector<int32_t>> data(rows, std::vector<int32_t>(cols));
+
+  for (auto &row : data) {
+    for (auto &el : row) {
+      el = -200 + gen() % (300 + 200 + 1);
+    }
+  }
+
+  return data;
+}
+
+}  // namespace malyshev_a_sum_rows_matrix_test_function
+
+TEST(malyshev_a_sum_rows_matrix_mpi, test_pipeline_run) {
+  uint32_t rows = 3000;
+  uint32_t cols = 3000;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(rows);
+  }
+
+  auto testMpiTaskParallel = std::make_shared<malyshev_a_sum_rows_matrix_mpi::TestTaskParallel>(taskDataPar);
+
+  ASSERT_TRUE(testMpiTaskParallel->validation());
+  ASSERT_TRUE(testMpiTaskParallel->pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel->run());
+  ASSERT_TRUE(testMpiTaskParallel->post_processing());
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) ppc::core::Perf::print_perf_statistic(perfResults);
+}
+
+TEST(malyshev_a_sum_rows_matrix_mpi, test_task_run) {
+  uint32_t rows = 3000;
+  uint32_t cols = 3000;
+
+  boost::mpi::communicator world;
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> mpiSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_mpi::TestTaskParallel taskMPI(taskDataPar);
+
+  if (world.rank() == 0) {
+    randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+    mpiSum.resize(rows);
+
+    for (auto &row : randomData) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+    }
+
+    taskDataPar->inputs_count.push_back(rows);
+    taskDataPar->inputs_count.push_back(cols);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(mpiSum.data()));
+    taskDataPar->outputs_count.push_back(rows);
+  }
+
+  auto testMpiTaskParallel = std::make_shared<malyshev_a_sum_rows_matrix_mpi::TestTaskParallel>(taskDataPar);
+
+  ASSERT_TRUE(testMpiTaskParallel->validation());
+  ASSERT_TRUE(testMpiTaskParallel->pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel->run());
+  ASSERT_TRUE(testMpiTaskParallel->post_processing());
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) ppc::core::Perf::print_perf_statistic(perfResults);
+}

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/src/ops_mpi.cpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/src/ops_mpi.cpp
@@ -1,0 +1,118 @@
+#include "mpi/malyshev_a_sum_rows_matrix/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <boost/serialization/vector.hpp>
+#include <vector>
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskSequential ::pre_processing() {
+  internal_order_test();
+
+  uint32_t rows = taskData->inputs_count[0];
+  uint32_t cols = taskData->inputs_count[1];
+
+  input_.resize(rows, std::vector<int32_t>(cols));
+  res_.resize(rows);
+
+  int32_t* data;
+  for (uint32_t i = 0; i < input_.size(); i++) {
+    data = reinterpret_cast<int32_t*>(taskData->inputs[i]);
+    std::copy(data, data + cols, input_[i].data());
+  }
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskSequential::validation() {
+  internal_order_test();
+
+  return taskData->outputs_count[0] == taskData->inputs_count[0];
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskSequential ::run() {
+  internal_order_test();
+
+  for (uint32_t i = 0; i < input_.size(); i++) {
+    res_[i] = std::accumulate(input_[i].begin(), input_[i].end(), 0);
+  }
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskSequential ::post_processing() {
+  internal_order_test();
+
+  std::copy(res_.begin(), res_.end(), reinterpret_cast<int32_t*>(taskData->outputs[0]));
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskParallel::pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    rows_ = taskData->inputs_count[0];
+    cols_ = taskData->inputs_count[1];
+
+    input_.resize(rows_, std::vector<int32_t>(cols_));
+    res_.resize(rows_);
+
+    int32_t* data;
+    for (uint32_t i = 0; i < input_.size(); i++) {
+      data = reinterpret_cast<int32_t*>(taskData->inputs[i]);
+      std::copy(data, data + cols_, input_[i].data());
+    }
+  }
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskParallel::validation() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    return taskData->outputs_count[0] == taskData->inputs_count[0];
+  }
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskParallel::run() {
+  internal_order_test();
+
+  broadcast(world, rows_, 0);
+  broadcast(world, cols_, 0);
+
+  uint32_t delta = rows_ / world.size();
+  uint32_t ext = rows_ % world.size();
+
+  std::vector<int32_t> sizes(world.size(), delta);
+  sizes[world.size() - 1] += ext;
+
+  if (world.rank() == world.size() - 1) {
+    local_input_.resize(delta + ext, std::vector<int32_t>(cols_));
+    local_res_.resize(delta + ext);
+  } else {
+    local_input_.resize(delta, std::vector<int32_t>(cols_));
+    local_res_.resize(delta);
+  }
+
+  scatterv(world, input_, sizes, local_input_.data(), 0);
+
+  for (uint32_t i = 0; i < local_input_.size(); i++) {
+    local_res_[i] = std::accumulate(local_input_[i].begin(), local_input_[i].end(), 0);
+  }
+
+  gatherv(world, local_res_, res_.data(), sizes, 0);
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_mpi::TestTaskParallel::post_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    std::copy(res_.begin(), res_.end(), reinterpret_cast<int32_t*>(taskData->outputs[0]));
+  }
+
+  return true;
+}

--- a/tasks/mpi/malyshev_a_sum_rows_matrix/src/ops_mpi.cpp
+++ b/tasks/mpi/malyshev_a_sum_rows_matrix/src/ops_mpi.cpp
@@ -86,15 +86,12 @@ bool malyshev_a_sum_rows_matrix_mpi::TestTaskParallel::run() {
   uint32_t ext = rows_ % world.size();
 
   std::vector<int32_t> sizes(world.size(), delta);
-  sizes[world.size() - 1] += ext;
-
-  if (world.rank() == world.size() - 1) {
-    local_input_.resize(delta + ext, std::vector<int32_t>(cols_));
-    local_res_.resize(delta + ext);
-  } else {
-    local_input_.resize(delta, std::vector<int32_t>(cols_));
-    local_res_.resize(delta);
+  for (uint32_t i = 0; i < ext; i++) {
+    sizes[world.size() - i - 1]++;
   }
+
+  local_input_.resize(sizes[world.rank()], std::vector<int32_t>(cols_));
+  local_res_.resize(sizes[world.rank()]);
 
   scatterv(world, input_, sizes, local_input_.data(), 0);
 

--- a/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -25,7 +25,7 @@ std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
 
 }  // namespace malyshev_a_sum_rows_matrix_test_function
 
-TEST(malyshev_a_sum_rows_matrix_seq, rectangular_matrix_stretched_horizontally_7х17) {
+TEST(malyshev_a_sum_rows_matrix_seq, rectangular_matrix_stretched_horizontally_7x17) {
   uint32_t rows = 7;
   uint32_t cols = 17;
 

--- a/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Nesterov Alexander
 #include <gtest/gtest.h>
 
+#include <numeric>
 #include <random>
 #include <vector>
 

--- a/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -25,7 +25,7 @@ std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
 
 }  // namespace malyshev_a_sum_rows_matrix_test_function
 
-TEST(malyshev_a_sum_rows_matrix_seq, test_run_1) {
+TEST(malyshev_a_sum_rows_matrix_seq, rectangular_matrix_stretched_horizontally_7х17) {
   uint32_t rows = 7;
   uint32_t cols = 17;
 
@@ -54,7 +54,7 @@ TEST(malyshev_a_sum_rows_matrix_seq, test_run_1) {
   }
 }
 
-TEST(malyshev_a_sum_rows_matrix_seq, test_run_2) {
+TEST(malyshev_a_sum_rows_matrix_seq, rectangular_matrix_stretched_verticaly_100x75) {
   uint32_t rows = 100;
   uint32_t cols = 75;
 
@@ -82,9 +82,37 @@ TEST(malyshev_a_sum_rows_matrix_seq, test_run_2) {
   }
 }
 
-TEST(malyshev_a_sum_rows_matrix_seq, test_run_3) {
+TEST(malyshev_a_sum_rows_matrix_seq, squere_matrix_100x100) {
   uint32_t rows = 100;
   uint32_t cols = 100;
+
+  std::vector<int32_t> seqSum(rows);
+  std::vector<std::vector<int32_t>> randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_seq::TestTaskSequential taskSeq(taskDataSeq);
+
+  for (auto &row : randomData) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(seqSum.size());
+
+  ASSERT_TRUE(taskSeq.validation());
+  ASSERT_TRUE(taskSeq.pre_processing());
+  ASSERT_TRUE(taskSeq.run());
+  ASSERT_TRUE(taskSeq.post_processing());
+
+  for (uint32_t i = 0; i < seqSum.size(); i++) {
+    ASSERT_EQ(seqSum[i], std::accumulate(randomData[i].begin(), randomData[i].end(), 0));
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_seq, matrix_1x1) {
+  uint32_t rows = 1;
+  uint32_t cols = 1;
 
   std::vector<int32_t> seqSum(rows);
   std::vector<std::vector<int32_t>> randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);

--- a/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/func_tests/main.cpp
@@ -1,0 +1,131 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "seq/malyshev_a_sum_rows_matrix/include/ops_seq.hpp"
+
+namespace malyshev_a_sum_rows_matrix_test_function {
+
+std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<std::vector<int32_t>> data(rows, std::vector<int32_t>(cols));
+
+  for (auto &row : data) {
+    for (auto &el : row) {
+      el = -200 + gen() % (300 + 200 + 1);
+    }
+  }
+
+  return data;
+}
+
+}  // namespace malyshev_a_sum_rows_matrix_test_function
+
+TEST(malyshev_a_sum_rows_matrix_seq, test_run_1) {
+  uint32_t rows = 7;
+  uint32_t cols = 17;
+
+  std::vector<int32_t> seqSum(rows);
+  std::vector<std::vector<int32_t>> data(rows, std::vector(cols, 1));
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_seq::TestTaskSequential taskSeq(taskDataSeq);
+
+  for (auto &row : data) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(seqSum.size());
+
+  ASSERT_TRUE(taskSeq.validation());
+  ASSERT_TRUE(taskSeq.pre_processing());
+  ASSERT_TRUE(taskSeq.run());
+  ASSERT_TRUE(taskSeq.post_processing());
+
+  for (uint32_t i = 0; i < seqSum.size(); i++) {
+    ASSERT_EQ(seqSum[i], (int32_t)cols);
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_seq, test_run_2) {
+  uint32_t rows = 100;
+  uint32_t cols = 75;
+
+  std::vector<int32_t> seqSum(rows);
+  std::vector<std::vector<int32_t>> randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_seq::TestTaskSequential taskSeq(taskDataSeq);
+
+  for (auto &row : randomData) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(seqSum.size());
+
+  ASSERT_TRUE(taskSeq.validation());
+  ASSERT_TRUE(taskSeq.pre_processing());
+  ASSERT_TRUE(taskSeq.run());
+  ASSERT_TRUE(taskSeq.post_processing());
+
+  for (uint32_t i = 0; i < seqSum.size(); i++) {
+    ASSERT_EQ(seqSum[i], std::accumulate(randomData[i].begin(), randomData[i].end(), 0));
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_seq, test_run_3) {
+  uint32_t rows = 100;
+  uint32_t cols = 100;
+
+  std::vector<int32_t> seqSum(rows);
+  std::vector<std::vector<int32_t>> randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_seq::TestTaskSequential taskSeq(taskDataSeq);
+
+  for (auto &row : randomData) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(seqSum.size());
+
+  ASSERT_TRUE(taskSeq.validation());
+  ASSERT_TRUE(taskSeq.pre_processing());
+  ASSERT_TRUE(taskSeq.run());
+  ASSERT_TRUE(taskSeq.post_processing());
+
+  for (uint32_t i = 0; i < seqSum.size(); i++) {
+    ASSERT_EQ(seqSum[i], std::accumulate(randomData[i].begin(), randomData[i].end(), 0));
+  }
+}
+
+TEST(malyshev_a_sum_rows_matrix_seq, test_validation) {
+  uint32_t rows = 7;
+  uint32_t cols = 17;
+
+  std::vector<int32_t> seqSum(rows);
+  std::vector<std::vector<int32_t>> randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  malyshev_a_sum_rows_matrix_seq::TestTaskSequential taskSeq(taskDataSeq);
+
+  for (auto &row : randomData) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(0);
+
+  ASSERT_FALSE(taskSeq.validation());
+}

--- a/tasks/seq/malyshev_a_sum_rows_matrix/include/ops_seq.hpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/include/ops_seq.hpp
@@ -1,0 +1,24 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace malyshev_a_sum_rows_matrix_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<std::vector<int32_t>> input_;
+  std::vector<int32_t> res_;
+};
+
+}  // namespace malyshev_a_sum_rows_matrix_seq

--- a/tasks/seq/malyshev_a_sum_rows_matrix/perf_tests/main.cpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/perf_tests/main.cpp
@@ -1,0 +1,114 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/malyshev_a_sum_rows_matrix/include/ops_seq.hpp"
+
+namespace malyshev_a_sum_rows_matrix_test_function {
+
+std::vector<std::vector<int32_t>> getRandomData(uint32_t rows, uint32_t cols) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<std::vector<int32_t>> data(rows, std::vector<int32_t>(cols));
+
+  for (auto &row : data) {
+    for (auto &el : row) {
+      el = -200 + gen() % (300 + 200 + 1);
+    }
+  }
+
+  return data;
+}
+
+}  // namespace malyshev_a_sum_rows_matrix_test_function
+
+TEST(malyshev_a_sum_rows_matrix_seq, test_pipeline_run) {
+  uint32_t rows = 3000;
+  uint32_t cols = 3000;
+
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> seqSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+  seqSum.resize(rows);
+
+  for (auto &row : randomData) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(rows);
+
+  auto taskSeq = std::make_shared<malyshev_a_sum_rows_matrix_seq::TestTaskSequential>(taskDataSeq);
+
+  ASSERT_TRUE(taskSeq->validation());
+  ASSERT_TRUE(taskSeq->pre_processing());
+  ASSERT_TRUE(taskSeq->run());
+  ASSERT_TRUE(taskSeq->post_processing());
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskSeq);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}
+
+TEST(malyshev_a_sum_rows_matrix_seq, test_task_run) {
+  uint32_t rows = 3000;
+  uint32_t cols = 3000;
+
+  std::vector<std::vector<int32_t>> randomData;
+  std::vector<int32_t> seqSum;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  randomData = malyshev_a_sum_rows_matrix_test_function::getRandomData(rows, cols);
+  seqSum.resize(rows);
+
+  for (auto &row : randomData) {
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(row.data()));
+  }
+
+  taskDataSeq->inputs_count.push_back(rows);
+  taskDataSeq->inputs_count.push_back(cols);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(seqSum.data()));
+  taskDataSeq->outputs_count.push_back(rows);
+
+  auto taskSeq = std::make_shared<malyshev_a_sum_rows_matrix_seq::TestTaskSequential>(taskDataSeq);
+
+  ASSERT_TRUE(taskSeq->validation());
+  ASSERT_TRUE(taskSeq->pre_processing());
+  ASSERT_TRUE(taskSeq->run());
+  ASSERT_TRUE(taskSeq->post_processing());
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskSeq);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}

--- a/tasks/seq/malyshev_a_sum_rows_matrix/src/ops_seq.cpp
+++ b/tasks/seq/malyshev_a_sum_rows_matrix/src/ops_seq.cpp
@@ -1,0 +1,47 @@
+#include "seq/malyshev_a_sum_rows_matrix/include/ops_seq.hpp"
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+bool malyshev_a_sum_rows_matrix_seq::TestTaskSequential::pre_processing() {
+  internal_order_test();
+
+  uint32_t rows = taskData->inputs_count[0];
+  uint32_t cols = taskData->inputs_count[1];
+
+  input_.resize(rows, std::vector<int32_t>(cols));
+  res_.resize(rows);
+
+  int32_t* data;
+  for (uint32_t i = 0; i < input_.size(); i++) {
+    data = reinterpret_cast<int32_t*>(taskData->inputs[i]);
+    std::copy(data, data + cols, input_[i].data());
+  }
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_seq::TestTaskSequential::validation() {
+  internal_order_test();
+
+  return taskData->outputs_count[0] == taskData->inputs_count[0];
+}
+
+bool malyshev_a_sum_rows_matrix_seq::TestTaskSequential::run() {
+  internal_order_test();
+
+  for (uint32_t i = 0; i < input_.size(); i++) {
+    res_[i] = std::accumulate(input_[i].begin(), input_[i].end(), 0);
+  }
+
+  return true;
+}
+
+bool malyshev_a_sum_rows_matrix_seq::TestTaskSequential::post_processing() {
+  internal_order_test();
+
+  std::copy(res_.begin(), res_.end(), reinterpret_cast<int32_t*>(taskData->outputs[0]));
+
+  return true;
+}


### PR DESCRIPTION
Seq: 
1. Данные валидируются (количество строк матрицы должно совпадать с размером выхода)
2. Данные построчно копируются из 'taskData'
3. Строки суммируются с помощью `std::accumulate`
4. Результат копируется в `taskData`

MPI: 
1. Данные нулевого процесса валидируются (количество строк матрицы должно совпадать с размером выхода)
2. Данные нулевого процесса построчно копируются из 'taskData'
3. Вычисляются размеры передаваемых данных процессам. Неделящийся остаток будет ~отправлен последнему процессу~ равномерно распределен между процессами начиная с конца. (upd by [0a6e48c](https://github.com/learning-process/ppc-2024-autumn/pull/201/commits/0a6e48c6a0e7fbd8e607299de1f17dae3d091645)) 
4. Данные рассылаются с помощью `scatterv`
5. Локальные строки суммируются с помощью `std::accumulate`
6. Локальные результаты собираются с помощью `gatherv` копируется в 'taskData' 
7. Собранные результаты копируются в `taskData`