### PR TITLE
Revert. Шульпин Илья. Задача 1. Вариант 21. Интегрирование методом Монте-Карло

### DIFF
--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -169,11 +169,7 @@ TEST(shulpin_monte_carlo_integration, test_empty_input) {
 
   shulpin_monte_carlo_integration::TestMPITaskParallel parallel_empty_task(empty_task_data);
 
-  ASSERT_EQ(parallel_empty_task.validation(), false);
-
   if (world.rank() == 0) {
-    shulpin_monte_carlo_integration::TestMPITaskSequential seq_empty_task(empty_task_data);
-
-    ASSERT_EQ(seq_empty_task.validation(), false);
+    ASSERT_FALSE(parallel_empty_task.validation());
   }
 }

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -8,7 +8,7 @@
 
 #include "mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
 
-#define ESTIMATE 1e-3
+constexpr double ESTIMATE = 1e-3;
 
 TEST(shulpin_monte_carlo_integration, sin_test) {
   boost::mpi::communicator world;

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -168,6 +168,8 @@ TEST(shulpin_monte_carlo_integration, test_empty_input) {
   std::shared_ptr<ppc::core::TaskData> task_data_sin = std::make_shared<ppc::core::TaskData>();
 
   shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_integral(task_data_sin);
+  task_data_sin->inputs.clear();
+  task_data_sin->outputs_count.clear();
   ASSERT_EQ(parallel_MC_integral.validation(), false);
 
   if (world.rank() == 0) {

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -58,7 +58,7 @@ TEST(shulpin_monte_carlo_integration, sin_test) {
     seq_MC_integral.run();
     seq_MC_integral.post_processing();
 
-    ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
+    ASSERT_NEAR(ref_integral, global_integral, ESTIMATE);
   }
 }
 
@@ -108,7 +108,7 @@ TEST(shulpin_monte_carlo_integration, test_cos) {
     seq_MC_integral.run();
     seq_MC_integral.post_processing();
 
-    ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
+    ASSERT_NEAR(ref_integral, global_integral, ESTIMATE);
   }
 }
 
@@ -158,7 +158,7 @@ TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
     seq_two_sin_cos.run();
     seq_two_sin_cos.post_processing();
 
-    ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
+    ASSERT_NEAR(ref_integral, global_integral, ESTIMATE);
   }
 }
 

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -161,3 +161,23 @@ TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
     ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
   }
 }
+
+TEST(shulpin_monte_carlo_integration, test_empty_input) {
+  boost::mpi::communicator world;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_sin = std::make_shared<ppc::core::TaskData>();
+
+  shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_integral(task_data_sin);
+  parallel_MC_integral.set_MPI(shulpin_monte_carlo_integration::fsin);
+
+  ASSERT_EQ(parallel_MC_integral.validation(), false);
+
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> seq_sin_task_data = std::make_shared<ppc::core::TaskData>();
+
+    shulpin_monte_carlo_integration::TestMPITaskSequential seq_MC_integral(seq_sin_task_data);
+    seq_MC_integral.set_seq(shulpin_monte_carlo_integration::fsin);
+
+    ASSERT_EQ(seq_MC_integral.validation(), false);
+  }
+}

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -165,17 +165,15 @@ TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
 TEST(shulpin_monte_carlo_integration, test_empty_input) {
   boost::mpi::communicator world;
 
-  std::shared_ptr<ppc::core::TaskData> task_data_sin = std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> empty_task_data = std::make_shared<ppc::core::TaskData>();
 
-  shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_integral(task_data_sin);
-  task_data_sin->inputs.clear();
-  task_data_sin->outputs_count.clear();
-  ASSERT_EQ(parallel_MC_integral.validation(), false);
+  shulpin_monte_carlo_integration::TestMPITaskParallel parallel_empty_task(empty_task_data);
+
+  ASSERT_EQ(parallel_empty_task.validation(), false);
 
   if (world.rank() == 0) {
-    std::shared_ptr<ppc::core::TaskData> seq_sin_task_data = std::make_shared<ppc::core::TaskData>();
+    shulpin_monte_carlo_integration::TestMPITaskSequential seq_empty_task(empty_task_data);
 
-    shulpin_monte_carlo_integration::TestMPITaskSequential seq_MC_integral(seq_sin_task_data);
-    ASSERT_EQ(seq_MC_integral.validation(), false);
+    ASSERT_EQ(seq_empty_task.validation(), false);
   }
 }

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <cmath>
+#include <memory>
+
+#include "mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
+
+#define ESTIMATE 1e-3
+
+TEST(shulpin_monte_carlo_integration, sin_test) {
+  boost::mpi::communicator world;
+  double global_integral = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_sin = std::make_shared<ppc::core::TaskData>();
+
+  double a = 5.0;
+  double b = 11.0;
+  int N = 100000;
+
+  if (world.rank() == 0) {
+    task_data_sin->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    task_data_sin->inputs_count.emplace_back(1);
+    task_data_sin->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    task_data_sin->inputs_count.emplace_back(1);
+    task_data_sin->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+    task_data_sin->inputs_count.emplace_back(1);
+    task_data_sin->outputs.emplace_back(reinterpret_cast<uint8_t*>(&global_integral));
+    task_data_sin->outputs_count.emplace_back(1);
+  }
+
+  shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_interal(task_data_sin);
+  parallel_MC_interal.set_MPI(shulpin_monte_carlo_integration::fsin);
+  ASSERT_EQ(parallel_MC_interal.validation(), true);
+  parallel_MC_interal.pre_processing();
+  parallel_MC_interal.run();
+  parallel_MC_interal.post_processing();
+
+  if (world.rank() == 0) {
+    double ref_integral = 0.0;
+
+    std::shared_ptr<ppc::core::TaskData> seq_sin_task_data = std::make_shared<ppc::core::TaskData>();
+    seq_sin_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    seq_sin_task_data->inputs_count.emplace_back(1);
+    seq_sin_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    seq_sin_task_data->inputs_count.emplace_back(1);
+    seq_sin_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+    seq_sin_task_data->inputs_count.emplace_back(1);
+    seq_sin_task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&ref_integral));
+    seq_sin_task_data->outputs_count.emplace_back(1);
+
+    shulpin_monte_carlo_integration::TestMPITaskSequential seq_MC_integral(seq_sin_task_data);
+    seq_MC_integral.set_seq(shulpin_monte_carlo_integration::fsin);
+    ASSERT_EQ(seq_MC_integral.validation(), true);
+    seq_MC_integral.pre_processing();
+    seq_MC_integral.run();
+    seq_MC_integral.post_processing();
+
+    ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
+  }
+}
+
+TEST(shulpin_monte_carlo_integration, test_cos) {
+  boost::mpi::communicator world;
+  double global_integral = 0.0;
+  std::shared_ptr<ppc::core::TaskData> task_data_cos = std::make_shared<ppc::core::TaskData>();
+
+  double a = -10.0;
+  double b = -1.5;
+  int n = 100000;
+
+  if (world.rank() == 0) {
+    task_data_cos->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    task_data_cos->inputs_count.emplace_back(1);
+    task_data_cos->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    task_data_cos->inputs_count.emplace_back(1);
+    task_data_cos->inputs.emplace_back(reinterpret_cast<uint8_t*>(&n));
+    task_data_cos->inputs_count.emplace_back(1);
+    task_data_cos->outputs.emplace_back(reinterpret_cast<uint8_t*>(&global_integral));
+    task_data_cos->outputs_count.emplace_back(1);
+  }
+
+  shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_interal(task_data_cos);
+  parallel_MC_interal.set_MPI(shulpin_monte_carlo_integration::fcos);
+  ASSERT_EQ(parallel_MC_interal.validation(), true);
+  parallel_MC_interal.pre_processing();
+  parallel_MC_interal.run();
+  parallel_MC_interal.post_processing();
+
+  if (world.rank() == 0) {
+    double ref_integral = 0.0;
+    std::shared_ptr<ppc::core::TaskData> seq_cos_task_data = std::make_shared<ppc::core::TaskData>();
+    seq_cos_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    seq_cos_task_data->inputs_count.emplace_back(1);
+    seq_cos_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    seq_cos_task_data->inputs_count.emplace_back(1);
+    seq_cos_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&n));
+    seq_cos_task_data->inputs_count.emplace_back(1);
+    seq_cos_task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&ref_integral));
+    seq_cos_task_data->outputs_count.emplace_back(1);
+
+    shulpin_monte_carlo_integration::TestMPITaskSequential seq_MC_integral(seq_cos_task_data);
+    seq_MC_integral.set_seq(shulpin_monte_carlo_integration::fcos);
+    ASSERT_EQ(seq_MC_integral.validation(), true);
+    seq_MC_integral.pre_processing();
+    seq_MC_integral.run();
+    seq_MC_integral.post_processing();
+
+    ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
+  }
+}
+
+TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
+  boost::mpi::communicator world;
+  double global_integral = 0.0;
+  std::shared_ptr<ppc::core::TaskData> task_data_two_sin_cos = std::make_shared<ppc::core::TaskData>();
+
+  double a = -3.0;
+  double b = 4.0;
+  int n = 1000000;
+
+  if (world.rank() == 0) {
+    task_data_two_sin_cos->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    task_data_two_sin_cos->inputs_count.emplace_back(1);
+    task_data_two_sin_cos->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    task_data_two_sin_cos->inputs_count.emplace_back(1);
+    task_data_two_sin_cos->inputs.emplace_back(reinterpret_cast<uint8_t*>(&n));
+    task_data_two_sin_cos->inputs_count.emplace_back(1);
+    task_data_two_sin_cos->outputs.emplace_back(reinterpret_cast<uint8_t*>(&global_integral));
+    task_data_two_sin_cos->outputs_count.emplace_back(1);
+  }
+
+  shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_interal(task_data_two_sin_cos);
+  parallel_MC_interal.set_MPI(shulpin_monte_carlo_integration::f_two_sin_cos);
+  ASSERT_EQ(parallel_MC_interal.validation(), true);
+  parallel_MC_interal.pre_processing();
+  parallel_MC_interal.run();
+  parallel_MC_interal.post_processing();
+
+  if (world.rank() == 0) {
+    double ref_integral = 0.0;
+    std::shared_ptr<ppc::core::TaskData> seq_two_sin_cos_task_data = std::make_shared<ppc::core::TaskData>();
+    seq_two_sin_cos_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    seq_two_sin_cos_task_data->inputs_count.emplace_back(1);
+    seq_two_sin_cos_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    seq_two_sin_cos_task_data->inputs_count.emplace_back(1);
+    seq_two_sin_cos_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&n));
+    seq_two_sin_cos_task_data->inputs_count.emplace_back(1);
+    seq_two_sin_cos_task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&ref_integral));
+    seq_two_sin_cos_task_data->outputs_count.emplace_back(1);
+
+    shulpin_monte_carlo_integration::TestMPITaskSequential seq_two_sin_cos(seq_two_sin_cos_task_data);
+    seq_two_sin_cos.set_seq(shulpin_monte_carlo_integration::f_two_sin_cos);
+    ASSERT_EQ(seq_two_sin_cos.validation(), true);
+    seq_two_sin_cos.pre_processing();
+    seq_two_sin_cos.run();
+    seq_two_sin_cos.post_processing();
+
+    ASSERT_LT(std::abs(ref_integral - global_integral), ESTIMATE);
+  }
+}

--- a/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -168,16 +168,12 @@ TEST(shulpin_monte_carlo_integration, test_empty_input) {
   std::shared_ptr<ppc::core::TaskData> task_data_sin = std::make_shared<ppc::core::TaskData>();
 
   shulpin_monte_carlo_integration::TestMPITaskParallel parallel_MC_integral(task_data_sin);
-  parallel_MC_integral.set_MPI(shulpin_monte_carlo_integration::fsin);
-
   ASSERT_EQ(parallel_MC_integral.validation(), false);
 
   if (world.rank() == 0) {
     std::shared_ptr<ppc::core::TaskData> seq_sin_task_data = std::make_shared<ppc::core::TaskData>();
 
     shulpin_monte_carlo_integration::TestMPITaskSequential seq_MC_integral(seq_sin_task_data);
-    seq_MC_integral.set_seq(shulpin_monte_carlo_integration::fsin);
-
     ASSERT_EQ(seq_MC_integral.validation(), false);
   }
 }

--- a/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -24,7 +24,8 @@ double parallel_integral(double a, double b, int N, const func &f);
 
 class TestMPITaskSequential : public ppc::core::Task {
  public:
-  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(taskData_ ? taskData_ : std::make_shared<ppc::core::TaskData>()) {}
   bool pre_processing() override;
   bool validation() override;
   bool run() override;
@@ -41,7 +42,8 @@ class TestMPITaskSequential : public ppc::core::Task {
 
 class TestMPITaskParallel : public ppc::core::Task {
  public:
-  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(taskData_ ? taskData_ : std::make_shared<ppc::core::TaskData>()) {}
   bool pre_processing() override;
   bool validation() override;
   bool run() override;

--- a/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -24,7 +24,7 @@ double parallel_integral(double a, double b, int N, const func &f);
 
 class TestMPITaskSequential : public ppc::core::Task {
  public:
-  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_)
+  explicit TestMPITaskSequential(const std::shared_ptr<ppc::core::TaskData>& taskData_)
       : Task(taskData_ ? taskData_ : std::make_shared<ppc::core::TaskData>()) {}
   bool pre_processing() override;
   bool validation() override;
@@ -42,7 +42,7 @@ class TestMPITaskSequential : public ppc::core::Task {
 
 class TestMPITaskParallel : public ppc::core::Task {
  public:
-  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_)
+  explicit TestMPITaskParallel(const std::shared_ptr<ppc::core::TaskData>& taskData_)
       : Task(taskData_ ? taskData_ : std::make_shared<ppc::core::TaskData>()) {}
   bool pre_processing() override;
   bool validation() override;

--- a/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -18,9 +18,9 @@ double fsin(double x);
 double fcos(double x);
 double f_two_sin_cos(double x);
 
-double integral(double a, double b, int N, func f);
+double integral(double a, double b, int N, const func &f);
 
-double parallel_integral(double a, double b, int N, func f);
+double parallel_integral(double a, double b, int N, const func &f);
 
 class TestMPITaskSequential : public ppc::core::Task {
  public:

--- a/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <functional>
+#include <memory>
+#include <numeric>
+#include <utility>
+
+#include "core/task/include/task.hpp"
+
+namespace shulpin_monte_carlo_integration {
+using func = std::function<double(double)>;
+
+double fsin(double x);
+double fcos(double x);
+double f_two_sin_cos(double x);
+
+double integral(double a, double b, int N, func f);
+
+double parallel_integral(double a, double b, int N, func f);
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  void set_seq(const func &f);
+
+ private:
+  double a_seq{};
+  double b_seq{};
+  double N_seq{};
+  func func_seq;
+  double res{};
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  void set_MPI(const func &f);
+
+ private:
+  double a_MPI{};
+  double b_MPI{};
+  double N_MPI{};
+  func func_MPI;
+  double res{};
+  boost::mpi::communicator world;
+};
+}  // namespace shulpin_monte_carlo_integration

--- a/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -24,7 +24,7 @@ double parallel_integral(double a, double b, int N, const func &f);
 
 class TestMPITaskSequential : public ppc::core::Task {
  public:
-  explicit TestMPITaskSequential(const std::shared_ptr<ppc::core::TaskData>& taskData_)
+  explicit TestMPITaskSequential(const std::shared_ptr<ppc::core::TaskData> &taskData_)
       : Task(taskData_ ? taskData_ : std::make_shared<ppc::core::TaskData>()) {}
   bool pre_processing() override;
   bool validation() override;
@@ -42,7 +42,7 @@ class TestMPITaskSequential : public ppc::core::Task {
 
 class TestMPITaskParallel : public ppc::core::Task {
  public:
-  explicit TestMPITaskParallel(const std::shared_ptr<ppc::core::TaskData>& taskData_)
+  explicit TestMPITaskParallel(const std::shared_ptr<ppc::core::TaskData> &taskData_)
       : Task(taskData_ ? taskData_ : std::make_shared<ppc::core::TaskData>()) {}
   bool pre_processing() override;
   bool validation() override;

--- a/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -53,7 +53,7 @@ class TestMPITaskParallel : public ppc::core::Task {
  private:
   double a_MPI{};
   double b_MPI{};
-  double N_MPI{};
+  int N_MPI{};
   func func_MPI;
   double res{};
   boost::mpi::communicator world;

--- a/tasks/mpi/shulpin_monte_carlo_integration/perf_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/perf_tests/main.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include <boost/mpi/timer.hpp>
+#include <cmath>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
+
+#define ESTIMATE 1e-3
+
+TEST(shulpin_monte_carlo_integration, test_pipeline_run) {
+  boost::mpi::communicator world;
+  double a = 0.0;
+  double b = M_PI;
+  int N = 1000000;
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> task_Data_parallel = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&a));
+    task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&b));
+    task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&N));
+    task_Data_parallel->outputs.push_back(reinterpret_cast<uint8_t*>(&output));
+    task_Data_parallel->outputs_count.push_back(1);
+  }
+
+  auto test_MPI_parallel = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskParallel>(task_Data_parallel);
+  test_MPI_parallel->set_MPI(shulpin_monte_carlo_integration::fsin);
+
+  ASSERT_TRUE(test_MPI_parallel->validation());
+  test_MPI_parallel->pre_processing();
+  test_MPI_parallel->run();
+  test_MPI_parallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(test_MPI_parallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    double exact = 2.0;
+    EXPECT_NEAR(output, exact, ESTIMATE);
+  }
+}
+
+TEST(shulpin_monte_carlo_integration, test_task_run) {
+  boost::mpi::communicator world;
+  double a = 0.0;
+  double b = M_PI;
+  int N = 1000000;
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> task_Data_parallel = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&a));
+    task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&b));
+    task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&N));
+    task_Data_parallel->outputs.push_back(reinterpret_cast<uint8_t*>(&output));
+    task_Data_parallel->outputs_count.push_back(1);
+  }
+
+  auto test_MPI_parallel = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskParallel>(task_Data_parallel);
+  test_MPI_parallel->set_MPI(shulpin_monte_carlo_integration::fsin);
+
+  ASSERT_TRUE(test_MPI_parallel->validation());
+  test_MPI_parallel->pre_processing();
+  test_MPI_parallel->run();
+  test_MPI_parallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(test_MPI_parallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    double exact = 2.0;
+    EXPECT_NEAR(output, exact, ESTIMATE);
+  }
+}

--- a/tasks/mpi/shulpin_monte_carlo_integration/perf_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/perf_tests/main.cpp
@@ -22,8 +22,11 @@ TEST(shulpin_monte_carlo_integration, test_pipeline_run) {
   std::shared_ptr<ppc::core::TaskData> task_Data_parallel = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&a));
+    task_Data_parallel->inputs_count.push_back(1);
     task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&b));
+    task_Data_parallel->inputs_count.push_back(1);
     task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&N));
+    task_Data_parallel->inputs_count.push_back(1);
     task_Data_parallel->outputs.push_back(reinterpret_cast<uint8_t*>(&output));
     task_Data_parallel->outputs_count.push_back(1);
   }
@@ -63,8 +66,11 @@ TEST(shulpin_monte_carlo_integration, test_task_run) {
   std::shared_ptr<ppc::core::TaskData> task_Data_parallel = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&a));
+    task_Data_parallel->inputs_count.push_back(1);
     task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&b));
+    task_Data_parallel->inputs_count.push_back(1);
     task_Data_parallel->inputs.push_back(reinterpret_cast<uint8_t*>(&N));
+    task_Data_parallel->inputs_count.push_back(1);
     task_Data_parallel->outputs.push_back(reinterpret_cast<uint8_t*>(&output));
     task_Data_parallel->outputs_count.push_back(1);
   }

--- a/tasks/mpi/shulpin_monte_carlo_integration/perf_tests/main.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/perf_tests/main.cpp
@@ -10,7 +10,7 @@
 #include "core/perf/include/perf.hpp"
 #include "mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
 
-#define ESTIMATE 1e-3
+constexpr double ESTIMATE = 1e-3;
 
 TEST(shulpin_monte_carlo_integration, test_pipeline_run) {
   boost::mpi::communicator world;

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -27,17 +27,17 @@ double shulpin_monte_carlo_integration::parallel_integral(double a, double b, in
   double b_chunk = a_chunk + chunk;
   double h_chunk = (b_chunk - a_chunk) / (N * 1.0);
 
-  double local_s = 0.0;
-  double global_s = 0.0;
+  double local_sum = 0.0;
+  double global_sum = 0.0;
 
   for (int i = 0; i < N; ++i) {
-    local_s += func_MPI(a_chunk + h_chunk * i);
+    local_sum += func_MPI(a_chunk + h_chunk * i);
   }
-  local_s *= h_chunk;
+  local_sum *= h_chunk;
 
-  boost::mpi::reduce(world, local_s, global_s, std::plus<>(), 0);
+  boost::mpi::reduce(world, local_sum, global_sum, std::plus<>(), 0);
 
-  return global_s;
+  return global_sum;
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -84,10 +84,6 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::pre_processing() {
     N_MPI = N_value;
   }
 
-  boost::mpi::broadcast(world, a_MPI, 0);
-  boost::mpi::broadcast(world, b_MPI, 0);
-  boost::mpi::broadcast(world, N_MPI, 0);
-
   return true;
 }
 
@@ -105,6 +101,10 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::run() {
   internal_order_test();
 
   double local_res{};
+
+  boost::mpi::broadcast(world, a_MPI, 0);
+  boost::mpi::broadcast(world, b_MPI, 0);
+  boost::mpi::broadcast(world, N_MPI, 0);
 
   local_res = parallel_integral(a_MPI, b_MPI, N_MPI, func_MPI);
   boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -1,0 +1,126 @@
+#include "mpi/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <numeric>
+#include <random>
+
+using namespace std::chrono_literals;
+
+double shulpin_monte_carlo_integration::fsin(double x) { return std::sin(x); }
+double shulpin_monte_carlo_integration::fcos(double x) { return std::cos(x); }
+double shulpin_monte_carlo_integration::f_two_sin_cos(double x) { return 2 * std::sin(x) * std::cos(x); }
+
+double shulpin_monte_carlo_integration::integral(double a, double b, int N, func func_seq) {
+  double h = (b - a) / (N * 1.0);
+  double sum = 0.0;
+
+  for (int i = 0; i < N; ++i) {
+    sum += func_seq(a + h * i);
+  }
+
+  return h * sum;
+}
+
+double shulpin_monte_carlo_integration::parallel_integral(double a, double b, int N, func func_MPI) {
+  boost::mpi::communicator world;
+  double chunk = (b - a) / world.size();
+
+  double a_chunk = a + chunk * world.rank();
+  double b_chunk = a_chunk + chunk;
+  double h_chunk = (b_chunk - a_chunk) / (N * 1.0);
+
+  double local_sum = 0.0;
+  double global_sum = 0.0;
+
+  for (int i = 0; i < N; ++i) {
+    local_sum += func_MPI(a_chunk + h_chunk * i);
+  }
+  local_sum *= h_chunk;
+
+  boost::mpi::reduce(world, local_sum, global_sum, std::plus<double>(), 0);
+
+  return global_sum;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+
+  double a_value = *reinterpret_cast<double*>(taskData->inputs[0]);
+  double b_value = *reinterpret_cast<double*>(taskData->inputs[1]);
+  int N_value = *reinterpret_cast<int*>(taskData->inputs[2]);
+
+  a_seq = a_value;
+  b_seq = b_value;
+  N_seq = N_value;
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
+  internal_order_test();
+
+  return taskData->outputs_count[0] == 1;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::run() {
+  internal_order_test();
+
+  res = integral(a_seq, b_seq, N_seq, func_seq);
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskParallel::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    double a_value = *reinterpret_cast<double*>(taskData->inputs[0]);
+    double b_value = *reinterpret_cast<double*>(taskData->inputs[1]);
+    int N_value = *reinterpret_cast<int*>(taskData->inputs[2]);
+
+    a_MPI = a_value;
+    b_MPI = b_value;
+    N_MPI = N_value;
+  }
+
+  boost::mpi::broadcast(world, a_MPI, 0);
+  boost::mpi::broadcast(world, b_MPI, 0);
+  boost::mpi::broadcast(world, N_MPI, 0);
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskParallel::validation() {
+  internal_order_test();
+
+  return world.rank() == 0 ? taskData->outputs_count[0] == 1 : true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskParallel::run() {
+  internal_order_test();
+
+  res = parallel_integral(a_MPI, b_MPI, N_MPI, func_MPI);
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+  }
+
+  return true;
+}
+
+void shulpin_monte_carlo_integration::TestMPITaskSequential::set_seq(const func& f) { func_seq = f; }
+
+void shulpin_monte_carlo_integration::TestMPITaskParallel::set_MPI(const func& f) { func_MPI = f; }

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -57,10 +57,6 @@ bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
   internal_order_test();
 
-  if (taskData->outputs_count.empty()) {
-    return false;
-  }
-
   return taskData->outputs_count[0] == 1;
 }
 
@@ -102,11 +98,7 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::validation() {
   internal_order_test();
 
   if (world.rank() == 0) {
-    if (taskData->outputs_count.empty()) {
-      return false;
-    }
-
-    return taskData->outputs_count[0] == 1;
+    return (taskData->inputs_count.size() == 3 && taskData->outputs_count[0] == 1);
   }
 
   return true;

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -55,11 +55,11 @@ bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
-  internal_order_test();
-
   if (!taskData || taskData->outputs_count.empty()) {
     return false;
   }
+  
+  internal_order_test();
 
   return taskData->outputs_count[0] == 1;
 }
@@ -99,14 +99,16 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::pre_processing() {
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskParallel::validation() {
-  internal_order_test();
-
   if (world.rank() == 0) {
     if (!taskData || taskData->outputs_count.empty()) {
       return false;
     }
+
+    internal_order_test();
+
     return taskData->outputs_count[0] == 1;
   }
+
   return true;
 }
 

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -55,11 +55,11 @@ bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
+  internal_order_test();
+
   if (!taskData || taskData->outputs_count.empty()) {
     return false;
   }
-
-  internal_order_test();
 
   return taskData->outputs_count[0] == 1;
 }
@@ -99,12 +99,12 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::pre_processing() {
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskParallel::validation() {
+  internal_order_test();
+
   if (world.rank() == 0) {
     if (!taskData || taskData->outputs_count.empty()) {
       return false;
     }
-
-    internal_order_test();
 
     return taskData->outputs_count[0] == 1;
   }

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -3,10 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
-#include <numeric>
-#include <random>
-
-using namespace std::chrono_literals;
 
 double shulpin_monte_carlo_integration::fsin(double x) { return std::sin(x); }
 double shulpin_monte_carlo_integration::fcos(double x) { return std::cos(x); }
@@ -61,6 +57,10 @@ bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
   internal_order_test();
 
+  if (!taskData || taskData->outputs_count.empty()) {
+    return false;
+  }
+
   return taskData->outputs_count[0] == 1;
 }
 
@@ -101,7 +101,13 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::pre_processing() {
 bool shulpin_monte_carlo_integration::TestMPITaskParallel::validation() {
   internal_order_test();
 
-  return world.rank() == 0 ? taskData->outputs_count[0] == 1 : true;
+  if (world.rank() == 0) {
+    if (!taskData || taskData->outputs_count.empty()) {
+      return false;
+    }
+    return taskData->outputs_count[0] == 1;
+  }
+  return true;
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskParallel::run() {

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -58,7 +58,7 @@ bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
   if (!taskData || taskData->outputs_count.empty()) {
     return false;
   }
-  
+
   internal_order_test();
 
   return taskData->outputs_count[0] == 1;

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -39,7 +39,7 @@ double shulpin_monte_carlo_integration::parallel_integral(double a, double b, in
   }
   local_sum *= h_chunk;
 
-  boost::mpi::reduce(world, local_sum, global_sum, std::plus<double>(), 0);
+  boost::mpi::reduce(world, local_sum, global_sum, std::plus<>(), 0);
 
   return global_sum;
 }

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -27,17 +27,17 @@ double shulpin_monte_carlo_integration::parallel_integral(double a, double b, in
   double b_chunk = a_chunk + chunk;
   double h_chunk = (b_chunk - a_chunk) / (N * 1.0);
 
-  double local_sum = 0.0;
-  double global_sum = 0.0;
+  double local_s = 0.0;
+  double global_s = 0.0;
 
   for (int i = 0; i < N; ++i) {
-    local_sum += func_MPI(a_chunk + h_chunk * i);
+    local_s += func_MPI(a_chunk + h_chunk * i);
   }
-  local_sum *= h_chunk;
+  local_s *= h_chunk;
 
-  boost::mpi::reduce(world, local_sum, global_sum, std::plus<>(), 0);
+  boost::mpi::reduce(world, local_s, global_s, std::plus<>(), 0);
 
-  return global_sum;
+  return global_s;
 }
 
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -57,7 +57,7 @@ bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
 bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
   internal_order_test();
 
-  if (!taskData || taskData->outputs_count.empty()) {
+  if (taskData->outputs_count.empty()) {
     return false;
   }
 
@@ -102,7 +102,7 @@ bool shulpin_monte_carlo_integration::TestMPITaskParallel::validation() {
   internal_order_test();
 
   if (world.rank() == 0) {
-    if (!taskData || taskData->outputs_count.empty()) {
+    if (taskData->outputs_count.empty()) {
       return false;
     }
 

--- a/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/mpi/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -12,7 +12,7 @@ double shulpin_monte_carlo_integration::fsin(double x) { return std::sin(x); }
 double shulpin_monte_carlo_integration::fcos(double x) { return std::cos(x); }
 double shulpin_monte_carlo_integration::f_two_sin_cos(double x) { return 2 * std::sin(x) * std::cos(x); }
 
-double shulpin_monte_carlo_integration::integral(double a, double b, int N, func func_seq) {
+double shulpin_monte_carlo_integration::integral(double a, double b, int N, const func& func_seq) {
   double h = (b - a) / (N * 1.0);
   double sum = 0.0;
 
@@ -23,7 +23,7 @@ double shulpin_monte_carlo_integration::integral(double a, double b, int N, func
   return h * sum;
 }
 
-double shulpin_monte_carlo_integration::parallel_integral(double a, double b, int N, func func_MPI) {
+double shulpin_monte_carlo_integration::parallel_integral(double a, double b, int N, const func& func_MPI) {
   boost::mpi::communicator world;
   double chunk = (b - a) / world.size();
 

--- a/tasks/seq/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
+
+#define ESTIMATE 1e-3
+
+TEST(shulpin_monte_carlo_integration, sin_test) {
+  double lower_limit = 0.0;
+  double upper_limit = M_PI;
+  int interval_count = 100000;
+  const double expected_sin_integral_result = 2.0;
+
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> seq_sin_task_data = std::make_shared<ppc::core::TaskData>();
+
+  seq_sin_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&lower_limit));
+  seq_sin_task_data->inputs_count.emplace_back(1);
+
+  seq_sin_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&upper_limit));
+  seq_sin_task_data->inputs_count.emplace_back(1);
+
+  seq_sin_task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(&interval_count));
+  seq_sin_task_data->inputs_count.emplace_back(1);
+
+  seq_sin_task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+  seq_sin_task_data->outputs_count.emplace_back(1);
+
+  auto testTaskSequential = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskSequential>(seq_sin_task_data);
+
+  testTaskSequential->set_seq(shulpin_monte_carlo_integration::fsin);
+
+  ASSERT_TRUE(testTaskSequential->validation());
+  testTaskSequential->pre_processing();
+  testTaskSequential->run();
+  testTaskSequential->post_processing();
+
+  ASSERT_LT(std::abs(output - expected_sin_integral_result), ESTIMATE);
+}
+
+TEST(shulpin_monte_carlo_integration, test_cos) {
+  const double lower_limit = 0.0;
+  const double upper_limit = M_PI;
+  const int interval_count = 100000;
+  const double expected_cos_integral_result = 0.0;
+
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(&lower_limit)));
+  taskDataSeq->inputs_count.emplace_back(1);
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(&upper_limit)));
+  taskDataSeq->inputs_count.emplace_back(1);
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&interval_count)));
+  taskDataSeq->inputs_count.emplace_back(1);
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+  taskDataSeq->outputs_count.emplace_back(1);
+
+  auto testTaskSequential = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskSequential>(taskDataSeq);
+
+  testTaskSequential->set_seq(shulpin_monte_carlo_integration::fcos);
+
+  ASSERT_TRUE(testTaskSequential->validation());
+  testTaskSequential->pre_processing();
+  testTaskSequential->run();
+  testTaskSequential->post_processing();
+
+  ASSERT_LT(std::abs(output - expected_cos_integral_result), ESTIMATE);
+}
+
+TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
+  const double lower_limit = 0.0;
+  const double upper_limit = M_PI;
+  const int interval_count = 100000;
+  const double expected_integral_result = 0.0;
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(&lower_limit)));
+  taskDataSeq->inputs_count.emplace_back(1);
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(&upper_limit)));
+  taskDataSeq->inputs_count.emplace_back(1);
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&interval_count)));
+  taskDataSeq->inputs_count.emplace_back(1);
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+  taskDataSeq->outputs_count.emplace_back(1);
+
+  auto testTaskSequential = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskSequential>(taskDataSeq);
+
+  testTaskSequential->set_seq(shulpin_monte_carlo_integration::f_two_sin_cos);
+
+  ASSERT_TRUE(testTaskSequential->validation());
+  testTaskSequential->pre_processing();
+  testTaskSequential->run();
+  testTaskSequential->post_processing();
+
+  ASSERT_LT(std::abs(output - expected_integral_result), ESTIMATE);
+}

--- a/tasks/seq/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -44,7 +44,7 @@ TEST(shulpin_monte_carlo_integration, sin_test) {
   testTaskSequential->run();
   testTaskSequential->post_processing();
 
-  ASSERT_LT(std::abs(output - expected_sin_integral_result), ESTIMATE);
+  ASSERT_NEAR(output, expected_sin_integral_result, ESTIMATE);
 }
 
 TEST(shulpin_monte_carlo_integration, test_cos) {
@@ -78,7 +78,7 @@ TEST(shulpin_monte_carlo_integration, test_cos) {
   testTaskSequential->run();
   testTaskSequential->post_processing();
 
-  ASSERT_LT(std::abs(output - expected_cos_integral_result), ESTIMATE);
+  ASSERT_NEAR(output, expected_cos_integral_result, ESTIMATE);
 }
 
 TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
@@ -110,5 +110,5 @@ TEST(shulpin_monte_carlo_integration, test_two_sin_cos) {
   testTaskSequential->run();
   testTaskSequential->post_processing();
 
-  ASSERT_LT(std::abs(output - expected_integral_result), ESTIMATE);
+  ASSERT_NEAR(output, expected_integral_result, ESTIMATE);
 }

--- a/tasks/seq/shulpin_monte_carlo_integration/func_tests/main.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/func_tests/main.cpp
@@ -11,7 +11,7 @@
 
 #include "seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
 
-#define ESTIMATE 1e-3
+constexpr double ESTIMATE = 1e-3;
 
 TEST(shulpin_monte_carlo_integration, sin_test) {
   double lower_limit = 0.0;

--- a/tasks/seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -24,7 +24,7 @@ class TestMPITaskSequential : public ppc::core::Task {
   bool validation() override;
   bool run() override;
   bool post_processing() override;
-  void set_seq(const func &f);
+  void set_seq(const func& f);
 
  private:
   double a_seq{};

--- a/tasks/seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <numeric>
+
+#include "core/task/include/task.hpp"
+
+namespace shulpin_monte_carlo_integration {
+using func = std::function<double(double)>;
+
+double fsin(double x);
+double fcos(double x);
+double f_two_sin_cos(double x);
+
+double integral(double a, double b, int N, func f);
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  void set_seq(const func &f);
+
+ private:
+  double a_seq{};
+  double b_seq{};
+  double N_seq{};
+  func func_seq;
+  double res{};
+};
+}  // namespace shulpin_monte_carlo_integration

--- a/tasks/seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp
@@ -15,7 +15,7 @@ double fsin(double x);
 double fcos(double x);
 double f_two_sin_cos(double x);
 
-double integral(double a, double b, int N, func f);
+double integral(double a, double b, int N, const func& f);
 
 class TestMPITaskSequential : public ppc::core::Task {
  public:

--- a/tasks/seq/shulpin_monte_carlo_integration/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/perf_tests/main.cpp
@@ -9,12 +9,12 @@
 #include "core/perf/include/perf.hpp"
 #include "seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
 
-#define ESTIMATE 1e-3
+constexpr double ESTIMATE = 1e-3;
 
 TEST(shulpin_monte_carlo_integration, test_pipeline_run) {
   double a = 0.0;
   double b = M_PI;
-  int N = 10000;
+  int N = 1000000;
 
   const double expected_result = 2.0;
 
@@ -54,7 +54,7 @@ TEST(shulpin_monte_carlo_integration, test_pipeline_run) {
 TEST(shulpin_monte_carlo_integration, test_task_run) {
   double a = 0.0;
   double b = M_PI;
-  int N = 10000;
+  int N = 1000000;
   const double expected_result = 2.0;
 
   double output = 0.0;

--- a/tasks/seq/shulpin_monte_carlo_integration/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/perf_tests/main.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include <cmath>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
+
+#define ESTIMATE 1e-3
+
+TEST(shulpin_monte_carlo_integration, test_pipeline_run) {
+  double a = 0.0;
+  double b = M_PI;
+  int N = 10000;
+
+  const double expected_result = 2.0;
+
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+  taskDataSeq->outputs_count.emplace_back(1);
+
+  auto testTaskSequential = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskSequential>(taskDataSeq);
+
+  testTaskSequential->set_seq(shulpin_monte_carlo_integration::fsin);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  ASSERT_LT(std::abs(output - expected_result), ESTIMATE);
+}
+
+TEST(shulpin_monte_carlo_integration, test_task_run) {
+  double a = 0.0;
+  double b = M_PI;
+  int N = 10000;
+  const double expected_result = 2.0;
+
+  double output = 0.0;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+  taskDataSeq->outputs_count.emplace_back(1);
+
+  auto testTaskSequential = std::make_shared<shulpin_monte_carlo_integration::TestMPITaskSequential>(taskDataSeq);
+
+  testTaskSequential->set_seq(shulpin_monte_carlo_integration::fsin);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  ASSERT_LT(std::abs(output - expected_result), ESTIMATE);
+}

--- a/tasks/seq/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -3,10 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
-#include <numeric>
-#include <random>
-
-using namespace std::chrono_literals;
 
 double shulpin_monte_carlo_integration::fsin(double x) { return std::sin(x); }
 double shulpin_monte_carlo_integration::fcos(double x) { return std::cos(x); }

--- a/tasks/seq/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -1,0 +1,61 @@
+#include "seq/shulpin_monte_carlo_integration/include/monte_carlo_integral.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <numeric>
+#include <random>
+
+using namespace std::chrono_literals;
+
+double shulpin_monte_carlo_integration::fsin(double x) { return std::sin(x); }
+double shulpin_monte_carlo_integration::fcos(double x) { return std::cos(x); }
+double shulpin_monte_carlo_integration::f_two_sin_cos(double x) { return 2 * std::sin(x) * std::cos(x); }
+
+double shulpin_monte_carlo_integration::integral(double a, double b, int N, func func_seq) {
+  double h = (b - a) / (N * 1.0);
+  double sum = 0.0;
+
+  for (int i = 0; i < N; ++i) {
+    sum += func_seq(a + h * i);
+  }
+
+  return h * sum;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+
+  double a_value = *reinterpret_cast<double*>(taskData->inputs[0]);
+  double b_value = *reinterpret_cast<double*>(taskData->inputs[1]);
+  int N_value = *reinterpret_cast<int*>(taskData->inputs[2]);
+
+  a_seq = a_value;
+  b_seq = b_value;
+  N_seq = N_value;
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::validation() {
+  internal_order_test();
+
+  return taskData->outputs_count[0] == 1;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::run() {
+  internal_order_test();
+
+  res = integral(a_seq, b_seq, N_seq, func_seq);
+
+  return true;
+}
+
+bool shulpin_monte_carlo_integration::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+
+  return true;
+}
+
+void shulpin_monte_carlo_integration::TestMPITaskSequential::set_seq(const func& f) { func_seq = f; }

--- a/tasks/seq/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
+++ b/tasks/seq/shulpin_monte_carlo_integration/src/monte_carlo_integral.cpp
@@ -12,7 +12,7 @@ double shulpin_monte_carlo_integration::fsin(double x) { return std::sin(x); }
 double shulpin_monte_carlo_integration::fcos(double x) { return std::cos(x); }
 double shulpin_monte_carlo_integration::f_two_sin_cos(double x) { return 2 * std::sin(x) * std::cos(x); }
 
-double shulpin_monte_carlo_integration::integral(double a, double b, int N, func func_seq) {
+double shulpin_monte_carlo_integration::integral(double a, double b, int N, const func& func_seq) {
   double h = (b - a) / (N * 1.0);
   double sum = 0.0;
 


### PR DESCRIPTION
**Описание ошибки**
Ошибка заключалась в том, что validation проверяет количество введенных параметров(a, b, N). В perf test было реализовано только добавления параметра N(для переменной inputs_count), из-за чего валидация постоянно проваливалась. Исправлено