### PR TITLE
Хохлов Андрей. Задача 2. Вариант 23. Итеративные методы (Зейделя).

### DIFF
--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -83,9 +83,13 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
   };
   khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seidel_method_mpi(taskdataMpi);
   ASSERT_TRUE(seidel_method_mpi.validation());
+  std::cout << world.rank() << std::endl;
   seidel_method_mpi.pre_processing();
+  std::cout << world.rank() << std::endl;
   seidel_method_mpi.run();
+  std::cout << world.rank() << std::endl;
   seidel_method_mpi.post_processing();
+  std::cout << world.rank() << std::endl;
 
   ASSERT_EQ(result.size(), b.size());
 

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+
+#include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
+  boost::mpi::communicator world;
+  const int n = 0;
+  const int maxiter = 10;
+
+  // create data
+  std::vector<double> A = {};
+  std::vector<double> b = {};
+  std::vector<double> expect = {};
+  std::vector<double> result;
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataSeq->inputs_count.emplace_back(n);
+    taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataSeq->outputs_count.emplace_back(result.size());
+  }
+
+  // crate task
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataSeq);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(seidel_method_mpi.validation());
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
+  boost::mpi::communicator world;
+  const int n = 2;
+  const int maxiter = 0;
+
+  // create data
+  std::vector<double> A = {1, 2, 3, 4};
+  std::vector<double> b = {1, 2};
+  std::vector<double> expect = {};
+  std::vector<double> result;
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataSeq->inputs_count.emplace_back(n);
+    taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataSeq->outputs_count.emplace_back(result.size());
+  }
+
+  // crate task
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataSeq);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(seidel_method_mpi.validation());
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
+  boost::mpi::communicator world;
+  const int n = 300;
+  const int maxiter = 1000;
+
+  // Create data
+  std::vector<double> A(n * n, 0.0);
+  std::vector<double> b(n, 0.0);
+  std::vector<double> result(n, 0.0);
+  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
+  };
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seidel_method_mpi(taskdataMpi);
+  ASSERT_TRUE(seidel_method_mpi.validation());
+  seidel_method_mpi.pre_processing();
+  seidel_method_mpi.run();
+  seidel_method_mpi.post_processing();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(result.size(), b.size());
+  }
+  if (world.rank() == 0) {
+    std::vector<double> result_seq(n, 0.0);
+    // create task data
+    std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataSeq->inputs_count.emplace_back(n);
+    taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataSeq->outputs_count.emplace_back(result.size());
+
+    // crate task
+    khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seidel_method_seq(taskdataSeq);
+    ASSERT_TRUE(seidel_method_seq.validation());
+    seidel_method_seq.pre_processing();
+    seidel_method_seq.run();
+    seidel_method_seq.post_processing();
+    if (world.rank() == 0) {
+      for (int i = 0; i < n; i++) {
+        ASSERT_NEAR(result[i], result_seq[i], 1e-1);
+      }
+    }
+  }
+}

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -83,13 +83,9 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
   };
   khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seidel_method_mpi(taskdataMpi);
   ASSERT_TRUE(seidel_method_mpi.validation());
-  std::cout << world.rank() << std::endl;
   seidel_method_mpi.pre_processing();
-  std::cout << world.rank() << std::endl;
   seidel_method_mpi.run();
-  std::cout << world.rank() << std::endl;
   seidel_method_mpi.post_processing();
-  std::cout << world.rank() << std::endl;
 
   ASSERT_EQ(result.size(), b.size());
 

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -17,19 +17,19 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   std::vector<double> result;
 
   // create task data
-  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
-    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
-    taskdataSeq->inputs_count.emplace_back(n);
-    taskdataSeq->inputs_count.emplace_back(maxiter);
-    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-    taskdataSeq->outputs_count.emplace_back(result.size());
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
   }
 
   // crate task
-  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataSeq);
   if (world.rank() == 0) {
+    khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
     ASSERT_FALSE(seidel_method_mpi.validation());
   }
 }
@@ -46,19 +46,19 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
   std::vector<double> result;
 
   // create task data
-  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
-    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
-    taskdataSeq->inputs_count.emplace_back(n);
-    taskdataSeq->inputs_count.emplace_back(maxiter);
-    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-    taskdataSeq->outputs_count.emplace_back(result.size());
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
   }
 
   // crate task
-  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataSeq);
   if (world.rank() == 0) {
+    khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
     ASSERT_FALSE(seidel_method_mpi.validation());
   }
 }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -62,7 +62,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
 
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
   boost::mpi::communicator world;
-  const int n = 300;
+  const int n = 30;
   const int maxiter = 1000;
 
   // Create data
@@ -81,13 +81,13 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   };
-  khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seidel_method_mpi(taskdataMpi);
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
   ASSERT_TRUE(seidel_method_mpi.validation());
   seidel_method_mpi.pre_processing();
   seidel_method_mpi.run();
   seidel_method_mpi.post_processing();
 
-  ASSERT_EQ(result.size(), b.size());
+  // ASSERT_EQ(result.size(), b.size());
 
   if (world.rank() == 0) {
     std::vector<double> result_seq(n, 0.0);
@@ -106,10 +106,8 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
     seidel_method_seq.pre_processing();
     seidel_method_seq.run();
     seidel_method_seq.post_processing();
-    if (world.rank() == 0) {
-      for (int i = 0; i < n; i++) {
-        ASSERT_NEAR(result[i], result_seq[i], 1e-1);
-      }
+    for (int i = 0; i < n; i++) {
+      ASSERT_NEAR(result[i], result_seq[i], 1e-1);
     }
   }
 }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -14,7 +14,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   std::vector<double> A = {};
   std::vector<double> b = {};
   std::vector<double> expect = {};
-  std::vector<double> result;
+  std::vector<double> result = {};
 
   // create task data
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
@@ -28,10 +28,9 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   }
 
   // crate task
-  if (world.rank() == 0) {
-    khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
-    ASSERT_FALSE(seidel_method_mpi.validation());
-  }
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
+  ASSERT_FALSE(seidel_method_mpi.validation());
+
 }
 
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
@@ -43,7 +42,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
   std::vector<double> A = {1, 2, 3, 4};
   std::vector<double> b = {1, 2};
   std::vector<double> expect = {};
-  std::vector<double> result;
+  std::vector<double> result = {};
 
   // create task data
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
@@ -57,10 +56,8 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
   }
 
   // crate task
-  if (world.rank() == 0) {
-    khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
-    ASSERT_FALSE(seidel_method_mpi.validation());
-  }
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi seidel_method_mpi(taskdataMpi);
+  ASSERT_FALSE(seidel_method_mpi.validation());
 }
 
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
@@ -90,9 +87,8 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
   seidel_method_mpi.run();
   seidel_method_mpi.post_processing();
 
-  if (world.rank() == 0) {
-    ASSERT_EQ(result.size(), b.size());
-  }
+  ASSERT_EQ(result.size(), b.size());
+
   if (world.rank() == 0) {
     std::vector<double> result_seq(n, 0.0);
     // create task data

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -101,8 +101,8 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
     taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataSeq->inputs_count.emplace_back(n);
     taskdataSeq->inputs_count.emplace_back(maxiter);
-    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-    taskdataSeq->outputs_count.emplace_back(result.size());
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    taskdataSeq->outputs_count.emplace_back(result_seq.size());
 
     // crate task
     khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seidel_method_seq(taskdataSeq);

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -2,7 +2,6 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
-#include <random>
 
 #include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
 #include "mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp"
@@ -11,6 +10,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   boost::mpi::communicator world;
   const int n = 0;
   const int maxiter = 10;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A = {};
@@ -25,6 +25,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
     taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataMpi->inputs_count.emplace_back(n);
     taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   }
@@ -40,6 +41,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
   boost::mpi::communicator world;
   const int n = 2;
   const int maxiter = 0;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A = {1, 2, 3, 4};
@@ -54,6 +56,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
     taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataMpi->inputs_count.emplace_back(n);
     taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   }
@@ -69,6 +72,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_validation) {
   boost::mpi::communicator world;
   const int n = 2;
   const int maxiter = 10;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A = {1, 2, 3, 4};
@@ -83,6 +87,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_validation) {
     taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataMpi->inputs_count.emplace_back(n);
     taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   }
@@ -92,10 +97,11 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_validation) {
   ASSERT_TRUE(mpi_task.validation());
 }
 
-TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix_10x10) {
   boost::mpi::communicator world;
-  const int n = 30;
+  const int n = 10;
   const int maxiter = 100;
+  const double eps = 1e-8;
 
   // Create data
   std::vector<double> A(n * n, 1.0);
@@ -111,6 +117,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
     taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataMpi->inputs_count.emplace_back(n);
     taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   };
@@ -130,6 +137,175 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
     taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataSeq->inputs_count.emplace_back(n);
     taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->inputs_count.emplace_back(eps);
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    taskdataSeq->outputs_count.emplace_back(result_seq.size());
+
+    // crate task
+    khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seq_task(taskdataSeq);
+    ASSERT_TRUE(seq_task.validation());
+    seq_task.pre_processing();
+    seq_task.run();
+    seq_task.post_processing();
+    for (int i = 0; i < n; i++) {
+      ASSERT_NEAR(result[i], result_seq[i], 1);
+    }
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix_20x20) {
+  boost::mpi::communicator world;
+  const int n = 20;
+  const int maxiter = 100;
+  const double eps = 1e-6;
+
+  // Create data
+  std::vector<double> A(n * n, 1.0);
+  std::vector<double> b(n, 1.0);
+  std::vector<double> result(n, 1.0);
+
+  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
+  };
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi mpi_task(taskdataMpi);
+  ASSERT_TRUE(mpi_task.validation());
+  mpi_task.pre_processing();
+  mpi_task.run();
+  mpi_task.post_processing();
+
+  ASSERT_EQ(result.size(), b.size());
+
+  if (world.rank() == 0) {
+    std::vector<double> result_seq(n, 0.0);
+    // create task data
+    std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataSeq->inputs_count.emplace_back(n);
+    taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->inputs_count.emplace_back(eps);
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    taskdataSeq->outputs_count.emplace_back(result_seq.size());
+
+    // crate task
+    khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seq_task(taskdataSeq);
+    ASSERT_TRUE(seq_task.validation());
+    seq_task.pre_processing();
+    seq_task.run();
+    seq_task.post_processing();
+    for (int i = 0; i < n; i++) {
+      ASSERT_NEAR(result[i], result_seq[i], 1e-1);
+    }
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix_50x50) {
+  boost::mpi::communicator world;
+  const int n = 50;
+  const int maxiter = 100;
+  const double eps = 1e-6;
+
+  // Create data
+  std::vector<double> A(n * n, 1.0);
+  std::vector<double> b(n, 1.0);
+  std::vector<double> result(n, 1.0);
+
+  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
+  };
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi mpi_task(taskdataMpi);
+  ASSERT_TRUE(mpi_task.validation());
+  mpi_task.pre_processing();
+  mpi_task.run();
+  mpi_task.post_processing();
+
+  ASSERT_EQ(result.size(), b.size());
+
+  if (world.rank() == 0) {
+    std::vector<double> result_seq(n, 0.0);
+    // create task data
+    std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataSeq->inputs_count.emplace_back(n);
+    taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->inputs_count.emplace_back(eps);
+    taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    taskdataSeq->outputs_count.emplace_back(result_seq.size());
+
+    // crate task
+    khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq seq_task(taskdataSeq);
+    ASSERT_TRUE(seq_task.validation());
+    seq_task.pre_processing();
+    seq_task.run();
+    seq_task.post_processing();
+    for (int i = 0; i < n; i++) {
+      ASSERT_NEAR(result[i], result_seq[i], 1e-1);
+    }
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix100x100) {
+  boost::mpi::communicator world;
+  const int n = 100;
+  const int maxiter = 150;
+  const double eps = 1e-6;
+
+  // Create data
+  std::vector<double> A(n * n, 1.0);
+  std::vector<double> b(n, 1.0);
+  std::vector<double> result(n, 1.0);
+
+  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
+  };
+  khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi mpi_task(taskdataMpi);
+  ASSERT_TRUE(mpi_task.validation());
+  mpi_task.pre_processing();
+  mpi_task.run();
+  mpi_task.post_processing();
+
+  ASSERT_EQ(result.size(), b.size());
+
+  if (world.rank() == 0) {
+    std::vector<double> result_seq(n, 0.0);
+    // create task data
+    std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataSeq->inputs_count.emplace_back(n);
+    taskdataSeq->inputs_count.emplace_back(maxiter);
+    taskdataSeq->inputs_count.emplace_back(eps);
     taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
     taskdataSeq->outputs_count.emplace_back(result_seq.size());
 

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -6,6 +6,22 @@
 #include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
 #include "mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp"
 
+void getRandomSLAU(std::vector<double> &A, std::vector<double> &b, int N) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  for (int i = 0; i < N; ++i) {
+    double rowSum = 0.0;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        A[i * N + j] = rand() % 10 - 5;
+        rowSum += std::abs(A[i * N + j]);
+      }
+    }
+    A[i * N + i] = rowSum + (rand() % 5 + 1);
+    b[i] = rand() % 20 - 10;
+  }
+}
+
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   boost::mpi::communicator world;
   const int n = 0;
@@ -108,7 +124,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix_10x10) {
   std::vector<double> b(n, 1.0);
   std::vector<double> result(n, 1.0);
 
-  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
@@ -164,7 +180,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix_20x20) {
   std::vector<double> b(n, 1.0);
   std::vector<double> result(n, 1.0);
 
-  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
@@ -220,7 +236,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix_50x50) {
   std::vector<double> b(n, 1.0);
   std::vector<double> result(n, 1.0);
 
-  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
@@ -276,7 +292,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix100x100) {
   std::vector<double> b(n, 1.0);
   std::vector<double> result(n, 1.0);
 
-  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -7,7 +7,6 @@
 #include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
 #include "mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp"
 
-
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   boost::mpi::communicator world;
   const int n = 0;
@@ -33,7 +32,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_empty_matrix) {
   // crate task
   khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi mpi_task(taskdataMpi);
   if (world.rank() == 0) {
-     ASSERT_FALSE(mpi_task.validation());
+    ASSERT_FALSE(mpi_task.validation());
   }
 }
 
@@ -62,7 +61,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_invalid_iter) {
   // crate task
   khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi mpi_task(taskdataMpi);
   if (world.rank() == 0) {
-     ASSERT_FALSE(mpi_task.validation());
+    ASSERT_FALSE(mpi_task.validation());
   }
 }
 
@@ -92,7 +91,6 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_validation) {
   khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi mpi_task(taskdataMpi);
   ASSERT_TRUE(mpi_task.validation());
 }
-
 
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_const_matrix) {
   boost::mpi::communicator world;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -6,6 +6,8 @@
 #include <iomanip>
 #include <random>
 #include <vector>
+#include <iostream>
+#include <fstream>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -43,7 +43,7 @@ class seidel_method_mpi : public ppc::core::Task {
   const double EPSILON = 1e-6;
   std::vector<double> A, local_A;
   std::vector<double> b, local_b;
-  std::vector<double> x, prevX, local_x;
+  std::vector<double> x, prevX, local_x, result;
   int maxIterations, n;
 };
 }  // namespace khokhlov_a_iterative_seidel_method_mpi

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -3,11 +3,11 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
+#include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <random>
 #include <vector>
-#include <iostream>
-#include <fstream>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -40,7 +40,7 @@ class seidel_method_mpi : public ppc::core::Task {
 
  private:
   boost::mpi::communicator world;
-  // const double EPSILON = 1e-6;
+  const double EPSILON = 1e-6;
   std::vector<double> A, local_A;
   std::vector<double> b, local_b;
   std::vector<double> x, prevX, local_x, result;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cmath>
+#include <iomanip>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace khokhlov_a_iterative_seidel_method_mpi {
+void getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N);
+
+class seidel_method_seq : public ppc::core::Task {
+ public:
+  explicit seidel_method_seq(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  const double EPSILON = 1e-6;
+  std::vector<double> A;
+  std::vector<double> b;
+  std::vector<double> result;
+  int maxIterations, n;
+};
+
+class seidel_method_mpi : public ppc::core::Task {
+ public:
+  explicit seidel_method_mpi(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  boost::mpi::communicator world;
+  const double EPSILON = 1e-6;
+  std::vector<double> A, local_A;
+  std::vector<double> b, local_b;
+  std::vector<double> result, local_result;
+  int maxIterations, n;
+};
+}  // namespace khokhlov_a_iterative_seidel_method_mpi

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -40,7 +40,7 @@ class seidel_method_mpi : public ppc::core::Task {
 
  private:
   boost::mpi::communicator world;
-  const double EPSILON = 1e-6;
+  // const double EPSILON = 1e-6;
   std::vector<double> A, local_A;
   std::vector<double> b, local_b;
   std::vector<double> x, prevX, local_x, result;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -9,7 +9,6 @@
 #include "core/task/include/task.hpp"
 
 namespace khokhlov_a_iterative_seidel_method_mpi {
-void getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N);
 
 class seidel_method_seq : public ppc::core::Task {
  public:

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -3,9 +3,6 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
-#include <fstream>
-#include <iomanip>
-#include <iostream>
 #include <random>
 #include <vector>
 
@@ -23,7 +20,7 @@ class seidel_method_seq : public ppc::core::Task {
   bool post_processing() override;
 
  private:
-  const double EPSILON = 1e-6;
+  double EPSILON;
   std::vector<double> A;
   std::vector<double> b;
   std::vector<double> result;
@@ -40,7 +37,7 @@ class seidel_method_mpi : public ppc::core::Task {
 
  private:
   boost::mpi::communicator world;
-  const double EPSILON = 1e-6;
+  double EPSILON;
   std::vector<double> A, local_A;
   std::vector<double> b, local_b;
   std::vector<double> x, prevX, local_x, result;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -20,7 +20,7 @@ class seidel_method_seq : public ppc::core::Task {
   bool post_processing() override;
 
  private:
-  int rank(std::vector<double> A_, int rows, int cols);
+  static int rank(std::vector<double> A_, int rows, int cols);
   double EPSILON;
   std::vector<double> A;
   std::vector<double> b;
@@ -37,7 +37,7 @@ class seidel_method_mpi : public ppc::core::Task {
   bool post_processing() override;
 
  private:
-  int rank(std::vector<double> A_, int rows, int cols);
+  static int rank(std::vector<double> A_, int rows, int cols);
   boost::mpi::communicator world;
   double EPSILON;
   std::vector<double> A, local_A;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -20,6 +20,7 @@ class seidel_method_seq : public ppc::core::Task {
   bool post_processing() override;
 
  private:
+  int rank(std::vector<double> A_, int rows, int cols);
   double EPSILON;
   std::vector<double> A;
   std::vector<double> b;
@@ -36,6 +37,7 @@ class seidel_method_mpi : public ppc::core::Task {
   bool post_processing() override;
 
  private:
+  int rank(std::vector<double> A_, int rows, int cols);
   boost::mpi::communicator world;
   double EPSILON;
   std::vector<double> A, local_A;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp
@@ -41,7 +41,7 @@ class seidel_method_mpi : public ppc::core::Task {
   const double EPSILON = 1e-6;
   std::vector<double> A, local_A;
   std::vector<double> b, local_b;
-  std::vector<double> result, local_result;
+  std::vector<double> x, prevX, local_x;
   int maxIterations, n;
 };
 }  // namespace khokhlov_a_iterative_seidel_method_mpi

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -5,8 +5,8 @@
 
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
   boost::mpi::communicator world;
-  const int n = 5000;
-  const int maxiter = 5000;
+  const int n = 1000;
+  const int maxiter = 1000;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -26,7 +26,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
   }
 
   // crate task
-  auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq>(taskdataMpi);
+  auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi>(taskdataMpi);
   ASSERT_EQ(testTaskMpi->validation(), true);
   testTaskMpi->pre_processing();
   testTaskMpi->run();
@@ -56,8 +56,8 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
 
 TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   boost::mpi::communicator world;
-  const int n = 5000;
-  const int maxiter = 5000;
+  const int n = 1000;
+  const int maxiter = 1000;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -77,7 +77,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   }
 
   // crate task
-  auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq>(taskdataMpi);
+  auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi>(taskdataMpi);
   ASSERT_EQ(testTaskMpi->validation(), true);
   testTaskMpi->pre_processing();
   testTaskMpi->run();

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -5,6 +5,22 @@
 #include "core/perf/include/perf.hpp"
 #include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
 
+void getRandomSLAU(std::vector<double> &A, std::vector<double> &b, int N) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  for (int i = 0; i < N; ++i) {
+    double rowSum = 0.0;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        A[i * N + j] = rand() % 10 - 5;
+        rowSum += std::abs(A[i * N + j]);
+      }
+    }
+    A[i * N + i] = rowSum + (rand() % 5 + 1);
+    b[i] = rand() % 20 - 10;
+  }
+}
+
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run) {
   boost::mpi::communicator world;
   const int n = 800;
@@ -15,7 +31,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run) {
   std::vector<double> A(n * n, 0.0);
   std::vector<double> b(n, 0.0);
   std::vector<double> result(n, 0.0);
-  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // create task data
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
@@ -63,7 +79,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_task_run) {
   std::vector<double> A(n * n, 0.0);
   std::vector<double> b(n, 0.0);
   std::vector<double> result(n, 0.0);
-  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // create task data
   std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -79,9 +79,13 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   // crate task
   auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq>(taskdataMpi);
   ASSERT_EQ(testTaskMpi->validation(), true);
+  std::cout << world.rank() << std::endl;
   testTaskMpi->pre_processing();
+  std::cout << world.rank() << std::endl;
   testTaskMpi->run();
+  std::cout << world.rank() << std::endl;
   testTaskMpi->post_processing();
+  std::cout << world.rank() << std::endl;
 
   // Create Perf attributes
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -1,13 +1,14 @@
 #include <gtest/gtest.h>
 
 #include "core/perf/include/perf.hpp"
+#include <boost/mpi/timer.hpp>
 #include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
 
-TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run) {
   boost::mpi::communicator world;
-  const int n = 1000;
-  const int maxiter = 1000;
-  const double eps = 1e-6;
+  const int n = 800;
+  const int maxiter = 800;
+  const double eps = 1e-3;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -37,12 +38,8 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
   // Create Perf attributes
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
-  const auto t0 = std::chrono::high_resolution_clock::now();
-  perfAttr->current_timer = [&] {
-    auto current_time_point = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
-    return static_cast<double>(duration) * 1e-9;
-  };
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
 
   // Create and init perf results
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
@@ -52,15 +49,14 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
   perfAnalyzer->pipeline_run(perfAttr, perfResults);
   if (world.rank() == 0) {
     ppc::core::Perf::print_perf_statistic(perfResults);
-    ASSERT_EQ(b.size(), result.size());
   }
 }
 
-TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_task_run) {
   boost::mpi::communicator world;
-  const int n = 1000;
-  const int maxiter = 1000;
-  const double eps = 1e-6;
+  const int n = 800;
+  const int maxiter = 800;
+  const double eps = 1e-3;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -90,12 +86,8 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   // Create Perf attributes
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
-  const auto t0 = std::chrono::high_resolution_clock::now();
-  perfAttr->current_timer = [&] {
-    auto current_time_point = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
-    return static_cast<double>(duration) * 1e-9;
-  };
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
 
   // Create and init perf results
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
@@ -105,6 +97,5 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   perfAnalyzer->task_run(perfAttr, perfResults);
   if (world.rank() == 0) {
     ppc::core::Perf::print_perf_statistic(perfResults);
-    ASSERT_EQ(b.size(), result.size());
   }
 }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "core/perf/include/perf.hpp"
 #include <boost/mpi/timer.hpp>
+
+#include "core/perf/include/perf.hpp"
 #include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
 
 TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run) {

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -7,6 +7,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
   boost::mpi::communicator world;
   const int n = 1000;
   const int maxiter = 1000;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -21,6 +22,7 @@ TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
     taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataMpi->inputs_count.emplace_back(n);
     taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   }
@@ -58,6 +60,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   boost::mpi::communicator world;
   const int n = 1000;
   const int maxiter = 1000;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -72,6 +75,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
     taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
     taskdataMpi->inputs_count.emplace_back(n);
     taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->inputs_count.emplace_back(eps);
     taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
     taskdataMpi->outputs_count.emplace_back(result.size());
   }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -79,13 +79,9 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
   // crate task
   auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq>(taskdataMpi);
   ASSERT_EQ(testTaskMpi->validation(), true);
-  std::cout << world.rank() << std::endl;
   testTaskMpi->pre_processing();
-  std::cout << world.rank() << std::endl;
   testTaskMpi->run();
-  std::cout << world.rank() << std::endl;
   testTaskMpi->post_processing();
-  std::cout << world.rank() << std::endl;
 
   // Create Perf attributes
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
+
+TEST(khokhlov_a_iterative_seidel_method_mpi, test_pipline_run_mpi) {
+  boost::mpi::communicator world;
+  const int n = 5000;
+  const int maxiter = 5000;
+
+  // create data
+  std::vector<double> A(n * n, 0.0);
+  std::vector<double> b(n, 0.0);
+  std::vector<double> result(n, 0.0);
+  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
+  }
+
+  // crate task
+  auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq>(taskdataMpi);
+  ASSERT_EQ(testTaskMpi->validation(), true);
+  testTaskMpi->pre_processing();
+  testTaskMpi->run();
+  testTaskMpi->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskMpi);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(b.size(), result.size());
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_mpi) {
+  boost::mpi::communicator world;
+  const int n = 5000;
+  const int maxiter = 5000;
+
+  // create data
+  std::vector<double> A(n * n, 0.0);
+  std::vector<double> b(n, 0.0);
+  std::vector<double> result(n, 0.0);
+  khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(A, b, n);
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataMpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+    taskdataMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+    taskdataMpi->inputs_count.emplace_back(n);
+    taskdataMpi->inputs_count.emplace_back(maxiter);
+    taskdataMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+    taskdataMpi->outputs_count.emplace_back(result.size());
+  }
+
+  // crate task
+  auto testTaskMpi = std::make_shared<khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq>(taskdataMpi);
+  ASSERT_EQ(testTaskMpi->validation(), true);
+  testTaskMpi->pre_processing();
+  testTaskMpi->run();
+  testTaskMpi->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskMpi);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(b.size(), result.size());
+  }
+}

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -158,6 +158,8 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
 
     // boost::mpi::all_gather(world, local_x.data(), local_n, x.data());
 
+    //boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
+
     double local_norm = 0.0;
     for (int i = 0; i < local_n; ++i) {
       int global_i = displs_b[world.rank()] + i;
@@ -165,10 +167,9 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     }
 
     double global_norm = 0.0;
-    boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
+    boost::mpi::reduce(world, local_norm, global_norm, std::plus<double>(), 0);
     global_norm = std::sqrt(global_norm);
 
-    //boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
     if (world.rank() == 0) {
       prevX = x;
     }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -107,9 +107,9 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   boost::mpi::broadcast(world, n, 0);
   boost::mpi::broadcast(world, maxIterations, 0);
   int delta = n / world.size();
-  int last_rows = n % world.size();
+  // int last_rows = n % world.size();
 
-  int local_n = (world.rank() == world.size() - 1) ? delta + last_rows : delta;
+  int local_n = delta; //(world.rank() == world.size() - 1) ? delta + last_rows : delta;
 
   local_A.resize(local_n * n);
   local_b.resize(local_n);
@@ -120,17 +120,18 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   std::vector<int> send_counts_b(world.size());
   std::vector<int> displs_A(world.size());
   std::vector<int> displs_b(world.size());
+  boost::mpi::scatter(world, A, local_A.data(), local_n, 0);
 
-  for (int i = 0; i < world.size(); ++i) {
-    send_counts_A[i] = (i == world.size() - 1) ? delta + last_rows : delta;
-    send_counts_A[i] *= n;
-    displs_A[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
-    send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
-    displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
-  }
+  //for (int i = 0; i < world.size(); ++i) {
+  //  send_counts_A[i] = (i == world.size() - 1) ? delta + last_rows : delta;
+  //  send_counts_A[i] *= n;
+  //  displs_A[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
+  //  send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
+  //  displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
+  //}
   // if (world.rank() == 0) {
-  boost::mpi::scatterv(world, A.data(), send_counts_A, /*displs_A,*/ local_A.data(), /*send_counts_A[world.rank()],*/ 0);
-  boost::mpi::scatterv(world, b.data(), send_counts_b, /*displs_b,*/ local_b.data(), /*send_counts_b[world.rank()],*/ 0);
+  // boost::mpi::scatterv(world, A.data(), send_counts_A, /*displs_A,*/ local_A.data(), /*send_counts_A[world.rank()],*/ 0);
+  // boost::mpi::scatterv(world, b.data(), send_counts_b, /*displs_b,*/ local_b.data(), /*send_counts_b[world.rank()],*/ 0); //seg foult
   //} else {
   //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
   //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -128,8 +128,8 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
   }
   // if (world.rank() == 0) {
-  boost::mpi::scatterv(world, A.data(), send_counts_A, displs_A, local_A.data(), send_counts_A[world.rank()], 0);
-  boost::mpi::scatterv(world, b.data(), send_counts_b, displs_b, local_b.data(), send_counts_b[world.rank()], 0);
+  boost::mpi::scatterv(world, A.data(), send_counts_A, /*displs_A,*/ local_A.data(), /*send_counts_A[world.rank()],*/ 0);
+  boost::mpi::scatterv(world, b.data(), send_counts_b, /*displs_b,*/ local_b.data(), /*send_counts_b[world.rank()],*/ 0);
   //} else {
   //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
   //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
@@ -167,11 +167,11 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     double global_norm = 0.0;
     boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
     global_norm = std::sqrt(global_norm);
-    if (world.rank() == 0) {
-      boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, displs_b, 0);
-    } else {
-      boost::mpi::gatherv(world, local_x.data(), local_n, 0);
-    }
+    //if (world.rank() == 0) {
+      boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
+    //} else {
+    //  boost::mpi::gatherv(world, local_x.data(), local_n, 0);
+    //}
     if (global_norm < EPSILON) {
       break;
     }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -29,6 +29,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::pre_processing()
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
   internal_order_test();
   int N = taskData->inputs_count[0];
+  if (N == 0) return false;
   std::vector<double> A_ = std::vector<double>(N * N);
   auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + N * N, A_.begin());
@@ -116,6 +117,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
   internal_order_test();
   if (world.rank() == 0) {
     int N = taskData->inputs_count[0];
+    if (N == 0) return false;
     std::vector<double> A_ = std::vector<double>(N * N);
     auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
     std::copy(tmp, tmp + N * N, A_.begin());

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -155,24 +155,24 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
 
   boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, 0);
 
-  //  double local_norm = 0.0;
-  //  for (int i = 0; i < local_n; ++i) {
-  //    int global_i = displs_b[world.rank()] + i;
-  //    local_norm += std::pow(x[global_i] - prevX[global_i], 2);
-  //  }
+   double local_norm = 0.0;
+   for (int i = 0; i < local_n; ++i) {
+     int global_i = displs_b[world.rank()] + i;
+     local_norm += std::pow(x[global_i] - prevX[global_i], 2);
+   }
 
-  //  double global_norm = 0.0;
-  //  boost::mpi::reduce(world, local_norm, global_norm, std::plus<double>(), 0);
-  //  global_norm = std::sqrt(global_norm);
+   double global_norm = 0.0;
+   boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
+   global_norm = std::sqrt(global_norm);
 
    if (world.rank() == 0) {
      prevX = x;
    }
    boost::mpi::broadcast(world, prevX.data(), n, 0);
 
-  //  if (global_norm < EPSILON) {
-  //    break;
-  //  }
+   if (global_norm < EPSILON) {
+     break;
+   }
   }
   if (world.rank() == 0){
     result = x;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -29,7 +29,9 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::pre_processing()
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
   internal_order_test();
   int N = taskData->inputs_count[0];
-  if (N == 0) return false;
+  int iter = taskData->inputs_count[1];
+  if (N < 1) return false;
+  if (iter < 1) return false;
   std::vector<double> A_ = std::vector<double>(N * N);
   auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + N * N, A_.begin());
@@ -46,8 +48,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
     }
   int rankA = rank(A_, N, N);
   int rankAb = rank(A_, N, N + 1);
-  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 &&
-          rankA == rankAb);
+  return (taskData->inputs_count[3] >= 0 && rankA == rankAb);
 }
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::run() {
@@ -117,7 +118,9 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
   internal_order_test();
   if (world.rank() == 0) {
     int N = taskData->inputs_count[0];
-    if (N == 0) return false;
+    int iter = taskData->inputs_count[1];
+    if (N < 1) return false;
+    if (iter < 1) return false;
     std::vector<double> A_ = std::vector<double>(N * N);
     auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
     std::copy(tmp, tmp + N * N, A_.begin());
@@ -134,8 +137,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
       }
     int rankA = rank(A_, N, N);
     int rankAb = rank(A_, N, N + 1);
-    return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 &&
-            rankA == rankAb);
+    return (taskData->inputs_count[3] >= 0 && rankA == rankAb);
   }
   return true;
 }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -114,7 +114,6 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   int last_rows = n % world.size();
 
   int local_n = (world.rank() == world.size() - 1) ? delta + last_rows : delta;
-  std::cout << world.rank() << std::endl;
 
   local_A.resize(local_n * n);
   local_b.resize(local_n);
@@ -169,8 +168,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
     global_norm = std::sqrt(global_norm);
 
-    boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
-
+    //boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
     if (world.rank() == 0) {
       prevX = x;
     }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -120,15 +120,15 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   std::vector<int> displs_b(world.size());
 
   for (int i = 0; i < world.size(); ++i) {
-    send_counts_A[i] = local_n;
+    send_counts_A[i] = (i == world.size() - 1) ? delta + last_rows : delta;
     send_counts_A[i] *= n;
     displs_A[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
-    send_counts_b[i] = local_n;
+    send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
     displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
   }
   //if (world.rank() == 0) {
-    boost::mpi::scatterv(world, A.data(), send_counts_A, displs_A, local_A.data(), send_counts_A[world.rank()], 0);
-    boost::mpi::scatterv(world, b.data(), send_counts_b, displs_b, local_b.data(), send_counts_b[world.rank()], 0);
+  boost::mpi::scatterv(world, A.data(), send_counts_A, displs_A, local_A.data(), send_counts_A[world.rank()], 0);
+  boost::mpi::scatterv(world, b.data(), send_counts_b, displs_b, local_b.data(), send_counts_b[world.rank()], 0);
   //} else {
   //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
   //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -128,8 +128,8 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
   }
   // if (world.rank() == 0) {
-  boost::mpi::scatterv(world, A.data(), send_counts_A, local_A.data(), 0);
-  boost::mpi::scatterv(world, b.data(), send_counts_b, local_b.data(), 0);
+  boost::mpi::scatterv(world, A.data(), send_counts_A, displs_A, local_A.data(), send_counts_A[world.rank()], 0);
+  boost::mpi::scatterv(world, b.data(), send_counts_b, displs_b, local_b.data(), send_counts_b[world.rank()], 0);
   //} else {
   //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
   //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
@@ -168,7 +168,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
     global_norm = std::sqrt(global_norm);
     if (world.rank() == 0) {
-      boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, 0);
+      boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, displs_b, 0);
     } else {
       boost::mpi::gatherv(world, local_x.data(), local_n, 0);
     }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -104,23 +104,23 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   internal_order_test();
-  boost::mpi::broadcast(world, n, 0);
-  boost::mpi::broadcast(world, maxIterations, 0);
-  int delta = n / world.size();
+  // boost::mpi::broadcast(world, n, 0);
+  // boost::mpi::broadcast(world, maxIterations, 0);
+  // int delta = n / world.size();
   // int last_rows = n % world.size();
 
-  int local_n = delta; //(world.rank() == world.size() - 1) ? delta + last_rows : delta;
+  // int local_n = (world.rank() == world.size() - 1) ? delta + last_rows : delta;
 
-  local_A.resize(local_n * n);
-  local_b.resize(local_n);
-  local_x.resize(local_n);
-  prevX.resize(n, 0.0);
+  // local_A.resize(local_n * n);
+  // local_b.resize(local_n);
+  // local_x.resize(local_n);
+  // prevX.resize(n, 0.0);
 
-  std::vector<int> send_counts_A(world.size());
-  std::vector<int> send_counts_b(world.size());
-  std::vector<int> displs_A(world.size());
-  std::vector<int> displs_b(world.size());
-  boost::mpi::scatter(world, A, local_A.data(), local_n, 0);
+  // std::vector<int> send_counts_A(world.size());
+  // std::vector<int> send_counts_b(world.size());
+  // std::vector<int> displs_A(world.size());
+  // std::vector<int> displs_b(world.size());
+  // boost::mpi::scatter(world, A, local_A.data(), local_n*n, 0);
 
   //for (int i = 0; i < world.size(); ++i) {
   //  send_counts_A[i] = (i == world.size() - 1) ? delta + last_rows : delta;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -123,15 +123,15 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     send_counts_A[i] *= n;
     displs_A[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
     send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
-    displs_b[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
+    displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
   }
-  if (world.rank() == 0) {
+  //if (world.rank() == 0) {
     boost::mpi::scatterv(world, A.data(), send_counts_A, displs_A, local_A.data(), send_counts_A[world.rank()], 0);
     boost::mpi::scatterv(world, b.data(), send_counts_b, displs_b, local_b.data(), send_counts_b[world.rank()] / n, 0);
-  } else {
-    boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
-    boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
-  }
+  //} else {
+  //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
+  //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
+  //}
 
   std::vector<double> x(n, 0.0);
   std::vector<double> prevX(n, 0.0);

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -71,10 +71,6 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::post_processing(
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::pre_processing() {
   internal_order_test();
-  std::cerr << world.rank() << std::endl;
-  std::ofstream qwe("C:\\Users\\Andre\\ppc\\123.txt");
-  qwe << "pizda";
-  qwe.close();
   if (world.rank() == 0) {
     // init matrix
     A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
@@ -132,7 +128,6 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
     displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
   }
-  std::cerr << world.rank();
   // if (world.rank() == 0) {
   boost::mpi::scatterv(world, A.data(), send_counts_A, /*displs_A,*/ local_A.data(), /*send_counts_A[world.rank()],*/ 0);
   boost::mpi::scatterv(world, b.data(), send_counts_b, /*displs_b,*/ local_b.data(), /*send_counts_b[world.rank()],*/ 0);
@@ -140,45 +135,45 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
   //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
   //}
-  for (int iter = 0; iter < maxIterations; ++iter) {
-    for (int i = 0; i < local_n; ++i) {
-      double sum = 0;
-      int global_i = displs_b[world.rank()] + i;
-      for (int j = 0; j < n; ++j) {
-        if (j != global_i) {
-          sum += local_A[i * n + j] * x[j];
-        }
-      }
-      if (local_A[i * n + i] != 0) {
-        local_x[i] = (local_b[i] - sum) / local_A[i * n + global_i];  
-      } else {
-        local_x[i] = 0;
-      }
-    }
+  //for (int iter = 0; iter < maxIterations; ++iter) {
+  //  for (int i = 0; i < local_n; ++i) {
+  //    double sum = 0;
+  //    int global_i = displs_b[world.rank()] + i;
+  //    for (int j = 0; j < n; ++j) {
+  //      if (j != global_i) {
+  //        sum += local_A[i * n + j] * x[j];
+  //      }
+  //    }
+  //    if (local_A[i * n + i] != 0) {
+  //      local_x[i] = (local_b[i] - sum) / local_A[i * n + global_i];  
+  //    } else {
+  //      local_x[i] = 0;
+  //    }
+  //  }
 
-    // boost::mpi::all_gather(world, local_x.data(), local_n, x.data());
+  //  // boost::mpi::all_gather(world, local_x.data(), local_n, x.data());
 
-    //boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
+  //  //  boost::mpi::gatherv(world, local_x.data(), local_n, x.data(), send_counts_b, /*displs_b,*/ 0);
 
-    double local_norm = 0.0;
-    for (int i = 0; i < local_n; ++i) {
-      int global_i = displs_b[world.rank()] + i;
-      local_norm += std::pow(x[global_i] - prevX[global_i], 2);
-    }
+  //  double local_norm = 0.0;
+  //  for (int i = 0; i < local_n; ++i) {
+  //    int global_i = displs_b[world.rank()] + i;
+  //    local_norm += std::pow(x[global_i] - prevX[global_i], 2);
+  //  }
 
-    double global_norm = 0.0;
-    boost::mpi::reduce(world, local_norm, global_norm, std::plus<double>(), 0);
-    global_norm = std::sqrt(global_norm);
+  //  double global_norm = 0.0;
+  //  boost::mpi::reduce(world, local_norm, global_norm, std::plus<double>(), 0);
+  //  global_norm = std::sqrt(global_norm);
 
-    if (world.rank() == 0) {
-      prevX = x;
-    }
-    boost::mpi::broadcast(world, prevX.data(), n, 0);
+  //  if (world.rank() == 0) {
+  //    prevX = x;
+  //  }
+  //  boost::mpi::broadcast(world, prevX.data(), n, 0);
 
-    if (global_norm < EPSILON) {
-      break;
-    }
-  }
+  //  if (global_norm < EPSILON) {
+  //    break;
+  //  }
+  //}
   return true;
 }
 

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -1,0 +1,203 @@
+#include "mpi/khokhlov_a_iterative_seidel_method/include/ops_mpi_khokhlov.hpp"
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::pre_processing() {
+  internal_order_test();
+  // init matrix
+  A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
+  auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+  std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
+
+  // init vector
+  b = std::vector<double>(taskData->inputs_count[0]);
+  auto tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
+  std::copy(tmp1, tmp1 + taskData->inputs_count[0], b.begin());
+
+  // init world.size()s
+  n = taskData->inputs_count[0];
+
+  // init maxIterations
+  maxIterations = taskData->inputs_count[1];
+
+  // Init value for output
+  result = std::vector<double>(taskData->inputs_count[0], 0);
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
+  internal_order_test();
+  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0);
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::run() {
+  internal_order_test();
+  std::vector<double> x(n, 1.0);
+  std::vector<double> prevX(n, 1.0);
+
+  for (int iter = 0; iter < maxIterations; ++iter) {
+    for (int i = 0; i < n; ++i) {
+      double sum = 0;
+      for (int j = 0; j < n; ++j) {
+        if (j != i) {
+          sum += (A[i * n + j] * x[j]);
+        }
+      }
+      if (A[i * n + i] != 0) {
+        x[i] = (b[i] - sum) / A[i * n + i];
+      } else {
+        x[i] = 0.0;
+      }
+    }
+    double norm = 0.0;
+    for (int i = 0; i < n; ++i) {
+      norm += std::pow(x[i] - prevX[i], 2);
+    }
+    norm = std::sqrt(norm);
+
+    if (norm < EPSILON) {
+      break;
+    }
+    prevX = x;
+  }
+  result = x;
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::post_processing() {
+  internal_order_test();
+  for (int i = 0; i < n; i++) reinterpret_cast<double*>(taskData->outputs[0])[i] = result[i];
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    // init matrix
+    A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
+    auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+    std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
+
+    // init vector
+    b = std::vector<double>(taskData->inputs_count[0]);
+    auto tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
+    std::copy(tmp1, tmp1 + taskData->inputs_count[0], b.begin());
+
+    // init world.size()s
+    n = taskData->inputs_count[0];
+
+    // init maxIterations
+    maxIterations = taskData->inputs_count[1];
+
+    // Init value for output
+    result = std::vector<double>(taskData->inputs_count[0], 0);
+  }
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0);
+  }
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
+  internal_order_test();
+
+  int delta = n / world.size();
+  int last_rows = n % world.size();
+
+  int local_n = (world.rank() == world.size() - 1) ? delta + last_rows : delta;
+
+  local_A.resize(local_n * n);
+  local_b.resize(local_n);
+  local_result.resize(local_n, 0.0);
+
+  std::vector<int> send_counts_A(world.size());
+  std::vector<int> send_counts_b(world.size());
+  std::vector<int> displs_A(world.size());
+  std::vector<int> displs_b(world.size());
+
+  for (int i = 0; i < world.size(); ++i) {
+    send_counts_A[i] = (i == world.size() - 1) ? delta + last_rows : delta;
+    send_counts_A[i] *= n;
+    displs_A[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
+    send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
+    displs_b[i] = (i > 0) ? displs_A[i - 1] + send_counts_A[i - 1] : 0;
+  }
+  if (world.rank() == 0) {
+    boost::mpi::scatterv(world, A.data(), send_counts_A, displs_A, local_A.data(), send_counts_A[world.rank()], 0);
+    boost::mpi::scatterv(world, b.data(), send_counts_b, displs_b, local_b.data(), send_counts_b[world.rank()] / n, 0);
+  } else {
+    boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
+    boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
+  }
+
+  std::vector<double> x(n, 0.0);
+  std::vector<double> prevX(n, 0.0);
+
+  for (int iter = 0; iter < maxIterations; ++iter) {
+    for (int i = 0; i < local_n; ++i) {
+      double sum = 0;
+      int global_i = displs_b[world.rank()] + i;
+      for (int j = 0; j < n; ++j) {
+        if (j != global_i) {
+          sum += local_A[i * n + j] * x[j];
+        }
+      }
+      if (local_A[i * n + i] != 0) {
+        local_result[i] = (local_b[i] - sum) / local_A[i * n + global_i];
+      } else {
+        local_result[i] = 0;
+      }
+    }
+
+    boost::mpi::all_gather(world, local_result.data(), local_n, x.data());
+
+    if (world.rank() == 0) {
+      prevX = x;
+    }
+    boost::mpi::broadcast(world, prevX.data(), n, 0);
+
+    double local_norm = 0.0;
+    for (int i = 0; i < local_n; ++i) {
+      int global_i = displs_b[world.rank()] + i;
+      local_norm += std::pow(x[global_i] - prevX[global_i], 2);
+    }
+
+    double global_norm = 0.0;
+    boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
+    global_norm = std::sqrt(global_norm);
+    if (world.rank() == 0) {
+      boost::mpi::gatherv(world, local_result.data(), local_n, result.data(), send_counts_b, displs_b, 0);
+    }
+    if (global_norm < EPSILON) {
+      break;
+    }
+  }
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    for (int i = 0; i < n; i++) reinterpret_cast<double*>(taskData->outputs[0])[i] = result[i];
+  }
+  return true;
+}
+
+void khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  for (int i = 0; i < N; ++i) {
+    double rowSum = 0.0;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        A[i * N + j] = rand() % 10 - 5;
+        rowSum += std::abs(A[i * N + j]);
+      }
+    }
+    A[i * N + i] = rowSum + (rand() % 5 + 1);
+    b[i] = rand() % 20 - 10;
+  }
+}

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -161,7 +161,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     }
 
     double global_norm = 0.0;
-    boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<double>());
+    boost::mpi::all_reduce(world, local_norm, global_norm, std::plus<>());
     global_norm = std::sqrt(global_norm);
 
     if (world.rank() == 0) {

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -14,12 +14,12 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::pre_processing()
   // init matrix
 
   A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
-  auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+  auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
 
   // init vector
   b = std::vector<double>(taskData->inputs_count[0]);
-  auto tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
+  auto* tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
   std::copy(tmp1, tmp1 + taskData->inputs_count[0], b.begin());
 
   // init world.size()s
@@ -83,12 +83,12 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::pre_processing()
   if (world.rank() == 0) {
     // init matrix
     A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
-    auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+    auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
     std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
 
     // init vector
     b = std::vector<double>(taskData->inputs_count[0]);
-    auto tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
+    auto* tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
     std::copy(tmp1, tmp1 + taskData->inputs_count[0], b.begin());
 
     // init world.size()s

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -40,12 +40,13 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
   }
   std::vector<double> Ab = std::vector<double>(N * (N + 1));
   for (int i = 0; i < N; i++)
-    for (int j = 0; j < N + 1; j++){
+    for (int j = 0; j < N + 1; j++) {
       Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
     }
   int rankA = rank(A_, N, N);
   int rankAb = rank(A_, N, N + 1);
-  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 && rankA == rankAb);
+  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 &&
+          rankA == rankAb);
 }
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::run() {
@@ -126,12 +127,13 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
     }
     std::vector<double> Ab = std::vector<double>(N * (N + 1));
     for (int i = 0; i < N; i++)
-      for (int j = 0; j < N + 1; j++){
+      for (int j = 0; j < N + 1; j++) {
         Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
       }
     int rankA = rank(A_, N, N);
     int rankAb = rank(A_, N, N + 1);
-    return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 && rankA == rankAb);
+    return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 &&
+            rankA == rankAb);
   }
   return true;
 }
@@ -229,50 +231,50 @@ void khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(std::vector<double>& 
   }
 }
 
-int khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::rank(std::vector<double> A_, int rows, int cols){
+int khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::rank(std::vector<double> A_, int rows, int cols) {
   int rank = 0;
-    for (int i = 0; i < std::min(rows, cols); ++i) {
-      int maxRow = i;
-        for (int k = i + 1; k < rows; ++k) {
-          if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows +i])) {
-            maxRow = k;
-          }
-        }
-        if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
-          continue;
-        }
-        std::swap(A_[i], A_[maxRow]);
-        for (int j = i + 1; j < rows; ++j) {
-          double factor = A_[j * rows + i] / A_[i * rows + i];
-          for (int k = i; k < cols; ++k) {
-            A_[j * rows + k] -= factor * A_[i * rows + k];
-          }
-        }
-      rank++;
+  for (int i = 0; i < std::min(rows, cols); ++i) {
+    int maxRow = i;
+    for (int k = i + 1; k < rows; ++k) {
+      if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows + i])) {
+        maxRow = k;
+      }
     }
+    if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
+      continue;
+    }
+    std::swap(A_[i], A_[maxRow]);
+    for (int j = i + 1; j < rows; ++j) {
+      double factor = A_[j * rows + i] / A_[i * rows + i];
+      for (int k = i; k < cols; ++k) {
+        A_[j * rows + k] -= factor * A_[i * rows + k];
+      }
+    }
+    rank++;
+  }
   return rank;
 }
 
-int khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::rank(std::vector<double> A_, int rows, int cols){
+int khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::rank(std::vector<double> A_, int rows, int cols) {
   int rank = 0;
-    for (int i = 0; i < std::min(rows, cols); ++i) {
-      int maxRow = i;
-        for (int k = i + 1; k < rows; ++k) {
-          if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows +i])) {
-            maxRow = k;
-          }
-        }
-        if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
-          continue;
-        }
-        std::swap(A_[i], A_[maxRow]);
-        for (int j = i + 1; j < rows; ++j) {
-          double factor = A_[j * rows + i] / A_[i * rows + i];
-          for (int k = i; k < cols; ++k) {
-            A_[j * rows + k] -= factor * A_[i * rows + k];
-          }
-        }
-      rank++;
+  for (int i = 0; i < std::min(rows, cols); ++i) {
+    int maxRow = i;
+    for (int k = i + 1; k < rows; ++k) {
+      if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows + i])) {
+        maxRow = k;
+      }
     }
+    if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
+      continue;
+    }
+    std::swap(A_[i], A_[maxRow]);
+    for (int j = i + 1; j < rows; ++j) {
+      double factor = A_[j * rows + i] / A_[i * rows + i];
+      for (int k = i; k < cols; ++k) {
+        A_[j * rows + k] -= factor * A_[i * rows + k];
+      }
+    }
+    rank++;
+  }
   return rank;
 }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -47,7 +47,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
       Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
     }
   int rankA = rank(A_, N, N);
-  int rankAb = rank(A_, N, N + 1);
+  int rankAb = rank(Ab, N, N + 1);
   return (taskData->inputs_count[3] >= 0 && rankA == rankAb);
 }
 
@@ -136,7 +136,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
         Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
       }
     int rankA = rank(A_, N, N);
-    int rankAb = rank(A_, N, N + 1);
+    int rankAb = rank(Ab, N, N + 1);
     return (taskData->inputs_count[3] >= 0 && rankA == rankAb);
   }
   return true;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -170,6 +170,8 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     global_norm = std::sqrt(global_norm);
     if (world.rank() == 0) {
       boost::mpi::gatherv(world, local_result.data(), local_n, result.data(), send_counts_b, displs_b, 0);
+    } else {
+      boost::mpi::gatherv(world, local_result.data(), local_n, 0);
     }
     if (global_norm < EPSILON) {
       break;

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -219,22 +219,6 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::post_processing(
   return true;
 }
 
-void khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N) {
-  std::random_device dev;
-  std::mt19937 gen(dev());
-  for (int i = 0; i < N; ++i) {
-    double rowSum = 0.0;
-    for (int j = 0; j < N; ++j) {
-      if (i != j) {
-        A[i * N + j] = rand() % 10 - 5;
-        rowSum += std::abs(A[i * N + j]);
-      }
-    }
-    A[i * N + i] = rowSum + (rand() % 5 + 1);
-    b[i] = rand() % 20 - 10;
-  }
-}
-
 int khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::rank(std::vector<double> A_, int rows, int cols) {
   int rank = 0;
   for (int i = 0; i < std::min(rows, cols); ++i) {

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -3,6 +3,7 @@
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::pre_processing() {
   internal_order_test();
   // init matrix
+
   A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
   auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
@@ -70,6 +71,10 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::post_processing(
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::pre_processing() {
   internal_order_test();
+  std::cerr << world.rank() << std::endl;
+  std::ofstream qwe("C:\\Users\\Andre\\ppc\\123.txt");
+  qwe << "pizda";
+  qwe.close();
   if (world.rank() == 0) {
     // init matrix
     A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
@@ -109,6 +114,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   int last_rows = n % world.size();
 
   int local_n = (world.rank() == world.size() - 1) ? delta + last_rows : delta;
+  std::cout << world.rank() << std::endl;
 
   local_A.resize(local_n * n);
   local_b.resize(local_n);
@@ -127,6 +133,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
     send_counts_b[i] = (i == world.size() - 1) ? delta + last_rows : delta;
     displs_b[i] = (i > 0) ? displs_b[i - 1] + send_counts_b[i - 1] : 0;
   }
+  std::cerr << world.rank();
   // if (world.rank() == 0) {
   boost::mpi::scatterv(world, A.data(), send_counts_A, /*displs_A,*/ local_A.data(), /*send_counts_A[world.rank()],*/ 0);
   boost::mpi::scatterv(world, b.data(), send_counts_b, /*displs_b,*/ local_b.data(), /*send_counts_b[world.rank()],*/ 0);
@@ -134,7 +141,6 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
   //  boost::mpi::scatterv(world, local_A.data(), send_counts_A[world.rank()], 0);
   //  boost::mpi::scatterv(world, local_b.data(), send_counts_b[world.rank()] / n, 0);
   //}
-
   for (int iter = 0; iter < maxIterations; ++iter) {
     for (int i = 0; i < local_n; ++i) {
       double sum = 0;
@@ -145,7 +151,7 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::run() {
         }
       }
       if (local_A[i * n + i] != 0) {
-        local_x[i] = (local_b[i] - sum) / local_A[i * n + global_i];
+        local_x[i] = (local_b[i] - sum) / local_A[i * n + global_i];  
       } else {
         local_x[i] = 0;
       }

--- a/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
+++ b/tasks/mpi/khokhlov_a_iterative_seidel_method/src/ops_mpi_khokhlov.cpp
@@ -28,13 +28,24 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::pre_processing()
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::validation() {
   internal_order_test();
-  std::vector<double> A_ = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
+  int N = taskData->inputs_count[0];
+  std::vector<double> A_ = std::vector<double>(N * N);
   auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
-  std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A_.begin());
-  for (unsigned int i = 0; i < taskData->inputs_count[0]; i++) {
-    if (A_[i * taskData->inputs_count[0] + i] == 0) return false;
+  std::copy(tmp, tmp + N * N, A_.begin());
+  std::vector<double> b_ = std::vector<double>(N);
+  tmp = reinterpret_cast<double*>(taskData->inputs[1]);
+  std::copy(tmp, tmp + N, b_.begin());
+  for (int i = 0; i < N; i++) {
+    if (A_[i * N + i] == 0) return false;
   }
-  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0);
+  std::vector<double> Ab = std::vector<double>(N * (N + 1));
+  for (int i = 0; i < N; i++)
+    for (int j = 0; j < N + 1; j++){
+      Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
+    }
+  int rankA = rank(A_, N, N);
+  int rankAb = rank(A_, N, N + 1);
+  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 && rankA == rankAb);
 }
 
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::run() {
@@ -103,13 +114,24 @@ bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::pre_processing()
 bool khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::validation() {
   internal_order_test();
   if (world.rank() == 0) {
-    std::vector<double> A_ = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
+    int N = taskData->inputs_count[0];
+    std::vector<double> A_ = std::vector<double>(N * N);
     auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
-    std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A_.begin());
-    for (unsigned int i = 0; i < taskData->inputs_count[0]; i++) {
-      if (A_[i * taskData->inputs_count[0] + i] == 0) return false;
+    std::copy(tmp, tmp + N * N, A_.begin());
+    std::vector<double> b_ = std::vector<double>(N);
+    tmp = reinterpret_cast<double*>(taskData->inputs[1]);
+    std::copy(tmp, tmp + N, b_.begin());
+    for (int i = 0; i < N; i++) {
+      if (A_[i * N + i] == 0) return false;
     }
-    return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0);
+    std::vector<double> Ab = std::vector<double>(N * (N + 1));
+    for (int i = 0; i < N; i++)
+      for (int j = 0; j < N + 1; j++){
+        Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
+      }
+    int rankA = rank(A_, N, N);
+    int rankAb = rank(A_, N, N + 1);
+    return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 && rankA == rankAb);
   }
   return true;
 }
@@ -205,4 +227,52 @@ void khokhlov_a_iterative_seidel_method_mpi::getRandomSLAU(std::vector<double>& 
     A[i * N + i] = rowSum + (rand() % 5 + 1);
     b[i] = rand() % 20 - 10;
   }
+}
+
+int khokhlov_a_iterative_seidel_method_mpi::seidel_method_mpi::rank(std::vector<double> A_, int rows, int cols){
+  int rank = 0;
+    for (int i = 0; i < std::min(rows, cols); ++i) {
+      int maxRow = i;
+        for (int k = i + 1; k < rows; ++k) {
+          if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows +i])) {
+            maxRow = k;
+          }
+        }
+        if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
+          continue;
+        }
+        std::swap(A_[i], A_[maxRow]);
+        for (int j = i + 1; j < rows; ++j) {
+          double factor = A_[j * rows + i] / A_[i * rows + i];
+          for (int k = i; k < cols; ++k) {
+            A_[j * rows + k] -= factor * A_[i * rows + k];
+          }
+        }
+      rank++;
+    }
+  return rank;
+}
+
+int khokhlov_a_iterative_seidel_method_mpi::seidel_method_seq::rank(std::vector<double> A_, int rows, int cols){
+  int rank = 0;
+    for (int i = 0; i < std::min(rows, cols); ++i) {
+      int maxRow = i;
+        for (int k = i + 1; k < rows; ++k) {
+          if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows +i])) {
+            maxRow = k;
+          }
+        }
+        if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
+          continue;
+        }
+        std::swap(A_[i], A_[maxRow]);
+        for (int j = i + 1; j < rows; ++j) {
+          double factor = A_[j * rows + i] / A_[i * rows + i];
+          for (int k = i; k < cols; ++k) {
+            A_[j * rows + k] -= factor * A_[i * rows + k];
+          }
+        }
+      rank++;
+    }
+  return rank;
 }

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -5,6 +5,7 @@
 TEST(khokhlov_a_iterative_seidel_method_seq, test_empty_matrix) {
   const int n = 0;
   const int maxiter = 0;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A = {};
@@ -18,6 +19,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_empty_matrix) {
   taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
   taskdataSeq->inputs_count.emplace_back(n);
   taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->inputs_count.emplace_back(eps);
   taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   taskdataSeq->outputs_count.emplace_back(result.size());
 
@@ -29,6 +31,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_empty_matrix) {
 TEST(khokhlov_a_iterative_seidel_method_seq, test_matrix_with_invalid_iter) {
   const int n = 3;
   const int maxiter = 0;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -42,6 +45,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_matrix_with_invalid_iter) {
   taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
   taskdataSeq->inputs_count.emplace_back(n);
   taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->inputs_count.emplace_back(eps);
   taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   taskdataSeq->outputs_count.emplace_back(result.size());
 
@@ -50,40 +54,10 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_matrix_with_invalid_iter) {
   ASSERT_FALSE(seidel_method_seq.validation());
 }
 
-TEST(khokhlov_a_iterative_seidel_method_seq, test_3x3_zero_matrix_with_1000_iter) {
-  const int n = 3;
-  const int maxiter = 1000;
-
-  // create data
-  std::vector<double> A = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  std::vector<double> b = {5.0, 7.0, 8.0};
-  std::vector<double> expect = {0.0, 0.0, 0.0};
-  std::vector<double> result(n, 0.0);
-
-  // create task data
-  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
-  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
-  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
-  taskdataSeq->inputs_count.emplace_back(n);
-  taskdataSeq->inputs_count.emplace_back(maxiter);
-  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskdataSeq->outputs_count.emplace_back(result.size());
-
-  // crate task
-  khokhlov_a_iterative_seidel_method_seq::seidel_method_seq seidel_method_seq(taskdataSeq);
-  ASSERT_TRUE(seidel_method_seq.validation());
-  seidel_method_seq.pre_processing();
-  seidel_method_seq.run();
-  seidel_method_seq.post_processing();
-
-  for (int i = 0; i < n; i++) {
-    ASSERT_NEAR(expect[i], result[i], 1e-1);
-  }
-}
-
 TEST(khokhlov_a_iterative_seidel_method_seq, test_3x3_matrix_with_1000_iter) {
   const int n = 3;
   const int maxiter = 1000;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A = {4.0, -1.0, 1.0, 2.0, 5.0, 2.0, 1.0, -1.0, 6.0};
@@ -97,6 +71,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_3x3_matrix_with_1000_iter) {
   taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
   taskdataSeq->inputs_count.emplace_back(n);
   taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->inputs_count.emplace_back(eps);
   taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   taskdataSeq->outputs_count.emplace_back(result.size());
 

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_empty_matrix) {
+  const int n = 0;
+  const int maxiter = 0;
+
+  // create data
+  std::vector<double> A = {};
+  std::vector<double> b = {};
+  std::vector<double> expect = {};
+  std::vector<double> result;
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+  taskdataSeq->inputs_count.emplace_back(n);
+  taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskdataSeq->outputs_count.emplace_back(result.size());
+
+  // crate task
+  khokhlov_a_iterative_seidel_method_seq::seidel_method_seq seidel_method_seq(taskdataSeq);
+  ASSERT_FALSE(seidel_method_seq.validation());
+}
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_matrix_with_invalid_iter) {
+  const int n = 3;
+  const int maxiter = 0;
+
+  // create data
+  std::vector<double> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<double> b = {1, 2, 3};
+  std::vector<double> expect = {};
+  std::vector<double> result;
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+  taskdataSeq->inputs_count.emplace_back(n);
+  taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskdataSeq->outputs_count.emplace_back(result.size());
+
+  // crate task
+  khokhlov_a_iterative_seidel_method_seq::seidel_method_seq seidel_method_seq(taskdataSeq);
+  ASSERT_FALSE(seidel_method_seq.validation());
+}
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_3x3_zero_matrix_with_1000_iter) {
+  const int n = 3;
+  const int maxiter = 1000;
+
+  // create data
+  std::vector<double> A = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  std::vector<double> b = {5.0, 7.0, 8.0};
+  std::vector<double> expect = {0.0, 0.0, 0.0};
+  std::vector<double> result(n, 0.0);
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+  taskdataSeq->inputs_count.emplace_back(n);
+  taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskdataSeq->outputs_count.emplace_back(result.size());
+
+  // crate task
+  khokhlov_a_iterative_seidel_method_seq::seidel_method_seq seidel_method_seq(taskdataSeq);
+  ASSERT_TRUE(seidel_method_seq.validation());
+  seidel_method_seq.pre_processing();
+  seidel_method_seq.run();
+  seidel_method_seq.post_processing();
+
+  for (int i = 0; i < n; i++) {
+    ASSERT_NEAR(expect[i], result[i], 1e-1);
+  }
+}
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_3x3_matrix_with_1000_iter) {
+  const int n = 3;
+  const int maxiter = 1000;
+
+  // create data
+  std::vector<double> A = {4.0, -1.0, 1.0, 2.0, 5.0, 2.0, 1.0, -1.0, 6.0};
+  std::vector<double> b = {5.0, 7.0, 8.0};
+  std::vector<double> expect = {1.0, 0.5, 1.25};
+  std::vector<double> result(n, 0.0);
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+  taskdataSeq->inputs_count.emplace_back(n);
+  taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskdataSeq->outputs_count.emplace_back(result.size());
+
+  // crate task
+  khokhlov_a_iterative_seidel_method_seq::seidel_method_seq seidel_method_seq(taskdataSeq);
+  ASSERT_TRUE(seidel_method_seq.validation());
+  seidel_method_seq.pre_processing();
+  seidel_method_seq.run();
+  seidel_method_seq.post_processing();
+
+  for (int i = 0; i < n; i++) {
+    ASSERT_NEAR(expect[i], result[i], 1e-1);
+  }
+}

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/func_tests/main_khokhlov.cpp
@@ -2,6 +2,22 @@
 
 #include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
 
+void getRandomSLAU(std::vector<double> &A, std::vector<double> &b, int N) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  for (int i = 0; i < N; ++i) {
+    double rowSum = 0.0;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        A[i * N + j] = rand() % 10 - 5;
+        rowSum += std::abs(A[i * N + j]);
+      }
+    }
+    A[i * N + i] = rowSum + (rand() % 5 + 1);
+    b[i] = rand() % 20 - 10;
+  }
+}
+
 TEST(khokhlov_a_iterative_seidel_method_seq, test_empty_matrix) {
   const int n = 0;
   const int maxiter = 0;

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cmath>
-#include <iomanip>
 #include <random>
 #include <vector>
 
@@ -20,7 +19,7 @@ class seidel_method_seq : public ppc::core::Task {
   bool post_processing() override;
 
  private:
-  const double EPSILON = 1e-6;
+  double EPSILON;
   std::vector<double> A;
   std::vector<double> b;
   std::vector<double> result;

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
@@ -8,8 +8,6 @@
 
 namespace khokhlov_a_iterative_seidel_method_seq {
 
-void getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N);
-
 class seidel_method_seq : public ppc::core::Task {
  public:
   explicit seidel_method_seq(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cmath>
+#include <iomanip>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace khokhlov_a_iterative_seidel_method_seq {
+
+void getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N);
+
+class seidel_method_seq : public ppc::core::Task {
+ public:
+  explicit seidel_method_seq(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  const double EPSILON = 1e-6;
+  std::vector<double> A;
+  std::vector<double> b;
+  std::vector<double> result;
+  int maxIterations, n;
+};
+}  // namespace khokhlov_a_iterative_seidel_method_seq

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
@@ -19,6 +19,7 @@ class seidel_method_seq : public ppc::core::Task {
   bool post_processing() override;
 
  private:
+  int rank(std::vector<double> A_, int rows, int cols);
   double EPSILON;
   std::vector<double> A;
   std::vector<double> b;

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp
@@ -19,7 +19,7 @@ class seidel_method_seq : public ppc::core::Task {
   bool post_processing() override;
 
  private:
-  int rank(std::vector<double> A_, int rows, int cols);
+  static int rank(std::vector<double> A_, int rows, int cols);
   double EPSILON;
   std::vector<double> A;
   std::vector<double> b;

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -3,6 +3,22 @@
 #include "core/perf/include/perf.hpp"
 #include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
 
+void getRandomSLAU(std::vector<double> &A, std::vector<double> &b, int N) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  for (int i = 0; i < N; ++i) {
+    double rowSum = 0.0;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        A[i * N + j] = rand() % 10 - 5;
+        rowSum += std::abs(A[i * N + j]);
+      }
+    }
+    A[i * N + i] = rowSum + (rand() % 5 + 1);
+    b[i] = rand() % 20 - 10;
+  }
+}
+
 TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
   const int n = 800;
   const int maxiter = 800;
@@ -12,7 +28,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
   std::vector<double> A(n * n, 0.0);
   std::vector<double> b(n, 0.0);
   std::vector<double> result(n, 0.0);
-  khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // create task data
   std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
@@ -56,7 +72,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_seq) {
   std::vector<double> A(n * n, 0.0);
   std::vector<double> b(n, 0.0);
   std::vector<double> result(n, 0.0);
-  khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(A, b, n);
+  getRandomSLAU(A, b, n);
 
   // create task data
   std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -4,9 +4,9 @@
 #include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
 
 TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
-  const int n = 1000;
-  const int maxiter = 1000;
-  const double eps = 1e-6;
+  const int n = 800;
+  const int maxiter = 800;
+  const double eps = 1e-3;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -48,9 +48,9 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
 }
 
 TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_seq) {
-  const int n = 1000;
-  const int maxiter = 1000;
-  const double eps = 1e-6;
+  const int n = 800;
+  const int maxiter = 800;
+  const double eps = 1e-3;
 
   // create data
   std::vector<double> A(n * n, 0.0);

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -4,8 +4,9 @@
 #include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
 
 TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
-  const int n = 5000;
-  const int maxiter = 5000;
+  const int n = 1000;
+  const int maxiter = 1000;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -19,6 +20,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
   taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
   taskdataSeq->inputs_count.emplace_back(n);
   taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->inputs_count.emplace_back(eps);
   taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   taskdataSeq->outputs_count.emplace_back(result.size());
 
@@ -46,8 +48,9 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
 }
 
 TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_seq) {
-  const int n = 5000;
-  const int maxiter = 5000;
+  const int n = 1000;
+  const int maxiter = 1000;
+  const double eps = 1e-6;
 
   // create data
   std::vector<double> A(n * n, 0.0);
@@ -61,6 +64,7 @@ TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_seq) {
   taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
   taskdataSeq->inputs_count.emplace_back(n);
   taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->inputs_count.emplace_back(eps);
   taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   taskdataSeq->outputs_count.emplace_back(result.size());
 

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/perf_tests/main_khokhlov.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_pipline_run_seq) {
+  const int n = 5000;
+  const int maxiter = 5000;
+
+  // create data
+  std::vector<double> A(n * n, 0.0);
+  std::vector<double> b(n, 0.0);
+  std::vector<double> result(n, 0.0);
+  khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(A, b, n);
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+  taskdataSeq->inputs_count.emplace_back(n);
+  taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskdataSeq->outputs_count.emplace_back(result.size());
+
+  // crate task
+  auto testTaskSeq = std::make_shared<khokhlov_a_iterative_seidel_method_seq::seidel_method_seq>(taskdataSeq);
+
+  // create perf attrib
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSeq);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_EQ(b.size(), result.size());
+}
+
+TEST(khokhlov_a_iterative_seidel_method_seq, test_task_run_seq) {
+  const int n = 5000;
+  const int maxiter = 5000;
+
+  // create data
+  std::vector<double> A(n * n, 0.0);
+  std::vector<double> b(n, 0.0);
+  std::vector<double> result(n, 0.0);
+  khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(A, b, n);
+
+  // create task data
+  std::shared_ptr<ppc::core::TaskData> taskdataSeq = std::make_shared<ppc::core::TaskData>();
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(A.data()));
+  taskdataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(b.data()));
+  taskdataSeq->inputs_count.emplace_back(n);
+  taskdataSeq->inputs_count.emplace_back(maxiter);
+  taskdataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskdataSeq->outputs_count.emplace_back(result.size());
+
+  // crate task
+  auto testTaskSeq = std::make_shared<khokhlov_a_iterative_seidel_method_seq::seidel_method_seq>(taskdataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSeq);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_EQ(b.size(), result.size());
+}

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -89,22 +89,6 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::post_processing(
   return true;
 }
 
-void khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N) {
-  std::random_device dev;
-  std::mt19937 gen(dev());
-  for (int i = 0; i < N; ++i) {
-    double rowSum = 0.0;
-    for (int j = 0; j < N; ++j) {
-      if (i != j) {
-        A[i * N + j] = rand() % 10 - 5;
-        rowSum += std::abs(A[i * N + j]);
-      }
-    }
-    A[i * N + i] = rowSum + (rand() % 5 + 1);
-    b[i] = rand() % 20 - 10;
-  }
-}
-
 int khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::rank(std::vector<double> A_, int rows, int cols) {
   int rank = 0;
   for (int i = 0; i < std::min(rows, cols); ++i) {

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -45,7 +45,7 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
       Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
     }
   int rankA = rank(A_, N, N);
-  int rankAb = rank(A_, N, N + 1);
+  int rankAb = rank(Ab, N, N + 1);
   return (taskData->inputs_count[3] >= 0 && rankA == rankAb);
 }
 

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -1,0 +1,84 @@
+#include "seq/khokhlov_a_iterative_seidel_method/include/ops_seq_khokhlov.hpp"
+
+bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::pre_processing() {
+  internal_order_test();
+  // init matrix
+  A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
+  auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+  std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
+
+  // init vector
+  b = std::vector<double>(taskData->inputs_count[0]);
+  auto tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
+  std::copy(tmp1, tmp1 + taskData->inputs_count[0], b.begin());
+
+  // init sizes
+  n = taskData->inputs_count[0];
+
+  // init maxIterations
+  maxIterations = taskData->inputs_count[1];
+
+  // Init value for output
+  result = std::vector<double>(taskData->inputs_count[0], 0);
+  return true;
+}
+bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
+  internal_order_test();
+  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0);
+}
+
+bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::run() {
+  internal_order_test();
+  std::vector<double> x(n, 1.0);
+  std::vector<double> prevX(n, 1.0);
+
+  for (int iter = 0; iter < maxIterations; ++iter) {
+    for (int i = 0; i < n; ++i) {
+      double sum = 0;
+      for (int j = 0; j < n; ++j) {
+        if (j != i) {
+          sum += (A[i * n + j] * x[j]);
+        }
+      }
+      if (A[i * n + i] != 0) {
+        x[i] = (b[i] - sum) / A[i * n + i];
+      } else {
+        x[i] = 0.0;
+      }
+    }
+    double norm = 0.0;
+    for (int i = 0; i < n; ++i) {
+      norm += std::pow(x[i] - prevX[i], 2);
+    }
+    norm = std::sqrt(norm);
+
+    if (norm < EPSILON) {
+      break;
+    }
+    prevX = x;
+  }
+  result = x;
+  return true;
+}
+
+bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::post_processing() {
+  internal_order_test();
+  for (int i = 0; i < n; i++) reinterpret_cast<double*>(taskData->outputs[0])[i] = result[i];
+  return true;
+}
+
+void khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(std::vector<double>& A, std::vector<double>& b, int N) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  for (int i = 0; i < N; ++i) {
+    double rowSum = 0.0;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        A[i * N + j] = rand() % 10 - 5;
+        rowSum += std::abs(A[i * N + j]);
+      }
+    }
+    A[i * N + i] = rowSum + (rand() % 5 + 1);
+    b[i] = rand() % 20 - 10;
+  }
+}

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -38,12 +38,13 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
   }
   std::vector<double> Ab = std::vector<double>(N * (N + 1));
   for (int i = 0; i < N; i++)
-    for (int j = 0; j < N + 1; j++){
+    for (int j = 0; j < N + 1; j++) {
       Ab[i * N + j] = (j % N == 0) ? b_[i] : A_[i * N + j];
     }
   int rankA = rank(A_, N, N);
   int rankAb = rank(A_, N, N + 1);
-  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 && rankA == rankAb);
+  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 &&
+          rankA == rankAb);
 }
 
 bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::run() {
@@ -102,26 +103,26 @@ void khokhlov_a_iterative_seidel_method_seq::getRandomSLAU(std::vector<double>& 
   }
 }
 
-int khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::rank(std::vector<double> A_, int rows, int cols){
+int khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::rank(std::vector<double> A_, int rows, int cols) {
   int rank = 0;
-    for (int i = 0; i < std::min(rows, cols); ++i) {
-      int maxRow = i;
-        for (int k = i + 1; k < rows; ++k) {
-          if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows +i])) {
-            maxRow = k;
-          }
-        }
-        if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
-          continue;
-        }
-        std::swap(A_[i], A_[maxRow]);
-        for (int j = i + 1; j < rows; ++j) {
-          double factor = A_[j * rows + i] / A_[i * rows + i];
-          for (int k = i; k < cols; ++k) {
-            A_[j * rows + k] -= factor * A_[i * rows + k];
-          }
-        }
-      rank++;
+  for (int i = 0; i < std::min(rows, cols); ++i) {
+    int maxRow = i;
+    for (int k = i + 1; k < rows; ++k) {
+      if (std::abs(A_[k * rows + i]) > std::abs(A_[maxRow * rows + i])) {
+        maxRow = k;
+      }
     }
+    if (std::abs(A_[maxRow * rows + i]) < 1e-9) {
+      continue;
+    }
+    std::swap(A_[i], A_[maxRow]);
+    for (int j = i + 1; j < rows; ++j) {
+      double factor = A_[j * rows + i] / A_[i * rows + i];
+      for (int k = i; k < cols; ++k) {
+        A_[j * rows + k] -= factor * A_[i * rows + k];
+      }
+    }
+    rank++;
+  }
   return rank;
 }

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -18,12 +18,20 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::pre_processing()
   // init maxIterations
   maxIterations = taskData->inputs_count[1];
 
+  EPSILON = taskData->inputs_count[2];
+
   // Init value for output
   result = std::vector<double>(taskData->inputs_count[0], 0);
   return true;
 }
 bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
   internal_order_test();
+  std::vector<double> A_ = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
+  auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+  std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A_.begin());
+  for (unsigned int i = 0; i < taskData->inputs_count[0]; i++) {
+    if (A_[i * taskData->inputs_count[0] + i] == 0) return false;
+  }
   return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0);
 }
 

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -4,12 +4,12 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::pre_processing()
   internal_order_test();
   // init matrix
   A = std::vector<double>(taskData->inputs_count[0] * taskData->inputs_count[0]);
-  auto tmp = reinterpret_cast<double*>(taskData->inputs[0]);
+  auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + taskData->inputs_count[0] * taskData->inputs_count[0], A.begin());
 
   // init vector
   b = std::vector<double>(taskData->inputs_count[0]);
-  auto tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
+  auto* tmp1 = reinterpret_cast<double*>(taskData->inputs[1]);
   std::copy(tmp1, tmp1 + taskData->inputs_count[0], b.begin());
 
   // init sizes

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -27,6 +27,7 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::pre_processing()
 bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
   internal_order_test();
   int N = taskData->inputs_count[0];
+  if (N == 0) return false;
   std::vector<double> A_ = std::vector<double>(N * N);
   auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + N * N, A_.begin());

--- a/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
+++ b/tasks/seq/khokhlov_a_iterative_seidel_method/src/ops_seq_khokhlov.cpp
@@ -27,7 +27,9 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::pre_processing()
 bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
   internal_order_test();
   int N = taskData->inputs_count[0];
-  if (N == 0) return false;
+  int iter = taskData->inputs_count[1];
+  if (N < 1) return false;
+  if (iter < 1) return false;
   std::vector<double> A_ = std::vector<double>(N * N);
   auto* tmp = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp, tmp + N * N, A_.begin());
@@ -44,8 +46,7 @@ bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::validation() {
     }
   int rankA = rank(A_, N, N);
   int rankAb = rank(A_, N, N + 1);
-  return (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[3] >= 0 &&
-          rankA == rankAb);
+  return (taskData->inputs_count[3] >= 0 && rankA == rankAb);
 }
 
 bool khokhlov_a_iterative_seidel_method_seq::seidel_method_seq::run() {


### PR DESCRIPTION
Задача: решить систему линейных алгебраических уравнений итеративным методом Зейделя.
Последовательная версия: на вход подается вещественная матрица коэффициентов А размером n на n и вектор b размером n, требуется найти вектор решений x размером n.  Метод Зейделя выполняет итерации, обновляя значения 
𝑥[𝑖] на основе текущего состояния других 𝑥[𝑗].
Условие сходимости: проверяется норма разности текущего и предыдущего решений 
∣∣𝑥(𝑘+1)−𝑥𝑘∣∣<𝜀.
формула обновления компоненты xi:
xi^(k+1) = 1/Aii(bi −(j=0,j!=i)(n-1)∑Aijxj^(k+1))

Параллельная версия: матрица коэффициентов А разбивается на локальные матрицы размера n*local_n, где local_n равняется делением нацело числа строк на число процессов, остаток записывается в последний процесс, вектор b также разбивается на локальные вектора размера local_n. После каждой итерации перезаписывается 𝑥(𝑘+1) и 𝑥𝑘, после чего считается локальная норма для каждого процесса и суммируется в нулевом, после чего происходит проверка на сходимость.

Чтобы решение сходилось, в тестах используется генерация матрицы с диагональным преобладанием.
​
  
​
