### PR TITLE
Кондратьев Ярослав. Задача 3. Вариант 21. Поразрядная сортировка для вещественных чисел (тип double)  с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,244 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+
+#include "mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp"
+namespace kondratev_ya_radix_sort_batcher_merge_mpi {
+std::vector<double> getRandomVector(uint32_t size) {
+  std::srand(std::time(nullptr));
+  std::vector<double> vec(size);
+
+  double lower_bound = -10000;
+  double upper_bound = 10000;
+  for (uint32_t i = 0; i < size; i++) {
+    vec[i] = lower_bound + std::rand() / (double)RAND_MAX * (upper_bound - lower_bound);
+  }
+  return vec;
+}
+}  // namespace kondratev_ya_radix_sort_batcher_merge_mpi
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, basic) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+  std::vector<double> out1;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    uint32_t size = 12;
+    in.assign({8, 2, 5, 10, 1, 7, 3, 12, 6, 11, 4, 9});
+    out.resize(size);
+    out1.resize(size);
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel testTaskParallel(taskDataMPI);
+  testTaskParallel.validation();
+  testTaskParallel.pre_processing();
+  testTaskParallel.run();
+  testTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+
+    taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskData->inputs_count.emplace_back(in.size());
+    taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskData->outputs_count.emplace_back(out1.size());
+
+    kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskSequential testTaskSequential(taskData);
+    testTaskSequential.validation();
+    testTaskSequential.pre_processing();
+    testTaskSequential.run();
+    testTaskSequential.post_processing();
+
+    ASSERT_EQ(out[0], out1[0]);
+    for (uint32_t i = 1; i < out.size(); i++) {
+      ASSERT_LE(out[i - 1], out[i]);
+      ASSERT_EQ(out[i], out1[i]);
+    }
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, empty) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel testTaskParallel(taskDataMPI);
+  testTaskParallel.validation();
+  testTaskParallel.pre_processing();
+  testTaskParallel.run();
+  testTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+
+    taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskData->inputs_count.emplace_back(in.size());
+    taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskData->outputs_count.emplace_back(out.size());
+
+    kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskSequential testTaskSequential(taskData);
+    testTaskSequential.validation();
+    testTaskSequential.pre_processing();
+    testTaskSequential.run();
+    testTaskSequential.post_processing();
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, scalar) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+  std::vector<double> out1;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    uint32_t size = 1;
+    in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
+    out.resize(size);
+    out1.resize(size);
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel testTaskParallel(taskDataMPI);
+  testTaskParallel.validation();
+  testTaskParallel.pre_processing();
+  testTaskParallel.run();
+  testTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+
+    taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskData->inputs_count.emplace_back(in.size());
+    taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskData->outputs_count.emplace_back(out1.size());
+
+    kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskSequential testTaskSequential(taskData);
+    testTaskSequential.validation();
+    testTaskSequential.pre_processing();
+    testTaskSequential.run();
+    testTaskSequential.post_processing();
+
+    ASSERT_EQ(out[0], out1[0]);
+    for (uint32_t i = 1; i < out.size(); i++) {
+      ASSERT_LE(out[i - 1], out[i]);
+      ASSERT_EQ(out[i], out1[i]);
+    }
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, prime) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+  std::vector<double> out1;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    uint32_t size = 239;
+    in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
+    out.resize(size);
+    out1.resize(size);
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel testTaskParallel(taskDataMPI);
+  testTaskParallel.validation();
+  testTaskParallel.pre_processing();
+  testTaskParallel.run();
+  testTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+
+    taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskData->inputs_count.emplace_back(in.size());
+    taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskData->outputs_count.emplace_back(out1.size());
+
+    kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskSequential testTaskSequential(taskData);
+    testTaskSequential.validation();
+    testTaskSequential.pre_processing();
+    testTaskSequential.run();
+    testTaskSequential.post_processing();
+
+    ASSERT_EQ(out[0], out1[0]);
+    for (uint32_t i = 1; i < out.size(); i++) {
+      ASSERT_LE(out[i - 1], out[i]);
+      ASSERT_EQ(out[i], out1[i]);
+    }
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, power2) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+  std::vector<double> out1;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    uint32_t size = 256;
+    in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
+    out.resize(size);
+    out1.resize(size);
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel testTaskParallel(taskDataMPI);
+  testTaskParallel.validation();
+  testTaskParallel.pre_processing();
+  testTaskParallel.run();
+  testTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+
+    taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskData->inputs_count.emplace_back(in.size());
+    taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskData->outputs_count.emplace_back(out1.size());
+
+    kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskSequential testTaskSequential(taskData);
+    testTaskSequential.validation();
+    testTaskSequential.pre_processing();
+    testTaskSequential.run();
+    testTaskSequential.post_processing();
+
+    ASSERT_EQ(out[0], out1[0]);
+    for (uint32_t i = 1; i < out.size(); i++) {
+      ASSERT_LE(out[i - 1], out[i]);
+      ASSERT_EQ(out[i], out1[i]);
+    }
+  }
+}

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
@@ -1,0 +1,46 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cmath>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kondratev_ya_radix_sort_batcher_merge_mpi {
+
+void radixSortDouble(std::vector<double>& arr, int32_t start, int32_t end);
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> data_;
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  std::vector<double> distribute_data(const std::vector<double>& input, int32_t size, int32_t rank);
+  void exchange_and_merge(int32_t rank1, int32_t rank2);
+
+ private:
+  std::vector<double> input_, local_input_;
+  std::vector<double> res_;
+  int32_t size_;
+  boost::mpi::communicator world;
+};
+
+}  // namespace kondratev_ya_radix_sort_batcher_merge_mpi

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
@@ -35,7 +35,7 @@ class TestMPITaskParallel : public ppc::core::Task {
   bool run() override;
   bool post_processing() override;
   std::vector<double> distribute_data(const std::vector<double>& input, int32_t size, int32_t rank);
-  void exchange_and_merge(int32_t rank1, int32_t rank2);
+  void exchange_and_merge(int32_t rank1, int32_t size1, int32_t rank2, int32_t size2);
   static void merge(const std::vector<double>& first, const std::vector<double>& second, std::vector<double>& result);
 
  private:

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
@@ -6,6 +6,7 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
+#include <numeric>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp
@@ -36,6 +36,7 @@ class TestMPITaskParallel : public ppc::core::Task {
   bool post_processing() override;
   std::vector<double> distribute_data(const std::vector<double>& input, int32_t size, int32_t rank);
   void exchange_and_merge(int32_t rank1, int32_t rank2);
+  static void merge(const std::vector<double>& first, const std::vector<double>& second, std::vector<double>& result);
 
  private:
   std::vector<double> input_, local_input_;

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,92 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp"
+namespace kondratev_ya_radix_sort_batcher_merge_mpi {
+std::vector<double> getRandomVector(uint32_t size) {
+  std::srand(std::time(nullptr));
+  std::vector<double> vec(size);
+
+  double lower_bound = 0;
+  double upper_bound = 10000;
+  for (uint32_t i = 0; i < size; i++) {
+    vec[i] = lower_bound + std::rand() / (double)RAND_MAX * (upper_bound - lower_bound);
+  }
+  return vec;
+}
+}  // namespace kondratev_ya_radix_sort_batcher_merge_mpi
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    uint32_t size = 8000000;
+    in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
+    out.resize(size);
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  auto testTaskParallel = std::make_shared<kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel>(taskDataMPI);
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    uint32_t size = 8000000;
+    in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
+    out.resize(size);
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataMPI->inputs_count.emplace_back(in.size());
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  auto testTaskParallel = std::make_shared<kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel>(taskDataMPI);
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+}

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -28,7 +28,7 @@ TEST(kondratev_ya_radix_sort_batcher_merge_mpi, test_pipeline_run) {
 
   std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    uint32_t size = 8000000;
+    uint32_t size = 5000000;
     in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
     out.resize(size);
 
@@ -63,7 +63,7 @@ TEST(kondratev_ya_radix_sort_batcher_merge_mpi, test_task_run) {
 
   std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    uint32_t size = 8000000;
+    uint32_t size = 5000000;
     in = kondratev_ya_radix_sort_batcher_merge_mpi::getRandomVector(size);
     out.resize(size);
 

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -12,7 +12,7 @@ std::vector<double> getRandomVector(uint32_t size) {
   std::srand(std::time(nullptr));
   std::vector<double> vec(size);
 
-  double lower_bound = 0;
+  double lower_bound = -10000;
   double upper_bound = 10000;
   for (uint32_t i = 0; i < size; i++) {
     vec[i] = lower_bound + std::rand() / (double)RAND_MAX * (upper_bound - lower_bound);

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
@@ -30,9 +30,7 @@ void kondratev_ya_radix_sort_batcher_merge_mpi::radixSortDouble(std::vector<doub
       count[(bits[i] >> shift) & full_byte_bit_mask]++;
     }
 
-    for (int32_t i = 1; i < byte_range; i++) {
-      count[i] += count[i - 1];
-    }
+    std::partial_sum(count.begin(), count.end(), count.begin());
 
     for (int32_t i = size - 1; i >= 0; i--) {
       int32_t bucket = (bits[i] >> shift) & full_byte_bit_mask;
@@ -117,13 +115,8 @@ bool kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel::run() {
   int32_t step = size_ / world.size();
   int32_t remain = size_ % world.size();
 
-  std::vector<int32_t> sizes;
-  int32_t recvSize;
-  for (int32_t i = 0; i < world.size(); i++) {
-    recvSize = step;
-    if (i < remain) recvSize++;
-    sizes.push_back(recvSize);
-  }
+  std::vector<int32_t> sizes(world.size(), step);
+  for (int32_t i = 0; i < remain; i++) sizes[i]++;
 
   local_input_.resize(sizes[world.rank()]);
   scatterv(world, input_, sizes, local_input_.data(), 0);

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
@@ -2,11 +2,11 @@
 #include "mpi/kondratev_ya_radix_sort_batcher_merge/include/ops_mpi.hpp"
 
 void kondratev_ya_radix_sort_batcher_merge_mpi::radixSortDouble(std::vector<double>& arr, int32_t start, int32_t end) {
-  static constexpr int32_t byte_size = 8;
-  static constexpr int32_t double_bit_size = byte_size * sizeof(double);
-  static constexpr int32_t full_byte_bit_mask = 0xFF;
-  static constexpr int32_t byte_range = std::pow(2, byte_size);
-  static constexpr uint64_t sign_bit_mask = 1ULL << (double_bit_size - 1);
+  constexpr int32_t byte_size = 8;
+  constexpr int32_t double_bit_size = byte_size * sizeof(double);
+  constexpr int32_t full_byte_bit_mask = 0xFF;
+  constexpr uint64_t sign_bit_mask = 1ULL << (double_bit_size - 1);
+  int32_t byte_range = std::pow(2, byte_size);
 
   int32_t size = end - start + 1;
   std::vector<double> temp(size);

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
@@ -156,14 +156,38 @@ void kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel::exchange_an
 
   if (!neighbor_data.empty()) {
     std::vector<double> merged_data(local_input_.size() + neighbor_data.size());
-    std::merge(local_input_.begin(), local_input_.end(), neighbor_data.begin(), neighbor_data.end(),
-               merged_data.begin());
+    merge(local_input_, neighbor_data, merged_data);
 
     if (world.rank() == rank1) {
       local_input_.assign(merged_data.begin(), merged_data.begin() + local_input_.size());
     } else {
       local_input_.assign(merged_data.end() - local_input_.size(), merged_data.end());
     }
+  }
+}
+
+void kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel::merge(const std::vector<double>& first,
+                                                                           const std::vector<double>& second,
+                                                                           std::vector<double>& result) {
+  auto it1 = first.begin();
+  auto last1 = first.end();
+  auto it2 = second.begin();
+  auto last2 = second.end();
+  auto out = result.begin();
+
+  while (it1 != last1 && it2 != last2) {
+    if (*it1 <= *it2)
+      *out++ = *it1++;
+    else
+      *out++ = *it2++;
+  }
+
+  while (it1 != last1) {
+    *out++ = *it1++;
+  }
+
+  while (it2 != last2) {
+    *out++ = *it2++;
   }
 }
 

--- a/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/kondratev_ya_radix_sort_batcher_merge/src/ops_mpi.cpp
@@ -130,8 +130,8 @@ bool kondratev_ya_radix_sort_batcher_merge_mpi::TestMPITaskParallel::run() {
 
   kondratev_ya_radix_sort_batcher_merge_mpi::radixSortDouble(local_input_, 0, local_input_.size() - 1);
 
-  for (int32_t step = 0; step < world.size(); ++step) {
-    if (step % 2 == 0) {
+  for (int32_t merge_step = 0; merge_step < world.size(); ++merge_step) {
+    if (merge_step % 2 == 0) {
       if (world.rank() % 2 == 0 && world.rank() + 1 < world.size()) {
         exchange_and_merge(world.rank(), world.rank() + 1);
       } else if (world.rank() % 2 != 0) {

--- a/tasks/seq/kondratev_ya_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/kondratev_ya_radix_sort_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,137 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp"
+namespace kondratev_ya_radix_sort_batcher_merge_seq {
+std::vector<double> getRandomVector(uint32_t size) {
+  std::srand(std::time(nullptr));
+  std::vector<double> vec(size);
+
+  double lower_bound = -10000;
+  double upper_bound = 10000;
+  for (uint32_t i = 0; i < size; i++) {
+    vec[i] = lower_bound + std::rand() / (double)RAND_MAX * (upper_bound - lower_bound);
+  }
+  return vec;
+}
+}  // namespace kondratev_ya_radix_sort_batcher_merge_seq
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, basic) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  uint32_t size = 12;
+  in.assign({8, 2, 5, 10, 1, 7, 3, 12, 6, 11, 4, 9});
+  out.resize(size);
+
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.validation();
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (uint32_t i = 1; i < out.size(); i++) {
+    ASSERT_LE(out[i - 1], out[i]);
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, empty) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.validation();
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, scalar) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  uint32_t size = 1;
+  in = kondratev_ya_radix_sort_batcher_merge_seq::getRandomVector(size);
+  out.resize(size);
+
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.validation();
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (uint32_t i = 1; i < out.size(); i++) {
+    ASSERT_LE(out[i - 1], out[i]);
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, prime) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  uint32_t size = 239;
+  in = kondratev_ya_radix_sort_batcher_merge_seq::getRandomVector(size);
+  out.resize(size);
+
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.validation();
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (uint32_t i = 1; i < out.size(); i++) {
+    ASSERT_LE(out[i - 1], out[i]);
+  }
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, power2) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  uint32_t size = 256;
+  in = kondratev_ya_radix_sort_batcher_merge_seq::getRandomVector(size);
+  out.resize(size);
+
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.validation();
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (uint32_t i = 1; i < out.size(); i++) {
+    ASSERT_LE(out[i - 1], out[i]);
+  }
+}

--- a/tasks/seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp
+++ b/tasks/seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp
@@ -1,0 +1,28 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kondratev_ya_radix_sort_batcher_merge_seq {
+
+void radixSortDouble(std::vector<double>& arr, int start, int end);
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> data_;
+};
+
+}  // namespace kondratev_ya_radix_sort_batcher_merge_seq

--- a/tasks/seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp
+++ b/tasks/seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/kondratev_ya_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,93 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp"
+
+namespace kondratev_ya_radix_sort_batcher_merge_seq {
+std::vector<double> getRandomVector(uint32_t size) {
+  std::srand(std::time(nullptr));
+  std::vector<double> vec(size);
+
+  double lower_bound = -10000;
+  double upper_bound = 10000;
+  for (uint32_t i = 0; i < size; i++) {
+    vec[i] = lower_bound + std::rand() / (double)RAND_MAX * (upper_bound - lower_bound);
+  }
+  return vec;
+}
+}  // namespace kondratev_ya_radix_sort_batcher_merge_seq
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, test_pipeline_run) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  uint32_t size = 5000000;
+  in = kondratev_ya_radix_sort_batcher_merge_seq::getRandomVector(size);
+  out.resize(size);
+
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto testTaskSequential = std::make_shared<kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential>(taskData);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}
+
+TEST(kondratev_ya_radix_sort_batcher_merge_seq, test_task_run) {
+  std::vector<double> in;
+  std::vector<double> out;
+
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  uint32_t size = 5000000;
+  in = kondratev_ya_radix_sort_batcher_merge_seq::getRandomVector(size);
+  out.resize(size);
+
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskData->inputs_count.emplace_back(in.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskData->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto testTaskSequential = std::make_shared<kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential>(taskData);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}

--- a/tasks/seq/kondratev_ya_radix_sort_batcher_merge/src/ops_seq.cpp
+++ b/tasks/seq/kondratev_ya_radix_sort_batcher_merge/src/ops_seq.cpp
@@ -30,9 +30,7 @@ void kondratev_ya_radix_sort_batcher_merge_seq::radixSortDouble(std::vector<doub
       count[(bits[i] >> shift) & full_byte_bit_mask]++;
     }
 
-    for (int i = 1; i < byte_range; i++) {
-      count[i] += count[i - 1];
-    }
+    std::partial_sum(count.begin(), count.end(), count.begin());
 
     for (int i = size - 1; i >= 0; i--) {
       int bucket = (bits[i] >> shift) & full_byte_bit_mask;

--- a/tasks/seq/kondratev_ya_radix_sort_batcher_merge/src/ops_seq.cpp
+++ b/tasks/seq/kondratev_ya_radix_sort_batcher_merge/src/ops_seq.cpp
@@ -1,0 +1,88 @@
+// Copyright 2024 Nesterov Alexander
+#include "seq/kondratev_ya_radix_sort_batcher_merge/include/ops_seq.hpp"
+
+void kondratev_ya_radix_sort_batcher_merge_seq::radixSortDouble(std::vector<double>& arr, int start, int end) {
+  const int byte_size = 8;
+  const int double_bit_size = byte_size * sizeof(double);
+  const int full_byte_bit_mask = 0xFF;
+  const int byte_range = std::pow(2, byte_size);
+  const uint64_t sign_bit_mask = 1ULL << (double_bit_size - 1);
+
+  int size = end - start + 1;
+  std::vector<double> temp(size);
+
+  // uint64_t because sizeof(uint64_t) == sizeof(double)
+  auto* bits = reinterpret_cast<uint64_t*>(arr.data() + start);
+
+  // Invert the sign bit for negative numbers
+  for (int i = 0; i < size; i++) {
+    if ((bool)(bits[i] >> (double_bit_size - 1))) {
+      bits[i] = ~bits[i];
+    } else {
+      bits[i] |= sign_bit_mask;
+    }
+  }
+
+  // Sorting by bits
+  for (int shift = 0; shift < double_bit_size; shift += byte_size) {
+    std::vector<int> count(byte_range, 0);
+    for (int i = 0; i < size; i++) {
+      count[(bits[i] >> shift) & full_byte_bit_mask]++;
+    }
+
+    for (int i = 1; i < byte_range; i++) {
+      count[i] += count[i - 1];
+    }
+
+    for (int i = size - 1; i >= 0; i--) {
+      int bucket = (bits[i] >> shift) & full_byte_bit_mask;
+      temp[count[bucket] - 1] = arr[start + i];
+      count[bucket]--;
+    }
+    std::copy(temp.begin(), temp.end(), arr.begin() + start);
+  }
+
+  // Restore inverted signs
+  for (int i = 0; i < size; i++) {
+    if (!(bool)(bits[i] & sign_bit_mask)) {
+      bits[i] = ~bits[i];
+    } else {
+      bits[i] &= ~sign_bit_mask;
+    }
+  }
+}
+
+bool kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential::pre_processing() {
+  internal_order_test();
+
+  auto* input = reinterpret_cast<double*>(taskData->inputs[0]);
+  data_.assign(input, input + taskData->inputs_count[0]);
+
+  return true;
+}
+
+bool kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential::validation() {
+  internal_order_test();
+
+  return !taskData->inputs_count.empty() && taskData->inputs_count[0] > 0 && !taskData->outputs_count.empty() &&
+         !taskData->outputs_count.empty() && taskData->outputs_count[0] == taskData->inputs_count[0] &&
+         !taskData->inputs.empty() && taskData->inputs[0] != nullptr && !taskData->outputs.empty() &&
+         taskData->outputs[0] != nullptr;
+}
+
+bool kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential::run() {
+  internal_order_test();
+
+  radixSortDouble(data_, 0, data_.size() - 1);
+
+  return true;
+}
+
+bool kondratev_ya_radix_sort_batcher_merge_seq::TestTaskSequential::post_processing() {
+  internal_order_test();
+
+  auto* output = reinterpret_cast<double*>(taskData->outputs[0]);
+  std::copy(data_.begin(), data_.end(), output);
+
+  return true;
+}


### PR DESCRIPTION
### Поразрядная сортировка: 
Из-за [особенностей хранния double](https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64)  сортировка происходит в три этапа:
- инвертирование знакового бита чтобы отрицательные числа стали меньше положительных
- сортировка
- восстановление знакового бита
Сортировка происходит в 8 шагов по 8 бит (1 байт)

### Четно-нечетное слияние Бэтчера:
- Массив разделяется по процессам
- Процессы сортируют локальные данные поразрядной сортировкой
- Цикл выполняется world.size() раз (по количеству процессов)
- На четных шагах (step % 2 == 0): Четные процессы (world.rank() % 2 == 0) обмениваются данными со следующим процессом. Нечетные процессы обмениваются данными с предыдущим процессом
- На нечетных шагах (step % 2 == 1): Нечетные процессы обмениваются данными со следующим процессом. Четные процессы обмениваются данными с предыдущим процессом

При каждом обмене вызывается `exchange_and_merge`, который:
- Обменивает данные между парой процессов
- Выполняет слияние отсортированных последовательностей
- Оставляет меньшие элементы процессу с меньшим рангом

Так как слияние Бэтчера - алгоритм параллельной сортировки, то в seq части используется только поразрядная сортировка