### PR TITLE
Ковалев Константин. Задача 3. Вариант 7. Вычисление многомерных интегралов с использованием многошаговой схемы (метод прямоугольников).

### DIFF
--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -203,8 +203,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 2x2_area) {
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.5;
   lims[0].second = lims[1].second = 2.0;
-  double h = 0.0005;
-  double eps = 1e-4;
+  double h = 0.001;
+  double eps = 1e-3;
   std::vector<double> out(1);
   boost::mpi::communicator world;
   std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
@@ -348,10 +348,10 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus03_0_x_15_1
   }
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 08_1_x_15_17_x_18_2_xyz) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 09_1_x_15_17_x_18_2_xyz) {
   const size_t dim = 3;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = 0.8;
+  lims[0].first = 0.9;
   lims[0].second = 1.0;
   lims[1].first = 1.5;
   lims[1].second = 1.7;
@@ -376,7 +376,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 08_1_x_15_17_x_1
   tmpTaskPar.run();
   tmpTaskPar.post_processing();
   if (world.rank() == 0) {
-    ASSERT_NEAR(0.021888, out[0], eps);
+    ASSERT_NEAR(0.011552, out[0], eps);
   }
 }
 

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -22,6 +22,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, invalid_integrat
   std::vector<std::pair<double, double>> lims;
   double h = 111.0;
   std::vector<double> out;
+  boost::mpi::communicator world;
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     taskSeq->inputs_count.emplace_back(lims.size());
@@ -32,7 +33,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, invalid_integrat
   }
   kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
       tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1);
-  ASSERT_FALSE(tmpTaskSeq.validation());
+  ASSERT_FALSE(tmpTaskPar.validation());
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, zero_length) {

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -18,6 +18,23 @@ double f3advanced(std::vector<double> &arguments) {
 }
 }  // namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi
 
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, invalid_integration_step) {
+  std::vector<std::pair<double, double>> lims;
+  double h = 111.0;
+  std::vector<double> out;
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskSeq->inputs_count.emplace_back(lims.size());
+    taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskSeq->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1);
+  ASSERT_FALSE(tmpTaskSeq.validation());
+}
+
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, zero_length) {
   std::vector<std::pair<double, double>> lims;
   double h = 0.001;

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -3,9 +3,8 @@
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
 namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
-const double M_PI = 3.14159265358979323846;
+const double MY_PI = 3.14159265358979323846;
 
-double area(std::vector<double> &arguments) { return 1.0; }
 double area(std::vector<double> &arguments) { return 1.0; }
 
 double f1(std::vector<double> &arguments) { return arguments.at(0); }
@@ -62,8 +61,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, incorrect_output
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus_05pi_05pi_cos) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);
@@ -91,7 +90,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, Eulers_integral)
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 0;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
   double h = 0.0005;
   double eps = 1e-3;
   std::vector<double> out(1);

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -33,7 +33,9 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, invalid_integrat
   }
   kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
       tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1);
-  ASSERT_FALSE(tmpTaskPar.validation());
+  if (world.rank() == 0) {
+    ASSERT_FALSE(tmpTaskPar.validation());
+  }
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, zero_length) {

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -20,16 +20,16 @@ double f3advanced(std::vector<double> &arguments) {
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, invalid_integration_step) {
   std::vector<std::pair<double, double>> lims;
-  double h = 111.0;
+  double h = 111.1;
   std::vector<double> out;
   boost::mpi::communicator world;
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    taskSeq->inputs_count.emplace_back(lims.size());
-    taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
-    taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
-    taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-    taskSeq->outputs_count.emplace_back(out.size());
+    tmpPar->inputs_count.emplace_back(lims.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
   }
   kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
       tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1);

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -1,0 +1,414 @@
+#include <gtest/gtest.h>
+
+#include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
+
+namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
+const double M_PI = 3.14159265358979323846;
+
+double area(std::vector<double> &arguments) { return 1.0; }
+double area(std::vector<double> &arguments) { return 1.0; }
+
+double f1(std::vector<double> &arguments) { return arguments.at(0); }
+double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }
+double f1Euler(std::vector<double> &arguments) { return 2 * std::cos(arguments.at(0)) * std::sin(arguments.at(0)); }
+double f2(std::vector<double> &arguments) { return arguments.at(0) * arguments.at(1); }
+double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at(0)) * std::atan(arguments.at(1)); }
+double f3(std::vector<double> &arguments) { return arguments.at(0) * arguments.at(1) * arguments.at(2); }
+double f3advanced(std::vector<double> &arguments) {
+  return std::sin(arguments.at(0)) * std::tan(arguments.at(1)) * std::log(arguments.at(2));
+}
+}  // namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, zero_length) {
+  std::vector<std::pair<double, double>> lims;
+  double h = 0.001;
+  std::vector<double> out;
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(lims.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(tmpTaskPar.validation());
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, incorrect_output) {
+  std::vector<std::pair<double, double>> lims(1);
+  double h = 0.001;
+  std::vector<double> out(2);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(tmpTaskPar.validation());
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus_05pi_05pi_cos) {
+  const size_t dim = 1;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(lims.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1cos);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(2.0, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, Eulers_integral) {
+  const size_t dim = 1;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  double h = 0.0005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1Euler);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(1.0, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 1x1_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.0;
+  double h = 0.0005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::area);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(1.0, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 1x1_xy) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.0;
+  double h = 0.0005;
+  double eps = 5e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f2);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(0.25, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus1_0xminus1_0_tg_x_arctan_y) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.0;
+  double h = 0.0005;
+  double eps = 5e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f2advanced);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(0.270152023066961, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 2x2_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.5;
+  lims[0].second = lims[1].second = 2.0;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::area);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(2.25, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 2_5x1_4_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 2.0;
+  lims[0].second = 5.0;
+  lims[1].first = 1.0;
+  lims[1].second = 4.0;
+  double h = 0.005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::area);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(9.0, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus1_0xminus1_0_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -1.0;
+  lims[0].second = 0.0;
+  lims[1].first = -1.0;
+  lims[1].second = 0.0;
+  double h = 0.0005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::area);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(1.0, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus1_0xminus1_0_xy) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -1.0;
+  lims[0].second = 0.0;
+  lims[1].first = -1.0;
+  lims[1].second = 0.0;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f2);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(0.25, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus03_0_x_15_17_x_2_21_area) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -0.3;
+  lims[0].second = 0.0;
+  lims[1].first = 1.5;
+  lims[1].second = 1.7;
+  lims[2].first = 2.0;
+  lims[2].second = 2.1;
+  double h = 0.001;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::area);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(0.006, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 08_1_x_15_17_x_18_2_xyz) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0.8;
+  lims[0].second = 1.0;
+  lims[1].first = 1.5;
+  lims[1].second = 1.7;
+  lims[2].first = 1.8;
+  lims[2].second = 2.0;
+  double h = 0.001;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f3);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(0.021888, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 08_1_x_19_2_x_29_3_sinx_tgy_lnz) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0.8;
+  lims[0].second = 1.0;
+  lims[1].first = 1.9;
+  lims[1].second = 2.0;
+  lims[2].first = 2.9;
+  lims[2].second = 3.0;
+  double h = 0.005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> TaskPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    TaskPar->inputs_count.emplace_back(lims.size());
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    TaskPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    TaskPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    TaskPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar tmpTaskPar(
+      TaskPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f3advanced);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    ASSERT_NEAR(-0.00427191467841401, out[0], eps);
+  }
+}

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -201,9 +201,9 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus1_0xminus1_
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 2x2_area) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = lims[1].first = 0.5;
+  lims[0].first = lims[1].first = 1.0;
   lims[0].second = lims[1].second = 2.0;
-  double h = 0.001;
+  double h = 0.0005;
   double eps = 1e-3;
   std::vector<double> out(1);
   boost::mpi::communicator world;
@@ -222,7 +222,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, 2x2_area) {
   tmpTaskPar.run();
   tmpTaskPar.post_processing();
   if (world.rank() == 0) {
-    ASSERT_NEAR(2.25, out[0], eps);
+    ASSERT_NEAR(1.0, out[0], eps);
   }
 }
 

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <numbers>
+
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
 namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
-const double MY_PI = 3.14159265358979323846;
-
 double area(std::vector<double> &arguments) { return 1.0; }
 
 double f1(std::vector<double> &arguments) { return arguments.at(0); }
@@ -61,8 +61,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, incorrect_output
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, minus_05pi_05pi_cos) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
+  lims[0].first = -0.5 * std::numbers::pi;
+  lims[0].second = 0.5 * std::numbers::pi;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);
@@ -90,7 +90,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, Eulers_integral)
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 0;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
+  lims[0].second = 0.5 * std::numbers::pi;
   double h = 0.0005;
   double eps = 1e-3;
   std::vector<double> out(1);

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -3,6 +3,7 @@
 #include <boost/mpi.hpp>
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <functional>

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <boost/mpi.hpp>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <stack>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
+class MultidimensionalIntegralsRectangleMethodPar : public ppc::core::Task {
+ private:
+  std::vector<std::pair<double, double>> limits;
+  size_t n;
+  std::function<double(std::vector<double>& args)> func;
+  double h;
+  double l_res;
+  double g_res;
+  boost::mpi::communicator world;
+
+ public:
+  explicit MultidimensionalIntegralsRectangleMethodPar(std::shared_ptr<ppc::core::TaskData> taskData_,
+                                                       std::function<double(std::vector<double>& args)> func_)
+      : Task(taskData_), func(func_) {}
+  bool count_multidimensional_integrals_rectangle_method_mpi();
+  double customRound(double value);
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+};
+}  // namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -28,7 +28,7 @@ class MultidimensionalIntegralsRectangleMethodPar : public ppc::core::Task {
                                                        std::function<double(std::vector<double>& args)> func_)
       : Task(std::move(taskData_)), func(std::move(func_)) {}
   bool count_multidimensional_integrals_rectangle_method_mpi();
-  const double customRound(double value);
+  double customRound(double value) const;
   bool pre_processing() override;
   bool validation() override;
   bool run() override;

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -26,9 +26,9 @@ class MultidimensionalIntegralsRectangleMethodPar : public ppc::core::Task {
  public:
   explicit MultidimensionalIntegralsRectangleMethodPar(std::shared_ptr<ppc::core::TaskData> taskData_,
                                                        std::function<double(std::vector<double>& args)> func_)
-      : Task(taskData_), func(func_) {}
+      : Task(std::move(taskData_)), func(std::move(func_)) {}
   bool count_multidimensional_integrals_rectangle_method_mpi();
-  double customRound(double value);
+  const double customRound(double value);
   bool pre_processing() override;
   bool validation() override;
   bool run() override;

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -53,9 +53,9 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, test_task_run) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 1.2;
+  lims[0].second = lims[1].second = 1.5;
   double h = 0.0005;
-  double eps = 5e-4;
+  double eps = 1e-3;
   std::vector<double> out(1);
   boost::mpi::communicator world;
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -82,6 +82,6 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, test_task_run) {
   perfAnalyzer->pipeline_run(perfAttr, perfResults);
   if (world.rank() == 0) {
     ppc::core::Perf::print_perf_statistic(perfResults);
-    ASSERT_NEAR(0.614424320346835, out[0], eps);
+    ASSERT_NEAR(2.34381088006031, out[0], eps);
   }
 }

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <cmath>
+#include <ctime>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
+
+namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
+const double M_PI = 3.14159265358979323846;
+
+double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }
+double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at(0)) * std::atan(arguments.at(1)); }
+}  // namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, test_pipeline_run) {
+  const size_t dim = 1;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(lims.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  auto testMpiParallel = std::make_shared<
+      kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar>(
+      tmpPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f1cos);
+  ASSERT_TRUE(testMpiParallel->validation());
+  testMpiParallel->pre_processing();
+  testMpiParallel->run();
+  testMpiParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_NEAR(2.0, out[0], eps);
+  }
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, test_task_run) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.2;
+  double h = 0.0005;
+  double eps = 5e-4;
+  std::vector<double> out(1);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs_count.emplace_back(lims.size());
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+  auto testMpiParallel = std::make_shared<
+      kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar>(
+      taskDataPar, kovalev_k_multidimensional_integrals_rectangle_method_mpi::f2advanced);
+  ASSERT_TRUE(testMpiParallel->validation());
+  testMpiParallel->pre_processing();
+  testMpiParallel->run();
+  testMpiParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_NEAR(0.614424320346835, out[0], eps);
+  }
+}

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <numbers>
 #include <boost/mpi/timer.hpp>
 #include <cmath>
 #include <ctime>
@@ -9,8 +10,6 @@
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
 namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
-const double MY_PI = 3.14159265358979323846;
-
 double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }
 double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at(0)) * std::atan(arguments.at(1)); }
 }  // namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi
@@ -18,8 +17,8 @@ double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, test_pipeline_run) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
+  lims[0].first = -0.5 * std::numbers::pi;
+  lims[0].second = 0.5 * std::numbers::pi;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -1,10 +1,8 @@
 #include <gtest/gtest.h>
 
-#include <numbers>
 #include <boost/mpi/timer.hpp>
-#include <cmath>
 #include <ctime>
-#include <vector>
+#include <numbers>
 
 #include "core/perf/include/perf.hpp"
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -9,7 +9,7 @@
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
 namespace kovalev_k_multidimensional_integrals_rectangle_method_mpi {
-const double M_PI = 3.14159265358979323846;
+const double MY_PI = 3.14159265358979323846;
 
 double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }
 double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at(0)) * std::atan(arguments.at(1)); }
@@ -18,8 +18,8 @@ double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_mpi, test_pipeline_run) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::M_PI;
+  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_mpi::MY_PI;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -62,7 +62,7 @@ bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::Multidimensional
   internal_order_test();
   if (world.rank() == 0) {
     if (taskData->inputs.empty() || taskData->outputs.empty() || taskData->inputs_count[0] <= 0 ||
-        taskData->outputs_count[0] != 1) {
+        taskData->outputs_count[0] != 1 || reinterpret_cast<double*>(taskData->inputs[1])[0] > 0.01) {
       return false;
     }
   }

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -1,8 +1,8 @@
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
-const double
+double
 kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::customRound(
-    double value) {
+    double value) const {
   int tmp = static_cast<int>(1 / h);
   int decimalPlaces = 0;
   while (tmp > 0 && tmp % 10 == 0) {
@@ -17,7 +17,7 @@ kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalInteg
 bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::
     count_multidimensional_integrals_rectangle_method_mpi() {
   std::stack<std::vector<double>> stack;
-  stack.emplace(std::vector<double>());
+  stack.emplace();
 
   while (!stack.empty()) {
     std::vector<double> point = stack.top();

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -1,0 +1,107 @@
+#include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
+
+double
+kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::customRound(
+    double value) {
+  int tmp = static_cast<int>(1 / h);
+  int decimalPlaces = 0;
+  while (tmp > 0 && tmp % 10 == 0) {
+    decimalPlaces++;
+    tmp /= 10;
+  }
+
+  double factor = std::pow(10.0, decimalPlaces);
+  return std::round(value * factor) / factor;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::
+    count_multidimensional_integrals_rectangle_method_mpi() {
+  std::stack<std::vector<double>> stack;
+  stack.push(std::vector<double>());
+
+  while (!stack.empty()) {
+    std::vector<double> point = stack.top();
+    stack.pop();
+
+    if (point.size() == n) {
+      l_res += func(point) * std::pow(h, n);
+      continue;
+    }
+
+    int dim = point.size();
+
+    for (double x = limits[dim].first; x + h <= limits[dim].second; x += h) {
+      point.push_back(x + h / 2);
+      stack.push(point);
+      point.pop_back();
+    }
+  }
+
+  return true;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::
+    pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    n = taskData->inputs_count[0];
+    limits.resize(n);
+    void* ptr_input = taskData->inputs[0];
+    void* ptr_vec = limits.data();
+    h = reinterpret_cast<double*>(taskData->inputs[1])[0];
+    memcpy(ptr_vec, ptr_input, sizeof(std::pair<double, double>) * n);
+  }
+
+  g_res = l_res = 0;
+  return true;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::
+    validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    if (taskData->inputs.empty() || taskData->outputs.empty() || taskData->inputs_count[0] <= 0 ||
+        taskData->outputs_count[0] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::run() {
+  internal_order_test();
+  boost::mpi::broadcast(world, n, 0);
+  boost::mpi::broadcast(world, h, 0);
+
+  if (world.rank() != 0) {
+    limits.resize(n);
+  }
+
+  MPI_Bcast(limits.data(), n * sizeof(std::pair<double, double>), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+  double delta = limits[0].second / world.size() - limits[0].first / world.size();
+
+  limits[0].first = customRound(limits[0].first + delta * world.rank());
+  limits[0].second = customRound(limits[0].second - delta * (world.size() - world.rank() - 1));
+  /*
+  std::cout << "after :\n";
+  std::cout << std::fixed << std::setprecision(8) << world.rank() << ' ' << limits[0].first << ' '
+            << limits[0].second << "\n";
+  fflush(stdout);*/
+
+  count_multidimensional_integrals_rectangle_method_mpi();
+
+  boost::mpi::reduce(world, l_res, g_res, std::plus<double>(), 0);
+
+  return true;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::
+    post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    reinterpret_cast<double*>(taskData->outputs[0])[0] = g_res;
+  }
+  return true;
+}

--- a/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -1,6 +1,6 @@
 #include "mpi/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
-double
+const double
 kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::customRound(
     double value) {
   int tmp = static_cast<int>(1 / h);
@@ -17,7 +17,7 @@ kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalInteg
 bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::MultidimensionalIntegralsRectangleMethodPar::
     count_multidimensional_integrals_rectangle_method_mpi() {
   std::stack<std::vector<double>> stack;
-  stack.push(std::vector<double>());
+  stack.emplace(std::vector<double>());
 
   while (!stack.empty()) {
     std::vector<double> point = stack.top();
@@ -32,7 +32,7 @@ bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::Multidimensional
 
     for (double x = limits[dim].first; x + h <= limits[dim].second; x += h) {
       point.push_back(x + h / 2);
-      stack.push(point);
+      stack.emplace(point);
       point.pop_back();
     }
   }
@@ -84,15 +84,10 @@ bool kovalev_k_multidimensional_integrals_rectangle_method_mpi::Multidimensional
 
   limits[0].first = customRound(limits[0].first + delta * world.rank());
   limits[0].second = customRound(limits[0].second - delta * (world.size() - world.rank() - 1));
-  /*
-  std::cout << "after :\n";
-  std::cout << std::fixed << std::setprecision(8) << world.rank() << ' ' << limits[0].first << ' '
-            << limits[0].second << "\n";
-  fflush(stdout);*/
 
   count_multidimensional_integrals_rectangle_method_mpi();
 
-  boost::mpi::reduce(world, l_res, g_res, std::plus<double>(), 0);
+  boost::mpi::reduce(world, l_res, g_res, std::plus<>(), 0);
 
   return true;
 }

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -140,11 +140,11 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_xy) {
   ASSERT_NEAR(0.015625, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_05x0_05_tg_x_arctan_y) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_04x0_04_tg_x_arctan_y) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 0.5;
+  lims[0].second = lims[1].second = 0.4;
   double h = 0.001;
   double eps = 1e-3;
   std::vector<double> out(1);
@@ -160,7 +160,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_05x0_05_tg_x_
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(0.0157030198483187, out[0], eps);
+  ASSERT_NEAR(0.006413250740706, out[0], eps);
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2x2_area) {

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -3,7 +3,7 @@
 #include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
 namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
-const double M_PI = 3.14159265358979323846;
+const double MY_PI = 3.14159265358979323846;
 
 double area(std::vector<double> &arguments) { return 1.0; }
 
@@ -51,8 +51,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, incorrect_output
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus_05pi_05pi_cos) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::M_PI;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::M_PI;
+  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::MY_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::MY_PI;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);
@@ -75,7 +75,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, Eulers_integral)
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 0;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::M_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::MY_PI;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <numbers>
+
 #include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
 namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
-const double MY_PI = 3.14159265358979323846;
-
 double area(std::vector<double> &arguments) { return 1.0 + arguments.at(0) * 0.0; }
 
 double f1(std::vector<double> &arguments) { return arguments.at(0); }
@@ -51,8 +51,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, incorrect_output
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus_05pi_05pi_cos) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::MY_PI;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::MY_PI;
+  lims[0].first = -0.5 * std::numbers::pi;
+  lims[0].second = 0.5 * std::numbers::pi;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);
@@ -75,7 +75,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, Eulers_integral)
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 0;
-  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::MY_PI;
+  lims[0].second = 0.5 * std::numbers::pi;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -5,7 +5,7 @@
 namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
 const double MY_PI = 3.14159265358979323846;
 
-double area(std::vector<double> &arguments) { return 1.0; }
+double area(std::vector<double> &arguments) { return 1.0 + arguments.at(0)*0.0; }
 
 double f1(std::vector<double> &arguments) { return arguments.at(0); }
 double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -18,6 +18,21 @@ double f3advanced(std::vector<double> &arguments) {
 }
 }  // namespace kovalev_k_multidimensional_integrals_rectangle_method_seq
 
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, invalid_integration_step) {
+  std::vector<std::pair<double, double>> lims;
+  double h = 11.0;
+  std::vector<double> out;
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f1);
+  ASSERT_FALSE(tmpTaskSeq.validation());
+}
+
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, zero_length) {
   std::vector<std::pair<double, double>> lims;
   double h = 0.001;

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -100,7 +100,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_area) {
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 0.5;
   double h = 0.0005;
-  double eps = 1e-5;
+  double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -94,13 +94,13 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, Eulers_integral)
   ASSERT_NEAR(1.0, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_area) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_area) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 1.0;
-  double h = 0.001;
-  double eps = 1e-3;
+  lims[0].second = lims[1].second = 0.5;
+  double h = 0.0005;
+  double eps = 1e-5;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());
@@ -117,11 +117,11 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_area) {
   ASSERT_NEAR(1.0, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_xy) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_xy) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 1.0;
+  lims[0].second = lims[1].second = 0.5;
   double h = 0.001;
   double eps = 1e-3;
   std::vector<double> out(1);
@@ -140,12 +140,12 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_xy) {
   ASSERT_NEAR(0.25, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_0xminus1_0_tg_x_arctan_y) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_07x0_07_tg_x_arctan_y) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 1.0;
-  double h = 0.001;
+  lims[0].second = lims[1].second = 0.7;
+  double h = 0.0005;
   double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
@@ -160,7 +160,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_0xminus1_
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(0.270152023066961, out[0], eps);
+  ASSERT_NEAR(0.0611557538713948, out[0], eps);
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 3x3_area) {

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -99,7 +99,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_area) {
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 0.5;
-  double h = 0.0005;
+  double h = 0.001;
   double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
@@ -122,7 +122,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_xy) {
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 0.5;
-  double h = 0.001;
+  double h = 0.005;
   double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
@@ -145,7 +145,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_07x0_07_tg_x_
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 0.7;
-  double h = 0.0005;
+  double h = 0.001;
   double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
@@ -163,11 +163,11 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_07x0_07_tg_x_
   ASSERT_NEAR(0.0611557538713948, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 3x3_area) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2x2_area) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 3.0;
+  lims[0].second = lims[1].second = 2.0;
   double h = 0.005;
   double eps = 1e-4;
   std::vector<double> out(1);
@@ -183,14 +183,14 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 3x3_area) {
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(9.0, out[0], eps);
+  ASSERT_NEAR(4.0, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2_5x1_4_area) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2_3x1_4_area) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 2.0;
-  lims[0].second = 5.0;
+  lims[0].second = 3.0;
   lims[1].first = 1.0;
   lims[1].second = 4.0;
   double h = 0.005;
@@ -208,15 +208,15 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2_5x1_4_area) {
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(9.0, out[0], eps);
+  ASSERT_NEAR(3.0, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_2xminus3_0_area) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_2xminus2_0_area) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
-  lims[0].first = -1.0;
+  lims[0].first = 0.0;
   lims[0].second = 2.0;
-  lims[1].first = -3.0;
+  lims[1].first = -2.0;
   lims[1].second = 0.0;
   double h = 0.005;
   double eps = 1e-4;
@@ -233,7 +233,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_2xminus3_
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(9.0, out[0], eps);
+  ASSERT_NEAR(4.0, out[0], eps);
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_0xminus1_0_xy) {

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -99,7 +99,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_area) {
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 0.5;
-  double h = 0.001;
+  double h = 0.002;
   double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
@@ -140,11 +140,11 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_xy) {
   ASSERT_NEAR(0.015625, out[0], eps);
 }
 
-TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_07x0_07_tg_x_arctan_y) {
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_05x0_05_tg_x_arctan_y) {
   const size_t dim = 2;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
-  lims[0].second = lims[1].second = 0.7;
+  lims[0].second = lims[1].second = 0.5;
   double h = 0.001;
   double eps = 1e-3;
   std::vector<double> out(1);
@@ -160,7 +160,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_07x0_07_tg_x_
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(0.0611557538713948, out[0], eps);
+  ASSERT_NEAR(0.0157030198483187, out[0], eps);
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2x2_area) {

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -5,7 +5,7 @@
 namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
 const double MY_PI = 3.14159265358979323846;
 
-double area(std::vector<double> &arguments) { return 1.0 + arguments.at(0)*0.0; }
+double area(std::vector<double> &arguments) { return 1.0 + arguments.at(0) * 0.0; }
 
 double f1(std::vector<double> &arguments) { return arguments.at(0); }
 double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -1,0 +1,343 @@
+#include <gtest/gtest.h>
+
+#include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
+
+namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
+const double M_PI = 3.14159265358979323846;
+
+double area(std::vector<double> &arguments) { return 1.0; }
+
+double f1(std::vector<double> &arguments) { return arguments.at(0); }
+double f1cos(std::vector<double> &arguments) { return std::cos(arguments.at(0)); }
+double f1Euler(std::vector<double> &arguments) { return 2 * std::cos(arguments.at(0)) * std::sin(arguments.at(0)); }
+double f2(std::vector<double> &arguments) { return arguments.at(0) * arguments.at(1); }
+double f2advanced(std::vector<double> &arguments) { return std::tan(arguments.at(0)) * std::atan(arguments.at(1)); }
+double f3(std::vector<double> &arguments) { return arguments.at(0) * arguments.at(1) * arguments.at(2); }
+double f3advanced(std::vector<double> &arguments) {
+  return std::sin(arguments.at(0)) * std::tan(arguments.at(1)) * std::log(arguments.at(2));
+}
+}  // namespace kovalev_k_multidimensional_integrals_rectangle_method_seq
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, zero_length) {
+  std::vector<std::pair<double, double>> lims;
+  double h = 0.001;
+  std::vector<double> out;
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f1);
+  ASSERT_FALSE(tmpTaskSeq.validation());
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, incorrect_output) {
+  std::vector<std::pair<double, double>> lims(1);
+  double h = 0.001;
+  std::vector<double> out(2);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f1);
+  ASSERT_FALSE(tmpTaskSeq.validation());
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus_05pi_05pi_cos) {
+  const size_t dim = 1;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::M_PI;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::M_PI;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f1cos);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(2.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, Eulers_integral) {
+  const size_t dim = 1;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0;
+  lims[0].second = 0.5 * kovalev_k_multidimensional_integrals_rectangle_method_seq::M_PI;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f1Euler);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(1.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.0;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::area);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(1.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_xy) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.0;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f2);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(0.25, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_0xminus1_0_tg_x_arctan_y) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 1.0;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f2advanced);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(0.270152023066961, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 3x3_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = lims[1].first = 0.0;
+  lims[0].second = lims[1].second = 3.0;
+  double h = 0.005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::area);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(9.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 2_5x1_4_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 2.0;
+  lims[0].second = 5.0;
+  lims[1].first = 1.0;
+  lims[1].second = 4.0;
+  double h = 0.005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::area);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(9.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_2xminus3_0_area) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -1.0;
+  lims[0].second = 2.0;
+  lims[1].first = -3.0;
+  lims[1].second = 0.0;
+  double h = 0.005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::area);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(9.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_0xminus1_0_xy) {
+  const size_t dim = 2;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -1.0;
+  lims[0].second = 0.0;
+  lims[1].first = -1.0;
+  lims[1].second = 0.0;
+  double h = 0.005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f2);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(0.25, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus03_0_x_15_17_x_2_21_area) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = -0.3;
+  lims[0].second = 0.0;
+  lims[1].first = 1.5;
+  lims[1].second = 1.7;
+  lims[2].first = 2.0;
+  lims[2].second = 2.1;
+  double h = 0.005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::area);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(0.006, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 08_1_x_15_17_x_18_2_xyz) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0.8;
+  lims[0].second = 1.0;
+  lims[1].first = 1.5;
+  lims[1].second = 1.7;
+  lims[2].first = 1.8;
+  lims[2].second = 2.0;
+  double h = 0.005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f3);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(0.021888, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 08_1_x_19_2_x_29_3_sinx_tgy_lnz) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0.8;
+  lims[0].second = 1.0;
+  lims[1].first = 1.9;
+  lims[1].second = 2.0;
+  lims[2].first = 2.9;
+  lims[2].second = 3.0;
+  double h = 0.005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod tmpTaskSeq(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f3advanced);
+  ASSERT_TRUE(tmpTaskSeq.validation());
+  tmpTaskSeq.pre_processing();
+  tmpTaskSeq.run();
+  tmpTaskSeq.post_processing();
+  ASSERT_NEAR(-0.00427191467841401, out[0], eps);
+}

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -114,7 +114,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_area) {
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(1.0, out[0], eps);
+  ASSERT_NEAR(0.25, out[0], eps);
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_xy) {
@@ -137,7 +137,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_xy) {
   tmpTaskSeq.pre_processing();
   tmpTaskSeq.run();
   tmpTaskSeq.post_processing();
-  ASSERT_NEAR(0.25, out[0], eps);
+  ASSERT_NEAR(0.015625, out[0], eps);
 }
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, _0_07x0_07_tg_x_arctan_y) {

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -100,7 +100,7 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 05x05_area) {
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 0.5;
   double h = 0.002;
-  double eps = 1e-3;
+  double eps = 3e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -20,7 +20,7 @@ double f3advanced(std::vector<double> &arguments) {
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, invalid_integration_step) {
   std::vector<std::pair<double, double>> lims;
-  double h = 11.0;
+  double h = 11.1;
   std::vector<double> out;
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/func_tests/main.cpp
@@ -99,8 +99,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_area) {
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 1.0;
-  double h = 0.0005;
-  double eps = 1e-4;
+  double h = 0.001;
+  double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());
@@ -122,8 +122,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, 1x1_xy) {
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 1.0;
-  double h = 0.0005;
-  double eps = 1e-4;
+  double h = 0.001;
+  double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());
@@ -145,8 +145,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, minus1_0xminus1_
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = lims[1].first = 0.0;
   lims[0].second = lims[1].second = 1.0;
-  double h = 0.0005;
-  double eps = 1e-4;
+  double h = 0.001;
+  double eps = 1e-3;
   std::vector<double> out(1);
   std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
   taskSeq->inputs_count.emplace_back(lims.size());

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <functional>

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <stack>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
+
+class MultidimensionalIntegralsRectangleMethod : public ppc::core::Task {
+ private:
+  std::vector<std::pair<double, double>> limits;
+  size_t n;
+  std::function<double(std::vector<double>& args)> func;
+  double h;
+  double res;
+
+ public:
+  explicit MultidimensionalIntegralsRectangleMethod(std::shared_ptr<ppc::core::TaskData> taskData_,
+                                                    std::function<double(std::vector<double>& args)> func_)
+      : Task(taskData_), n(taskData_->inputs_count[0]), func(func_) {}
+  bool count_multidimensional_integrals_rectangle_method_seq();
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+};
+}  // namespace kovalev_k_multidimensional_integrals_rectangle_method_seq

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -22,7 +22,7 @@ class MultidimensionalIntegralsRectangleMethod : public ppc::core::Task {
  public:
   explicit MultidimensionalIntegralsRectangleMethod(std::shared_ptr<ppc::core::TaskData> taskData_,
                                                     std::function<double(std::vector<double>& args)> func_)
-      : Task(taskData_), n(taskData_->inputs_count[0]), func(func_) {}
+      : Task(taskData_), n(taskData_->inputs_count[0]), func(std::move(func_)) {}
   bool count_multidimensional_integrals_rectangle_method_seq();
   bool pre_processing() override;
   bool validation() override;

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp
@@ -20,7 +20,7 @@ class MultidimensionalIntegralsRectangleMethod : public ppc::core::Task {
   double res;
 
  public:
-  explicit MultidimensionalIntegralsRectangleMethod(std::shared_ptr<ppc::core::TaskData> taskData_,
+  explicit MultidimensionalIntegralsRectangleMethod(const std::shared_ptr<ppc::core::TaskData>& taskData_,
                                                     std::function<double(std::vector<double>& args)> func_)
       : Task(taskData_), n(taskData_->inputs_count[0]), func(std::move(func_)) {}
   bool count_multidimensional_integrals_rectangle_method_seq();

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
+
+double f1Euler(std::vector<double> &arguments) { return 2 * std::cos(arguments.at(0)) * std::sin(arguments.at(0)); }
+double f3advanced(std::vector<double> &arguments) {
+  return std::sin(arguments.at(0)) * std::tan(arguments.at(1)) * std::log(arguments.at(2));
+}
+
+const double M_PI = 3.14159265358979323846;
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, test_pipeline_run) {
+  const size_t dim = 1;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0;
+  lims[0].second = 0.5 * M_PI;
+  double h = 0.0005;
+  double eps = 1e-4;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  auto testTaskSequential = std::make_shared<
+      kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod>(taskSeq,
+                                                                                                           f1Euler);
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_NEAR(1.0, out[0], eps);
+}
+
+TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, test_task_run) {
+  const size_t dim = 3;
+  std::vector<std::pair<double, double>> lims(dim);
+  lims[0].first = 0.8;
+  lims[0].second = 1.0;
+  lims[1].first = 1.9;
+  lims[1].second = 2.0;
+  lims[2].first = 2.9;
+  lims[2].second = 3.0;
+  double h = 0.005;
+  double eps = 1e-3;
+  std::vector<double> out(1);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(lims.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(lims.data()));
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&h));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  auto testTaskSequential = std::make_shared<
+      kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod>(taskSeq,
+                                                                                                           f3advanced);
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_NEAR(-0.00427191467841401, out[0], eps);
+}

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -1,23 +1,24 @@
 #include <gtest/gtest.h>
 
+#include <numbers>
 #include <cmath>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
 
+namespace kovalev_k_multidimensional_integrals_rectangle_method_seq {
 double f1Euler(std::vector<double> &arguments) { return 2 * std::cos(arguments.at(0)) * std::sin(arguments.at(0)); }
 double f3advanced(std::vector<double> &arguments) {
   return std::sin(arguments.at(0)) * std::tan(arguments.at(1)) * std::log(arguments.at(2));
 }
-
-const double MY_PI = 3.14159265358979323846;
+}  // namespace kovalev_k_multidimensional_integrals_rectangle_method_seq
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, test_pipeline_run) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 0;
-  lims[0].second = 0.5 * MY_PI;
+  lims[0].second = 0.5 * std::numbers::pi;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);
@@ -28,8 +29,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, test_pipeline_ru
   taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskSeq->outputs_count.emplace_back(out.size());
   auto testTaskSequential = std::make_shared<
-      kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod>(taskSeq,
-                                                                                                           f1Euler);
+      kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod>(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f1Euler);
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -64,8 +65,8 @@ TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, test_task_run) {
   taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskSeq->outputs_count.emplace_back(out.size());
   auto testTaskSequential = std::make_shared<
-      kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod>(taskSeq,
-                                                                                                           f3advanced);
+      kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod>(
+      taskSeq, kovalev_k_multidimensional_integrals_rectangle_method_seq::f3advanced);
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <numbers>
-#include <cmath>
-#include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/perf_tests/main.cpp
@@ -11,13 +11,13 @@ double f3advanced(std::vector<double> &arguments) {
   return std::sin(arguments.at(0)) * std::tan(arguments.at(1)) * std::log(arguments.at(2));
 }
 
-const double M_PI = 3.14159265358979323846;
+const double MY_PI = 3.14159265358979323846;
 
 TEST(kovalev_k_multidimensional_integrals_rectangle_method_seq, test_pipeline_run) {
   const size_t dim = 1;
   std::vector<std::pair<double, double>> lims(dim);
   lims[0].first = 0;
-  lims[0].second = 0.5 * M_PI;
+  lims[0].second = 0.5 * MY_PI;
   double h = 0.0005;
   double eps = 1e-4;
   std::vector<double> out(1);

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -1,0 +1,57 @@
+#include "seq/kovalev_k_multidimensional_integrals_rectangle_method/include/header.hpp"
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::
+    count_multidimensional_integrals_rectangle_method_seq() {
+  std::stack<std::vector<double>> stack;
+  stack.push(std::vector<double>());
+
+  while (!stack.empty()) {
+    std::vector<double> point = stack.top();
+    stack.pop();
+
+    if (point.size() == n) {
+      res += func(point) * std::pow(h, n);
+      continue;
+    }
+
+    int dim = point.size();
+
+    for (double x = limits[dim].first; x + h <= limits[dim].second; x += h) {
+      point.push_back(x + h / 2);
+      stack.push(point);
+      point.pop_back();
+    }
+  }
+
+  return true;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::
+    pre_processing() {
+  internal_order_test();
+  fflush(stdout);
+  limits.resize(n);
+  void* ptr_input = taskData->inputs[0];
+  void* ptr_vec = limits.data();
+  h = reinterpret_cast<double*>(taskData->inputs[1])[0];
+  memcpy(ptr_vec, ptr_input, sizeof(std::pair<double, double>) * n);
+  res = 0;
+  return true;
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::validation() {
+  internal_order_test();
+  return (taskData->inputs_count[0] > 0 && taskData->outputs_count[0] == 1 && taskData->inputs_count[0] == n);
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::run() {
+  internal_order_test();
+  return count_multidimensional_integrals_rectangle_method_seq();
+}
+
+bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::
+    post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+  return true;
+}

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -41,7 +41,8 @@ bool kovalev_k_multidimensional_integrals_rectangle_method_seq::Multidimensional
 
 bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::validation() {
   internal_order_test();
-  return (taskData->inputs_count[0] > 0 && taskData->outputs_count[0] == 1 && taskData->inputs_count[0] == n);
+  return (taskData->inputs_count[0] > 0 && taskData->outputs_count[0] == 1 && taskData->inputs_count[0] == n &&
+          reinterpret_cast<double*>(taskData->inputs[1])[0] <= 0.01);
 }
 
 bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::run() {

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -3,7 +3,7 @@
 bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::
     count_multidimensional_integrals_rectangle_method_seq() {
   std::stack<std::vector<double>> stack;
-  stack.push(std::vector<double>());
+  stack.emplace(std::vector<double>());
 
   while (!stack.empty()) {
     std::vector<double> point = stack.top();
@@ -18,7 +18,7 @@ bool kovalev_k_multidimensional_integrals_rectangle_method_seq::Multidimensional
 
     for (double x = limits[dim].first; x + h <= limits[dim].second; x += h) {
       point.push_back(x + h / 2);
-      stack.push(point);
+      stack.emplace(point);
       point.pop_back();
     }
   }

--- a/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_multidimensional_integrals_rectangle_method/src/sourse.cpp
@@ -3,7 +3,7 @@
 bool kovalev_k_multidimensional_integrals_rectangle_method_seq::MultidimensionalIntegralsRectangleMethod::
     count_multidimensional_integrals_rectangle_method_seq() {
   std::stack<std::vector<double>> stack;
-  stack.emplace(std::vector<double>());
+  stack.emplace();
 
   while (!stack.empty()) {
     std::vector<double> point = stack.top();


### PR DESCRIPTION
Задача состоит в приближенном вычислении многомерного определённого интеграла от заданной функции. Используется многошаговая схема: для каждой взятой с вершины стека точки вычисляются следующие (точки следующей размерности, отстоющие друг от друга на шаг h). Точки кладутся на стек. Если точка с вершины стека содержит в себе координаты всех размерностей, то вычисляется значение функции в ней, умножается на шаг интегрирования h в степени размерности интеграла. Точка удаляется со стека. Алгоритм повторяется до тех пор пока стек не окажется пуст.
В параллельной версии используется свойство аддитивности интеграла по области: каждый из процессов вычисляет интеграл на своём отрезке, совокупность которых образует первую размерность исходного интеграла. Затем результаты со всех процессов суммируются и собираются на процессе с рангом 0