### PR TITLE
Сомов Иван. Задача №3. Вариант 21. Поразрядная сортировка для вещественных чисел (тип double) с чётно-нечётным слиянием Бэтчера

### DIFF
--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -22,7 +22,7 @@ std::vector<double> create_random_vector(int size, double mean = 5.0, double std
   return tmp;
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_20) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_20_elements) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(20);
   std::vector<double> out(in.size(), 0);
@@ -63,7 +63,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_20) {
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1000) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_1000_elements) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(1000);
   std::vector<double> out(in.size(), 0);
@@ -104,7 +104,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1000) {
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_10000) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_10000_elements) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(10000);
   std::vector<double> out(in.size(), 0);
@@ -145,7 +145,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_10000) {
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1001) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_1001_elements) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(1001);
   std::vector<double> out(in.size(), 0);
@@ -186,7 +186,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1001) {
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_1_element) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(1);
   std::vector<double> out(in.size(), 0);

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -9,6 +9,8 @@
 
 #include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
 
+namespace somov_i_bitwise_sorting_batcher_merge_mpi {
+
 std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
@@ -22,9 +24,11 @@ std::vector<double> create_random_vector(int size, double mean = 3.0, double std
   return tmp;
 }
 
+}  // namespace somov_i_bitwise_sorting_batcher_merge_mpi
+
 TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_20_elements) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(20);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(20);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -63,9 +67,10 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequen
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_1000_elements) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_20_elements_reverse) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(1000);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(20);
+  std::reverse(in.begin(), in.end());
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -104,9 +109,10 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequen
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_10000_elements) {
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_10001_elements_reverse) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(10000);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(10001);
+  std::reverse(in.begin(), in.end());
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -147,7 +153,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequen
 
 TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_1001_elements) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(1001);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(1001);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -188,7 +194,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequen
 
 TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_1_element) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(1);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(1);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -223,6 +229,141 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequen
     for (size_t i = 1; i < out.size(); i++) {
       ASSERT_NEAR(out[i], out1[i], 1e-10);
       ASSERT_TRUE(out[i - 1] <= out[i]);
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_power_of_two) {
+  boost::mpi::communicator world;
+  std::vector<int> sizes = {2, 4, 8, 16, 32, 64};
+
+  for (int size : sizes) {
+    std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(size);
+    std::vector<double> out(in.size(), 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+      taskDataPar->inputs_count.emplace_back(in.size());
+      taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+      taskDataPar->outputs_count.emplace_back(out.size());
+    }
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    ASSERT_EQ(testMpiTaskParallel.validation(), true);
+    testMpiTaskParallel.pre_processing();
+    testMpiTaskParallel.run();
+    testMpiTaskParallel.post_processing();
+
+    if (world.rank() == 0) {
+      std::vector<double> out1(in.size(), 0);
+
+      std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+      taskDataSeq->inputs_count.emplace_back(in.size());
+      taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+      taskDataSeq->outputs_count.emplace_back(out1.size());
+
+      somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+      ASSERT_EQ(testMpiTaskSequential.validation(), true);
+      testMpiTaskSequential.pre_processing();
+      testMpiTaskSequential.run();
+      testMpiTaskSequential.post_processing();
+      for (size_t i = 1; i < out.size(); i++) {
+        ASSERT_NEAR(out[i], out1[i], 1e-10);
+        ASSERT_TRUE(out[i - 1] <= out[i]);
+      }
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_power_of_three) {
+  boost::mpi::communicator world;
+  std::vector<int> sizes = {3, 9, 27, 81, 243};
+
+  for (int size : sizes) {
+    std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(size);
+    std::vector<double> out(in.size(), 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+      taskDataPar->inputs_count.emplace_back(in.size());
+      taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+      taskDataPar->outputs_count.emplace_back(out.size());
+    }
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    ASSERT_EQ(testMpiTaskParallel.validation(), true);
+    testMpiTaskParallel.pre_processing();
+    testMpiTaskParallel.run();
+    testMpiTaskParallel.post_processing();
+
+    if (world.rank() == 0) {
+      std::vector<double> out1(in.size(), 0);
+
+      std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+      taskDataSeq->inputs_count.emplace_back(in.size());
+      taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+      taskDataSeq->outputs_count.emplace_back(out1.size());
+
+      somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+      ASSERT_EQ(testMpiTaskSequential.validation(), true);
+      testMpiTaskSequential.pre_processing();
+      testMpiTaskSequential.run();
+      testMpiTaskSequential.post_processing();
+      for (size_t i = 1; i < out.size(); i++) {
+        ASSERT_NEAR(out[i], out1[i], 1e-10);
+        ASSERT_TRUE(out[i - 1] <= out[i]);
+      }
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_sorting_parallel_and_sequential_prime_sizes) {
+  boost::mpi::communicator world;
+  std::vector<int> sizes = {5, 7, 11, 13, 17, 19};
+
+  for (int size : sizes) {
+    std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(size);
+    std::vector<double> out(in.size(), 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+      taskDataPar->inputs_count.emplace_back(in.size());
+      taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+      taskDataPar->outputs_count.emplace_back(out.size());
+    }
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    ASSERT_EQ(testMpiTaskParallel.validation(), true);
+    testMpiTaskParallel.pre_processing();
+    testMpiTaskParallel.run();
+    testMpiTaskParallel.post_processing();
+
+    if (world.rank() == 0) {
+      std::vector<double> out1(in.size(), 0);
+
+      std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+      taskDataSeq->inputs_count.emplace_back(in.size());
+      taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+      taskDataSeq->outputs_count.emplace_back(out1.size());
+
+      somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+      ASSERT_EQ(testMpiTaskSequential.validation(), true);
+      testMpiTaskSequential.pre_processing();
+      testMpiTaskSequential.run();
+      testMpiTaskSequential.post_processing();
+      for (size_t i = 1; i < out.size(); i++) {
+        ASSERT_NEAR(out[i], out1[i], 1e-6);
+        ASSERT_TRUE(out[i - 1] <= out[i]);
+      }
     }
   }
 }

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,243 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
+
+std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+  std::normal_distribution<double> norm_dist(mean, stddev);
+
+  std::random_device rand_dev;
+  std::mt19937 rand_engine(rand_dev());
+
+  std::vector<double> tmp(size);
+  for (int i = 0; i < size; i++) {
+    tmp[i] = norm_dist(rand_engine);
+  }
+  return tmp;
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_20) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(20);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+
+    std::vector<double> out1(in.size(), 0);
+
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataSeq->inputs_count.emplace_back(in.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskDataSeq->outputs_count.emplace_back(out1.size());
+
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    for (size_t i = 1; i < out.size(); i++) {
+      ASSERT_NEAR(out[i], out1[i], 1e-10);
+      ASSERT_TRUE(out[i - 1] <= out[i]);
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1000) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(1000);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+
+    std::vector<double> out1(in.size(), 0);
+
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataSeq->inputs_count.emplace_back(in.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskDataSeq->outputs_count.emplace_back(out1.size());
+
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    for (size_t i = 1; i < out.size(); i++) {
+      ASSERT_NEAR(out[i], out1[i], 1e-10);
+      ASSERT_TRUE(out[i - 1] <= out[i]);
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_10000) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(10000);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+
+    std::vector<double> out1(in.size(), 0);
+
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataSeq->inputs_count.emplace_back(in.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskDataSeq->outputs_count.emplace_back(out1.size());
+
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    for (size_t i = 1; i < out.size(); i++) {
+      ASSERT_NEAR(out[i], out1[i], 1e-10);
+      ASSERT_TRUE(out[i - 1] <= out[i]);
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1001) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(1001);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+
+    std::vector<double> out1(in.size(), 0);
+
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataSeq->inputs_count.emplace_back(in.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskDataSeq->outputs_count.emplace_back(out1.size());
+
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    for (size_t i = 1; i < out.size(); i++) {
+      ASSERT_NEAR(out[i], out1[i], 1e-10);
+      ASSERT_TRUE(out[i - 1] <= out[i]);
+    }
+  }
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(1);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+
+    std::vector<double> out1(in.size(), 0);
+
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    taskDataSeq->inputs_count.emplace_back(in.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
+    taskDataSeq->outputs_count.emplace_back(out1.size());
+
+
+    somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    for (size_t i = 1; i < out.size(); i++) {
+      ASSERT_NEAR(out[i], out1[i], 1e-10);
+      ASSERT_TRUE(out[i - 1] <= out[i]);
+    }
+  }
+}

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -43,16 +43,13 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_20) {
   testMpiTaskParallel.post_processing();
 
   if (world.rank() == 0) {
-
     std::vector<double> out1(in.size(), 0);
-
 
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
     taskDataSeq->inputs_count.emplace_back(in.size());
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
     taskDataSeq->outputs_count.emplace_back(out1.size());
-
 
     somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_EQ(testMpiTaskSequential.validation(), true);
@@ -87,16 +84,13 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1000) {
   testMpiTaskParallel.post_processing();
 
   if (world.rank() == 0) {
-
     std::vector<double> out1(in.size(), 0);
-
 
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
     taskDataSeq->inputs_count.emplace_back(in.size());
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
     taskDataSeq->outputs_count.emplace_back(out1.size());
-
 
     somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_EQ(testMpiTaskSequential.validation(), true);
@@ -131,16 +125,13 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_10000) {
   testMpiTaskParallel.post_processing();
 
   if (world.rank() == 0) {
-
     std::vector<double> out1(in.size(), 0);
-
 
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
     taskDataSeq->inputs_count.emplace_back(in.size());
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
     taskDataSeq->outputs_count.emplace_back(out1.size());
-
 
     somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_EQ(testMpiTaskSequential.validation(), true);
@@ -175,16 +166,13 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1001) {
   testMpiTaskParallel.post_processing();
 
   if (world.rank() == 0) {
-
     std::vector<double> out1(in.size(), 0);
-
 
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
     taskDataSeq->inputs_count.emplace_back(in.size());
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
     taskDataSeq->outputs_count.emplace_back(out1.size());
-
 
     somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_EQ(testMpiTaskSequential.validation(), true);
@@ -219,16 +207,13 @@ TEST(somov_i_bitwise_sorting_batcher_merge_MPI, test_1) {
   testMpiTaskParallel.post_processing();
 
   if (world.rank() == 0) {
-
     std::vector<double> out1(in.size(), 0);
-
 
     std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
     taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
     taskDataSeq->inputs_count.emplace_back(in.size());
     taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out1.data()));
     taskDataSeq->outputs_count.emplace_back(out1.size());
-
 
     somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_EQ(testMpiTaskSequential.validation(), true);

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -9,7 +9,7 @@
 
 #include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -9,7 +9,7 @@
 
 #include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp
@@ -2,9 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <array>
 #include <cstdint>
 #include <cstring>
 #include <memory>

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace somov_i_bitwise_sorting_batcher_merge_mpi {
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> input_;
+  std::vector<double> res_;
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> input_;
+  std::vector<double> local_input_;
+  std::vector<double> res_;
+  boost::mpi::communicator world;
+};
+
+}  // namespace somov_i_bitwise_sorting_batcher_merge_mpi

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -9,7 +9,7 @@
 #include "core/perf/include/perf.hpp"
 #include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -9,7 +9,7 @@
 #include "core/perf/include/perf.hpp"
 #include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/mpi/timer.hpp>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
+
+std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+  std::normal_distribution<double> norm_dist(mean, stddev);
+
+  std::random_device rand_dev;
+  std::mt19937 rand_engine(rand_dev());
+
+  std::vector<double> tmp(size);
+  for (int i = 0; i < size; i++) {
+    tmp[i] = norm_dist(rand_engine);
+  }
+  return tmp;
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(10000000);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 5;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+}
+TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000two) {
+  boost::mpi::communicator world;
+  std::vector<double> in = create_random_vector(10000000);
+  std::vector<double> out(in.size(), 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+    taskDataPar->inputs_count.emplace_back(in.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataPar->outputs_count.emplace_back(out.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 5;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+}

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -9,6 +9,8 @@
 #include "core/perf/include/perf.hpp"
 #include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
 
+namespace somov_i_bitwise_sorting_batcher_merge_mpi {
+
 std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
@@ -22,9 +24,11 @@ std::vector<double> create_random_vector(int size, double mean = 3.0, double std
   return tmp;
 }
 
+}  // namespace somov_i_bitwise_sorting_batcher_merge_mpi
+
 TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test_pipeline_run_10000000_elements) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(10000000);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(10000000);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
@@ -58,7 +62,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test_pipeline_run_10000000
 
 TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test_task_run_10000000_elements) {
   boost::mpi::communicator world;
-  std::vector<double> in = create_random_vector(10000000);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi::create_random_vector(10000000);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -22,7 +22,7 @@ std::vector<double> create_random_vector(int size, double mean = 5.0, double std
   return tmp;
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000) {
+TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test_pipeline_run_10000000_elements) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(10000000);
   std::vector<double> out(in.size(), 0);
@@ -56,7 +56,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000) {
   }
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000two) {
+TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test_task_run_10000000_elements) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(10000000);
   std::vector<double> out(in.size(), 0);

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -35,21 +35,19 @@ TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000) {
     taskDataPar->outputs_count.emplace_back(out.size());
   }
 
-  auto testMpiTaskParallel = std::make_shared<somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel>(taskDataPar);
+  auto testMpiTaskParallel =
+      std::make_shared<somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel>(taskDataPar);
   ASSERT_EQ(testMpiTaskParallel->validation(), true);
   testMpiTaskParallel->pre_processing();
   testMpiTaskParallel->run();
   testMpiTaskParallel->post_processing();
-
 
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 5;
   const boost::mpi::timer current_timer;
   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
 
-
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-
 
   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
   perfAnalyzer->pipeline_run(perfAttr, perfResults);
@@ -57,6 +55,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000) {
     ppc::core::Perf::print_perf_statistic(perfResults);
   }
 }
+
 TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000two) {
   boost::mpi::communicator world;
   std::vector<double> in = create_random_vector(10000000);
@@ -70,21 +69,19 @@ TEST(somov_i_bitwise_sorting_batcher_merge_perf_test, test10000000two) {
     taskDataPar->outputs_count.emplace_back(out.size());
   }
 
-  auto testMpiTaskParallel = std::make_shared<somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel>(taskDataPar);
+  auto testMpiTaskParallel =
+      std::make_shared<somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel>(taskDataPar);
   ASSERT_EQ(testMpiTaskParallel->validation(), true);
   testMpiTaskParallel->pre_processing();
   testMpiTaskParallel->run();
   testMpiTaskParallel->post_processing();
-
 
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 5;
   const boost::mpi::timer current_timer;
   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
 
-
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-
 
   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
   perfAnalyzer->task_run(perfAttr, perfResults);

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
@@ -1,0 +1,188 @@
+#include "mpi/somov_i_bitwise_sorting_batcher_merge/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <vector>
+
+void countingSortByByte(std::vector<uint64_t>& data, std::vector<uint64_t>& output, int byteIndex) {
+  const int base = 256;
+  std::array<int, base> count = {0};
+  for (uint64_t num : data) {
+    int byteValue = (num >> (byteIndex * 8)) & 0xFF;
+    count[byteValue]++;
+  }
+  for (int i = 1; i < base; i++) {
+    count[i] += count[i - 1];
+  }
+  for (int i = data.size() - 1; i >= 0; i--) {
+    int byteValue = (data[i] >> (byteIndex * 8)) & 0xFF;
+    output[--count[byteValue]] = data[i];
+  }
+}
+
+void radixSort(std::vector<uint64_t>& data) {
+  const int bytesCount = 8;
+  std::vector<uint64_t> temp(data.size());
+
+  for (int byteIndex = 0; byteIndex < bytesCount; byteIndex++) {
+    countingSortByByte(data, temp, byteIndex);
+    data.swap(temp);
+  }
+}
+
+void radix_sort_double(std::vector<double>& arr) {
+  size_t n = arr.size();
+  if (n == 0) return;
+
+  std::vector<double> positive, negative;
+  for (size_t i = 0; i < n; ++i) {
+    if (arr[i] < 0) {
+      negative.push_back(arr[i]);
+    } else {
+      positive.push_back(arr[i]);
+    }
+  }
+
+  std::vector<uint64_t> posData(positive.size());
+  for (size_t i = 0; i < positive.size(); ++i) {
+    std::memcpy(&posData[i], &positive[i], sizeof(double));
+  }
+
+  radixSort(posData);
+
+  for (size_t i = 0; i < positive.size(); ++i) {
+    std::memcpy(&positive[i], &posData[i], sizeof(double));
+  }
+
+  std::vector<uint64_t> negData(negative.size());
+  for (size_t i = 0; i < negative.size(); ++i) {
+    std::memcpy(&negData[i], &negative[i], sizeof(double));
+    negData[i] = ~negData[i];
+  }
+
+  radixSort(negData);
+
+  for (size_t i = 0; i < negative.size(); ++i) {
+    negData[i] = ~negData[i];
+    std::memcpy(&negative[i], &negData[i], sizeof(double));
+  }
+
+  arr.clear();
+  arr.insert(arr.end(), negative.begin(), negative.end());
+  arr.insert(arr.end(), positive.begin(), positive.end());
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+  input_ = std::vector<double>(taskData->inputs_count[0]);
+  auto* tmp_ptr = reinterpret_cast<double*>(taskData->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], input_.begin());
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  return taskData->inputs_count[0] > 0;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+  radix_sort_double(input_);
+  res_ = input_;
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  auto* tmp_ptr = reinterpret_cast<double*>(taskData->outputs[0]);
+  std::copy(res_.begin(), res_.end(), tmp_ptr);
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    input_.resize(taskData->inputs_count[0]);
+    auto* tmp_ptr = reinterpret_cast<double*>(taskData->inputs[0]);
+    std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], input_.begin());
+    res_.resize(taskData->inputs_count[0]);
+  }
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    return taskData->inputs_count[0] > 0;
+  }
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel::run() {
+  internal_order_test();
+
+  unsigned int delta = 0;
+  unsigned int r = 0;
+  if (world.rank() == 0) {
+    delta = taskData->inputs_count[0] / world.size();
+    r = taskData->inputs_count[0] % world.size();
+    local_input_.resize(delta + r);
+  }
+
+  broadcast(world, delta, 0);
+  broadcast(world, r, 0);
+
+  if (world.rank() != 0) local_input_.resize(delta);
+
+  std::vector<int> local_size(world.size(), delta);
+  local_size[0] += r;
+
+  scatterv(world, input_, local_size, local_input_.data(), 0);
+
+  radix_sort_double(local_input_);
+
+  for (int c = 0; c < world.size(); c++) {
+    if (c % 2 == 0) {
+      if (world.rank() % 2 == 0 && world.rank() + 1 != world.size()) {
+        world.send(world.rank() + 1, c, local_input_);
+        world.recv(world.rank() + 1, c, local_input_);
+      }
+      if (world.rank() % 2 != 0) {
+        std::vector<double> tmp;
+        world.recv(world.rank() - 1, c, tmp);
+        std::vector<double> m(local_input_.size() + tmp.size());
+        std::merge(local_input_.begin(), local_input_.end(), tmp.begin(), tmp.end(), m.begin());
+        tmp.assign(m.begin(), m.begin() + tmp.size());
+        local_input_.assign(m.end() - local_input_.size(), m.end());
+        world.send(world.rank() - 1, c, tmp);
+      }
+    } else {
+      if (world.rank() % 2 == 1 && world.rank() + 1 != world.size()) {
+        world.send(world.rank() + 1, c, local_input_);
+        world.recv(world.rank() + 1, c, local_input_);
+      }
+      if (world.rank() % 2 == 0 && world.rank() != 0) {
+        std::vector<double> tmp;
+        world.recv(world.rank() - 1, c, tmp);
+        std::vector<double> m(local_input_.size() + tmp.size());
+        std::merge(local_input_.begin(), local_input_.end(), tmp.begin(), tmp.end(), m.begin());
+        tmp.assign(m.begin(), m.begin() + tmp.size());
+        local_input_.assign(m.end() - local_input_.size(), m.end());
+        world.send(world.rank() - 1, c, tmp);
+      }
+    }
+  }
+
+  gatherv(world, local_input_.data(), local_input_.size(), res_.data(), local_size, 0);
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    auto* tmp_ptr = reinterpret_cast<double*>(taskData->outputs[0]);
+    std::copy(res_.begin(), res_.end(), tmp_ptr);
+  }
+  return true;
+}

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
@@ -146,7 +146,7 @@ bool somov_i_bitwise_sorting_batcher_merge_mpi::TestMPITaskParallel::run() {
 
   radix_sort_double(local_input_);
 
-  for (int c = 0; c < world.size(); c++) {
+  for (int c = 0; c < world.size() * 2; c++) {
     if (c % 2 == 0) {
       if (world.rank() % 2 == 0 && world.rank() + 1 != world.size()) {
         world.send(world.rank() + 1, c, local_input_);

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
@@ -37,28 +37,31 @@ void radix_sort_double(std::vector<double>& arr) {
 
   std::vector<double> positive;
   std::vector<double> negative;
+  positive.reserve(n / 2);
+  negative.reserve(n / 2);
+
   for (size_t i = 0; i < n; ++i) {
     if (arr[i] < 0) {
-      negative.push_back(arr[i]);
+      negative.emplace_back(arr[i]);
     } else {
-      positive.push_back(arr[i]);
+      positive.emplace_back(arr[i]);
     }
   }
 
   std::vector<uint64_t> posData(positive.size());
   for (size_t i = 0; i < positive.size(); ++i) {
-    std::memcpy(&posData[i], &positive[i], sizeof(double));
+    posData[i] = *reinterpret_cast<uint64_t*>(&positive[i]);
   }
 
   radixSort(posData);
 
   for (size_t i = 0; i < positive.size(); ++i) {
-    std::memcpy(&positive[i], &posData[i], sizeof(double));
+    positive[i] = *reinterpret_cast<double*>(&posData[i]);
   }
 
   std::vector<uint64_t> negData(negative.size());
   for (size_t i = 0; i < negative.size(); ++i) {
-    std::memcpy(&negData[i], &negative[i], sizeof(double));
+    negData[i] = *reinterpret_cast<uint64_t*>(&negative[i]);
     negData[i] = ~negData[i];
   }
 
@@ -66,7 +69,7 @@ void radix_sort_double(std::vector<double>& arr) {
 
   for (size_t i = 0; i < negative.size(); ++i) {
     negData[i] = ~negData[i];
-    std::memcpy(&negative[i], &negData[i], sizeof(double));
+    negative[i] = *reinterpret_cast<double*>(&negData[i]);
   }
 
   arr.clear();

--- a/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/somov_i_bitwise_sorting_batcher_merge/src/ops_mpi.cpp
@@ -35,7 +35,8 @@ void radix_sort_double(std::vector<double>& arr) {
   size_t n = arr.size();
   if (n == 0) return;
 
-  std::vector<double> positive, negative;
+  std::vector<double> positive;
+  std::vector<double> negative;
   for (size_t i = 0; i < n; ++i) {
     if (arr[i] < 0) {
       negative.push_back(arr[i]);

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -8,7 +8,7 @@
 
 #include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <climits>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
+
+std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+  std::normal_distribution<double> norm_dist(mean, stddev);
+
+  std::random_device rand_dev;
+  std::mt19937 rand_engine(rand_dev());
+
+  std::vector<double> tmp(size);
+  for (int i = 0; i < size; i++) {
+    tmp[i] = norm_dist(rand_engine);
+  }
+  return tmp;
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, teststart) {
+
+  std::vector<double> in = {3.14, -2.71, 1.41, 0.0, -3.14, 2.71};
+  std::vector<double> out(in.size(), 0);
+
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+
+  somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
+}
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test10) {
+
+  std::vector<double> in = create_random_vector(10);
+  std::vector<double> out(in.size(), 0);
+
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+
+  somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
+}
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test101) {
+
+  std::vector<double> in = create_random_vector(101);
+  std::vector<double> out(in.size(), 0);
+
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+
+  somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
+}
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test1007) {
+
+  std::vector<double> in = create_random_vector(1007);
+  std::vector<double> out(in.size(), 0);
+
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+
+  somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
+}

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -22,17 +22,14 @@ std::vector<double> create_random_vector(int size, double mean = 5.0, double std
 }
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, teststart) {
-
   std::vector<double> in = {3.14, -2.71, 1.41, 0.0, -3.14, 2.71};
   std::vector<double> out(in.size(), 0);
 
-
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   taskDataSeq->inputs_count.emplace_back(in.size());
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskDataSeq->outputs_count.emplace_back(out.size());
-
 
   somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
   ASSERT_EQ(testTaskSequential.validation(), true);
@@ -41,18 +38,16 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, teststart) {
   testTaskSequential.post_processing();
   for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
 }
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test10) {
 
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test10) {
   std::vector<double> in = create_random_vector(10);
   std::vector<double> out(in.size(), 0);
 
-
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   taskDataSeq->inputs_count.emplace_back(in.size());
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskDataSeq->outputs_count.emplace_back(out.size());
-
 
   somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
   ASSERT_EQ(testTaskSequential.validation(), true);
@@ -61,18 +56,16 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test10) {
   testTaskSequential.post_processing();
   for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
 }
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test101) {
 
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test101) {
   std::vector<double> in = create_random_vector(101);
   std::vector<double> out(in.size(), 0);
 
-
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   taskDataSeq->inputs_count.emplace_back(in.size());
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskDataSeq->outputs_count.emplace_back(out.size());
-
 
   somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
   ASSERT_EQ(testTaskSequential.validation(), true);
@@ -81,18 +74,16 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test101) {
   testTaskSequential.post_processing();
   for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
 }
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test1007) {
 
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test1007) {
   std::vector<double> in = create_random_vector(1007);
   std::vector<double> out(in.size(), 0);
-
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   taskDataSeq->inputs_count.emplace_back(in.size());
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskDataSeq->outputs_count.emplace_back(out.size());
-
 
   somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential testTaskSequential(taskDataSeq);
   ASSERT_EQ(testTaskSequential.validation(), true);

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -8,6 +8,8 @@
 
 #include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
 
+namespace somov_i_bitwise_sorting_batcher_merge_mpi_seq {
+
 std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
@@ -20,6 +22,8 @@ std::vector<double> create_random_vector(int size, double mean = 3.0, double std
   }
   return tmp;
 }
+
+}  // namespace somov_i_bitwise_sorting_batcher_merge_mpi_seq
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_basic_sorting) {
   std::vector<double> in = {3.14, -2.71, 1.41, 0.0, -3.14, 2.71};
@@ -40,7 +44,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_basic_sorting) {
 }
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_10_elements) {
-  std::vector<double> in = create_random_vector(10);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi_seq::create_random_vector(10);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -58,7 +62,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_10_elements) {
 }
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_101_elements) {
-  std::vector<double> in = create_random_vector(101);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi_seq::create_random_vector(101);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -76,7 +80,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_101_elements) {
 }
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_1007_elements) {
-  std::vector<double> in = create_random_vector(1007);
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi_seq::create_random_vector(1007);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -26,7 +26,7 @@ std::vector<double> create_random_vector(int size, double mean = 3.0, double std
 }  // namespace somov_i_bitwise_sorting_batcher_merge_mpi_seq
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_basic_sorting) {
-  std::vector<double> in = {3.14, -2.71, 1.41, 0.0, -3.14, 2.71};
+  std::vector<double> in = {3.14, -2.73, 1.41, 0.0, -3.14, 2.73};
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -21,7 +21,7 @@ std::vector<double> create_random_vector(int size, double mean = 5.0, double std
   return tmp;
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, teststart) {
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_basic_sorting) {
   std::vector<double> in = {3.14, -2.71, 1.41, 0.0, -3.14, 2.71};
   std::vector<double> out(in.size(), 0);
 
@@ -39,7 +39,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, teststart) {
   for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test10) {
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_10_elements) {
   std::vector<double> in = create_random_vector(10);
   std::vector<double> out(in.size(), 0);
 
@@ -57,7 +57,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test10) {
   for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test101) {
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_101_elements) {
   std::vector<double> in = create_random_vector(101);
   std::vector<double> out(in.size(), 0);
 
@@ -75,7 +75,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test101) {
   for (size_t i = 1; i < out.size(); i++) ASSERT_TRUE(out[i - 1] <= out[i]);
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test1007) {
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_sorting_1007_elements) {
   std::vector<double> in = create_random_vector(1007);
   std::vector<double> out(in.size(), 0);
 

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/func_tests/main.cpp
@@ -8,7 +8,7 @@
 
 #include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace somov_i_bitwise_sorting_batcher_merge_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> input_;
+  std::vector<double> res_;
+};
+
+}  // namespace somov_i_bitwise_sorting_batcher_merge_seq

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
+
+std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+  std::normal_distribution<double> norm_dist(mean, stddev);
+
+  std::random_device rand_dev;
+  std::mt19937 rand_engine(rand_dev());
+
+  std::vector<double> tmp(size);
+  for (int i = 0; i < size; i++) {
+    tmp[i] = norm_dist(rand_engine);
+  }
+  return tmp;
+}
+
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, pipeline) {
+
+  std::vector<double> in = create_random_vector(3000000);
+  std::vector<double> out(in.size(), 0);
+
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  auto testTaskSequential = std::make_shared<somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential>(taskDataSeq);
+
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, task) {
+
+  std::vector<double> in = create_random_vector(3000000);
+  std::vector<double> out(in.size(), 0);
+
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  auto testTaskSequential = std::make_shared<somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential>(taskDataSeq);
+
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -22,10 +22,8 @@ std::vector<double> create_random_vector(int size, double mean = 5.0, double std
 }
 
 TEST(somov_i_bitwise_sorting_batcher_merge_seq, pipeline) {
-
   std::vector<double> in = create_random_vector(3000000);
   std::vector<double> out(in.size(), 0);
-
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -33,8 +31,8 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, pipeline) {
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskDataSeq->outputs_count.emplace_back(out.size());
 
-  auto testTaskSequential = std::make_shared<somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential>(taskDataSeq);
-
+  auto testTaskSequential =
+      std::make_shared<somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential>(taskDataSeq);
 
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
@@ -45,19 +43,16 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, pipeline) {
     return static_cast<double>(duration) * 1e-9;
   };
 
-
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-
 
   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
   perfAnalyzer->pipeline_run(perfAttr, perfResults);
   ppc::core::Perf::print_perf_statistic(perfResults);
 }
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, task) {
 
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, task) {
   std::vector<double> in = create_random_vector(3000000);
   std::vector<double> out(in.size(), 0);
-
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -65,8 +60,8 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, task) {
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   taskDataSeq->outputs_count.emplace_back(out.size());
 
-  auto testTaskSequential = std::make_shared<somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential>(taskDataSeq);
-
+  auto testTaskSequential =
+      std::make_shared<somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential>(taskDataSeq);
 
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
@@ -77,9 +72,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, task) {
     return static_cast<double>(duration) * 1e-9;
   };
 
-
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-
 
   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
   perfAnalyzer->task_run(perfAttr, perfResults);

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -8,7 +8,7 @@
 #include "core/perf/include/perf.hpp"
 #include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 5.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -8,7 +8,7 @@
 #include "core/perf/include/perf.hpp"
 #include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
 
-std::vector<double> create_random_vector(int size, double mean = 4.0, double stddev = 300.0) {
+std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
   std::random_device rand_dev;

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -8,6 +8,8 @@
 #include "core/perf/include/perf.hpp"
 #include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
 
+namespace somov_i_bitwise_sorting_batcher_merge_mpi_seq {
+
 std::vector<double> create_random_vector(int size, double mean = 3.0, double stddev = 300.0) {
   std::normal_distribution<double> norm_dist(mean, stddev);
 
@@ -21,8 +23,10 @@ std::vector<double> create_random_vector(int size, double mean = 3.0, double std
   return tmp;
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_pipeline_3000000_el) {
-  std::vector<double> in = create_random_vector(3000000);
+}  // namespace somov_i_bitwise_sorting_batcher_merge_mpi_seq
+
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_pipeline_3000001_el) {
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi_seq::create_random_vector(3000001);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -50,8 +54,8 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_pipeline_3000000_el) {
   ppc::core::Perf::print_perf_statistic(perfResults);
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_task_3000000_el) {
-  std::vector<double> in = create_random_vector(3000000);
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_task_3000001_el) {
+  std::vector<double> in = somov_i_bitwise_sorting_batcher_merge_mpi_seq::create_random_vector(3000001);
   std::vector<double> out(in.size(), 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/perf_tests/main.cpp
@@ -21,7 +21,7 @@ std::vector<double> create_random_vector(int size, double mean = 5.0, double std
   return tmp;
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, pipeline) {
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_pipeline_3000000_el) {
   std::vector<double> in = create_random_vector(3000000);
   std::vector<double> out(in.size(), 0);
 
@@ -50,7 +50,7 @@ TEST(somov_i_bitwise_sorting_batcher_merge_seq, pipeline) {
   ppc::core::Perf::print_perf_statistic(perfResults);
 }
 
-TEST(somov_i_bitwise_sorting_batcher_merge_seq, task) {
+TEST(somov_i_bitwise_sorting_batcher_merge_seq, test_task_3000000_el) {
   std::vector<double> in = create_random_vector(3000000);
   std::vector<double> out(in.size(), 0);
 

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/src/ops_seq.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/src/ops_seq.cpp
@@ -1,0 +1,96 @@
+#include "seq/somov_i_bitwise_sorting_batcher_merge/include/ops_seq.hpp"
+
+void countingSortByByte(std::vector<uint64_t> &data, std::vector<uint64_t> &output, int byteIndex) {
+  const int base = 256;
+  std::array<int, base> count = {0};
+  for (uint64_t num : data) {
+    int byteValue = (num >> (byteIndex * 8)) & 0xFF;
+    count[byteValue]++;
+  }
+  for (int i = 1; i < base; i++) {
+    count[i] += count[i - 1];
+  }
+  for (int i = data.size() - 1; i >= 0; i--) {
+    int byteValue = (data[i] >> (byteIndex * 8)) & 0xFF;
+    output[--count[byteValue]] = data[i];
+  }
+}
+
+void radixSort(std::vector<uint64_t> &data) {
+  const int bytesCount = 8;
+  std::vector<uint64_t> temp(data.size());
+
+  for (int byteIndex = 0; byteIndex < bytesCount; byteIndex++) {
+    countingSortByByte(data, temp, byteIndex);
+    data.swap(temp);
+  }
+}
+
+void radix_sort_double(std::vector<double> &arr) {
+  size_t n = arr.size();
+  if (n == 0) return;
+
+  std::vector<double> positive, negative;
+  for (size_t i = 0; i < n; ++i) {
+    if (arr[i] < 0) {
+      negative.push_back(arr[i]);
+    } else {
+      positive.push_back(arr[i]);
+    }
+  }
+
+  std::vector<uint64_t> posData(positive.size());
+  for (size_t i = 0; i < positive.size(); ++i) {
+    std::memcpy(&posData[i], &positive[i], sizeof(double));
+  }
+
+  radixSort(posData);
+
+  for (size_t i = 0; i < positive.size(); ++i) {
+    std::memcpy(&positive[i], &posData[i], sizeof(double));
+  }
+
+  std::vector<uint64_t> negData(negative.size());
+  for (size_t i = 0; i < negative.size(); ++i) {
+    std::memcpy(&negData[i], &negative[i], sizeof(double));
+    negData[i] = ~negData[i];
+  }
+
+  radixSort(negData);
+
+  for (size_t i = 0; i < negative.size(); ++i) {
+    negData[i] = ~negData[i];
+    std::memcpy(&negative[i], &negData[i], sizeof(double));
+  }
+
+  arr.clear();
+  arr.insert(arr.end(), negative.begin(), negative.end());
+  arr.insert(arr.end(), positive.begin(), positive.end());
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential::pre_processing() {
+  internal_order_test();
+  input_.resize(taskData->inputs_count[0]);
+  auto *tmp_ptr = reinterpret_cast<double *>(taskData->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], input_.begin());
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential::validation() {
+  internal_order_test();
+  return taskData->inputs_count[0] > 0;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential::run() {
+  internal_order_test();
+  radix_sort_double(input_);
+  res_ = input_;
+  return true;
+}
+
+bool somov_i_bitwise_sorting_batcher_merge_seq::TestTaskSequential::post_processing() {
+  internal_order_test();
+  auto *tmp_ptr = reinterpret_cast<double *>(taskData->outputs[0]);
+  std::copy(res_.begin(), res_.end(), tmp_ptr);
+  return true;
+}

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/src/ops_seq.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/src/ops_seq.cpp
@@ -32,28 +32,31 @@ void radix_sort_double(std::vector<double> &arr) {
 
   std::vector<double> positive;
   std::vector<double> negative;
+  positive.reserve(n / 2);
+  negative.reserve(n / 2);
+
   for (size_t i = 0; i < n; ++i) {
     if (arr[i] < 0) {
-      negative.push_back(arr[i]);
+      negative.emplace_back(arr[i]);
     } else {
-      positive.push_back(arr[i]);
+      positive.emplace_back(arr[i]);
     }
   }
 
   std::vector<uint64_t> posData(positive.size());
   for (size_t i = 0; i < positive.size(); ++i) {
-    std::memcpy(&posData[i], &positive[i], sizeof(double));
+    posData[i] = *reinterpret_cast<uint64_t *>(&positive[i]);
   }
 
   radixSort(posData);
 
   for (size_t i = 0; i < positive.size(); ++i) {
-    std::memcpy(&positive[i], &posData[i], sizeof(double));
+    positive[i] = *reinterpret_cast<double *>(&posData[i]);
   }
 
   std::vector<uint64_t> negData(negative.size());
   for (size_t i = 0; i < negative.size(); ++i) {
-    std::memcpy(&negData[i], &negative[i], sizeof(double));
+    negData[i] = *reinterpret_cast<uint64_t *>(&negative[i]);
     negData[i] = ~negData[i];
   }
 
@@ -61,7 +64,7 @@ void radix_sort_double(std::vector<double> &arr) {
 
   for (size_t i = 0; i < negative.size(); ++i) {
     negData[i] = ~negData[i];
-    std::memcpy(&negative[i], &negData[i], sizeof(double));
+    negative[i] = *reinterpret_cast<double *>(&negData[i]);
   }
 
   arr.clear();

--- a/tasks/seq/somov_i_bitwise_sorting_batcher_merge/src/ops_seq.cpp
+++ b/tasks/seq/somov_i_bitwise_sorting_batcher_merge/src/ops_seq.cpp
@@ -30,7 +30,8 @@ void radix_sort_double(std::vector<double> &arr) {
   size_t n = arr.size();
   if (n == 0) return;
 
-  std::vector<double> positive, negative;
+  std::vector<double> positive;
+  std::vector<double> negative;
   for (size_t i = 0; i < n; ++i) {
     if (arr[i] < 0) {
       negative.push_back(arr[i]);


### PR DESCRIPTION
**1. SEQ (Последовательная версия):**

В последовательной версии алгоритма входной массив сортируется с использованием radix sort. Массив разбивается на положительные и отрицательные числа, которые преобразуются в целочисленное представление через reinterpret_cast и сортируются независимо друг от друга. Отрицательные числа инвертируются побитово перед сортировкой и восстанавливаются после. Затем два отсортированных массива объединяются, начиная с отрицательных чисел, обеспечивая корректный итоговый порядок.

**2. MPI (Параллельная версия):**

В параллельной реализации алгоритма массив данных распределяется между процессами с использованием MPI scatterv, при этом каждый процесс получает свою часть данных для обработки. На каждом процессе выполняется локальная сортировка с использованием radix sort. После локальной сортировки данные проходят через несколько фаз чётно-нечётного обмена (Odd-Even Merge Sort), где происходит обмен данными между соседними процессами. На каждой итерации данные сливаются и корректируются для сохранения глобального порядка. В финальной фазе все отсортированные подмассивы собираются на корневом процессе с помощью MPI gatherv для формирования окончательного отсортированного массива.