### PR TITLE
Крылов Михаил. Задача 3. Вариант 4. Умножение разреженных матриц. Элементы типа double.  Формат хранения матрицы – строковый (CRS).

### DIFF
--- a/tasks/mpi/krylov_m_crs_mmul/func_tests/main.cpp
+++ b/tasks/mpi/krylov_m_crs_mmul/func_tests/main.cpp
@@ -1,0 +1,279 @@
+#include <gtest/gtest.h>
+
+#include <random>
+#include <tuple>
+#include <utility>
+
+#include "../include/smmul_mpi.hpp"
+
+using TestElementType = double;
+
+class krylov_m_crs_mmul_test : public ::testing::TestWithParam<std::tuple<std::pair<size_t, size_t>, float>> {
+ protected:
+  boost::mpi::communicator world;
+
+  static krylov_m_crs_mmul::Matrix<TestElementType> generate_random_matrix(size_t rows, size_t cols,
+                                                                           TestElementType emin, TestElementType emax,
+                                                                           float density) {
+    const auto threshold = emin + ((emax - emin) * density);
+
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(emin, emax);
+
+    auto matrix = krylov_m_crs_mmul::Matrix<TestElementType>::create(rows, cols);
+    std::generate(matrix.storage.begin(), matrix.storage.end(), [&]() {
+      auto val = distr(gen);
+      return (val < threshold) ? val : 0;
+    });
+
+    return matrix;
+  }
+
+  void peform_mul_test(size_t lrows, size_t lcols, size_t rcols, TestElementType emin, TestElementType emax,
+                       float density) {
+    std::pair<krylov_m_crs_mmul::Matrix<TestElementType>, krylov_m_crs_mmul::Matrix<TestElementType>> in;
+    //
+    std::pair<krylov_m_crs_mmul::CRSMatrix<TestElementType>, krylov_m_crs_mmul::CRSMatrix<TestElementType>> sin;
+    krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+    auto taskData = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      in = {generate_random_matrix(lrows, lcols, emin, emax, density),
+            generate_random_matrix(lcols, rcols, emin, emax, density)};
+      sin = {krylov_m_crs_mmul::CRSMatrix<TestElementType>(in.first),
+             krylov_m_crs_mmul::CRSMatrix<TestElementType>(in.second)};
+
+      //
+      krylov_m_crs_mmul::fill_task_data(*taskData, sin.first, sin.second, sout);
+    }
+
+    //
+    krylov_m_crs_mmul::TaskParallel<TestElementType> task(taskData);
+    ASSERT_TRUE(task.validation());
+    task.pre_processing();
+    task.run();
+    task.post_processing();
+
+    if (world.rank() == 0) {
+      EXPECT_EQ(sout.densify(), in.first * in.second);
+    }
+  }
+
+  void perform_dimen_randomized_mul_test(size_t dmin, size_t dmax, TestElementType emin, TestElementType emax,
+                                         float density) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(dmin, dmax);
+
+    //
+    peform_mul_test(distr(gen), distr(gen), distr(gen), emin, emax, density);
+  }
+};
+
+TEST_P(krylov_m_crs_mmul_test, random_dimen_random_density) {
+  const auto &[dimens, density] = GetParam();
+  perform_dimen_randomized_mul_test(dimens.first, dimens.second, -128, 128, density);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, krylov_m_crs_mmul_test,
+    ::testing::Combine(
+      testing::Values(
+        std::make_pair(1, 2),
+        std::make_pair(2, 4),
+        std::make_pair(4, 8),
+        std::make_pair(8, 16),
+        std::make_pair(16, 24),
+        std::make_pair(24, 32),
+        std::make_pair(32, 48),
+        std::make_pair(48, 64)
+      ),
+      testing::Values(0.00f, 0.05f, 0.10f, 0.15f, 0.25f, 0.30f, 0.50f, 0.64f, 0.75f, 0.80f, 0.90, 1.00f)
+    )
+);
+// clang-format on
+
+TEST_F(krylov_m_crs_mmul_test, random_3_7_13) { peform_mul_test(3, 7, 13, -128, 128, 0.5f); }
+
+TEST_F(krylov_m_crs_mmul_test, bad_task_fail_validation) {
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> slhs{1, 3};
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> srhs{2, 2};
+
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    krylov_m_crs_mmul::fill_task_data(*taskData, slhs, srhs, sout);
+  }
+
+  krylov_m_crs_mmul::TaskParallel<TestElementType> task(taskData);
+  if (world.rank() == 0) {
+    EXPECT_FALSE(task.validation());
+  }
+}
+
+// clang-format off
+using MulTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* ref */
+>;
+// clang-format on
+
+class determined : public ::testing::TestWithParam<MulTestParam> {
+ protected:
+  boost::mpi::communicator world;
+
+  void SetUp() override {
+    const auto &[lhs, rhs, ref] = GetParam();
+
+    ASSERT_TRUE(lhs.check_integrity());
+    ASSERT_TRUE(rhs.check_integrity());
+    ASSERT_TRUE(ref.check_integrity());
+  }
+};
+
+TEST_P(determined, yields_correct_result) {
+  const auto &[lhs, rhs, ref] = GetParam();
+
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> slhs(lhs);
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> srhs(rhs);
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+  //
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    krylov_m_crs_mmul::fill_task_data(*taskData, slhs, srhs, sout);
+  }
+
+  //
+  krylov_m_crs_mmul::TaskParallel<TestElementType> task(taskData);
+  ASSERT_TRUE(task.validation());
+  task.pre_processing();
+  task.run();
+  task.post_processing();
+
+  if (world.rank() == 0) {
+    EXPECT_EQ(sout.densify(), ref);
+  }
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, determined,
+    ::testing::Values(
+      MulTestParam(
+        { 2, 2,
+          {
+            0, 0,
+            0, 0
+          }
+        },
+        { 2, 2,
+          {
+            0, 0,
+            0, 0
+          }
+        },
+        { 2, 2,
+          {
+            0, 0,
+            0, 0
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 2, 2,
+          {
+            4, 3,
+            7, 5
+          }
+        },
+        { 2, 2,
+          {
+            -28, 93,
+            38, -126
+          }
+        },
+        { 2, 2,
+          {
+            2, -6,
+            -6, 21
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 3, 3,
+          {
+            5, 3, -7,
+            -1, 6, -3,
+            2, -4, 1
+          }
+        },
+        { 3, 3,
+          {
+            4, -1, 3,
+            4, -2, -6,
+            2, 0, 3
+          }
+        },
+        { 3, 3,
+          {
+            18, -11, -24,
+            14, -11, -48,
+            -6, 6, 33
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 2, 3,
+          {
+            2, 4, 1,
+            1, 0, -2
+          }
+        },
+        { 3, 3,
+          {
+            7, 3, 2,
+            4, 1, 0,
+            2, -1, 6
+          }
+        },
+        { 2, 3,
+          {
+            32, 9, 10,
+            3, 5, -10
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 3, 3,
+          {
+            1,  0,  0,
+            1, -1,  0,
+            1,  0,  1
+          }
+        },
+        { 3, 3,
+          {
+            1,  0,  0,
+            1, -1,  0,
+            -1,  0,  1
+          }
+        },
+        { 3, 3,
+          {
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+          }
+        }
+      )
+    )
+);
+// clang-format on

--- a/tasks/mpi/krylov_m_crs_mmul/func_tests/matrix.cpp
+++ b/tasks/mpi/krylov_m_crs_mmul/func_tests/matrix.cpp
@@ -1,0 +1,268 @@
+#include "../include/matrix.hpp"
+
+#include <gtest/gtest.h>
+
+#include <random>
+#include <tuple>
+
+using TestElementType = int16_t;
+
+//
+
+// clang-format off
+using DenseMulTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* ref */
+>;
+// clang-format on
+
+class dense_mul : public ::testing::TestWithParam<DenseMulTestParam> {
+ protected:
+  void SetUp() override {
+    const auto &[lhs, rhs, ref] = GetParam();
+
+    ASSERT_TRUE(lhs.check_integrity());
+    ASSERT_TRUE(rhs.check_integrity());
+    ASSERT_TRUE(ref.check_integrity());
+    //
+    ASSERT_TRUE(ref.rows == lhs.rows);
+    ASSERT_TRUE(ref.cols == rhs.rows);
+  }
+};
+
+TEST_P(dense_mul, yields_correct_result) {
+  const auto &[lhs, rhs, ref] = GetParam();
+  EXPECT_EQ(lhs * rhs, ref);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, dense_mul,
+    ::testing::Values(
+      DenseMulTestParam(
+        { 2, 2,
+          {
+            4, 3,
+            7, 5
+          }
+        },
+        { 2, 2,
+          {
+            -28, 93,
+            38, -126
+          }
+        },
+        { 2, 2,
+          {
+            2, -6,
+            -6, 21
+          }
+        }
+      ),
+      //
+      DenseMulTestParam(
+        { 3, 3,
+          {
+            5, 3, -7,
+            -1, 6, -3,
+            2, -4, 1
+          }
+        },
+        { 3, 3,
+          {
+            4, -1, 3,
+            4, -2, -6,
+            2, 0, 3
+          }
+        },
+        { 3, 3,
+          {
+            18, -11, -24,
+            14, -11, -48,
+            -6, 6, 33
+          }
+        }
+      ),
+      //
+      DenseMulTestParam(
+        { 2, 3,
+          {
+            2, 4, 1,
+            1, 0, -2
+          }
+        },
+        { 3, 3,
+          {
+            7, 3, 2,
+            4, 1, 0,
+            2, -1, 6
+          }
+        },
+        { 2, 3,
+          {
+            32, 9, 10,
+            3, 5, -10
+          }
+        }
+      )
+    )
+);
+// clang-format on
+
+//
+
+// clang-format off
+using SparseConversionTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType>    /* dense  */,
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> /* sparse_ref */
+>;
+// clang-format on
+
+//
+
+class sparse_conversion : public ::testing::TestWithParam<SparseConversionTestParam> {
+  void SetUp() override {
+    const auto &[dense, sparse_ref] = GetParam();
+
+    ASSERT_TRUE(dense.check_integrity());
+    //
+    ASSERT_TRUE(dense.rows == sparse_ref.rows());
+    ASSERT_TRUE(dense.cols == sparse_ref.cols());
+  }
+};
+
+TEST_P(sparse_conversion, conversion_is_correct) {
+  const auto &[dense, sparse_ref] = GetParam();
+  EXPECT_EQ(krylov_m_crs_mmul::CRSMatrix<TestElementType>(dense), sparse_ref);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, sparse_conversion,
+    ::testing::Values(
+      SparseConversionTestParam(
+        { 7, 5,
+          {
+            8, 0, 2, 0, 0,
+            0, 0, 5, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 7, 1, 2,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 9, 0
+          }
+        },
+        {
+            { 0, 2, 3, 3, 3, 6, 6, 7}, 
+            { 0, 2, 2, 2, 3, 4, 3 },
+            { 8, 2, 5, 7, 1, 2, 9 },
+            5
+        }
+      )
+    )
+);
+// clang-format on
+
+//
+
+// clang-format off
+using SparseTranspositionTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType> /* dense_mat */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* dense_ref */
+>;
+// clang-format on
+
+//
+
+class sparse_transposition : public ::testing::TestWithParam<SparseTranspositionTestParam> {};
+
+TEST_P(sparse_transposition, conversion_is_correct) {
+  const auto &[dense_mat, dense_ref] = GetParam();
+  EXPECT_EQ(krylov_m_crs_mmul::CRSMatrix<TestElementType>(dense_mat).transpose(),
+            krylov_m_crs_mmul::CRSMatrix<TestElementType>(dense_ref));
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, sparse_transposition,
+    ::testing::Values(
+      SparseTranspositionTestParam(
+        { 7, 5,
+          {
+            8, 0, 2, 0, 0,
+            0, 0, 5, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 7, 1, 2,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 9, 0
+          }
+        },
+        { 5, 7,
+          {
+            8, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,
+            2, 5, 0, 0, 7, 0, 0,
+            0, 0, 0, 0, 1, 0, 9,
+            0, 0, 0, 0, 2, 0, 0
+          }
+        }
+      )
+    )
+);
+// clang-format on
+
+//
+
+class krylov_m_crs_mmul_test_generic : public ::testing::TestWithParam<krylov_m_crs_mmul::Matrix<TestElementType>> {
+ public:
+  static krylov_m_crs_mmul::Matrix<TestElementType> generate_random_matrix(size_t rows, size_t cols,
+                                                                           TestElementType emin, TestElementType emax,
+                                                                           float density) {
+    const TestElementType threshold = emin + ((emax - emin) * density);
+
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(emin, emax);
+
+    auto matrix = krylov_m_crs_mmul::Matrix<TestElementType>::create(rows, cols);
+    std::generate(matrix.storage.begin(), matrix.storage.end(), [&]() {
+      auto val = distr(gen);
+      return (val < threshold) ? val : 0;
+    });
+
+    return matrix;
+  }
+  static krylov_m_crs_mmul::Matrix<TestElementType> generate_random_size_matrix(size_t dmin, size_t dmax,
+                                                                                TestElementType emin,
+                                                                                TestElementType emax, float density) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(dmin, dmax);
+
+    return generate_random_matrix(distr(gen), distr(gen), emin, emax, density);
+  }
+};
+
+TEST_P(krylov_m_crs_mmul_test_generic, random_sparse_tests_conversion_is_idempotent) {
+  const auto dense = GetParam();
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> sparse(dense);
+  EXPECT_EQ(sparse.densify(), dense);
+}
+
+TEST_P(krylov_m_crs_mmul_test_generic, random_sparse_tests_transposition_is_idempotent) {
+  const auto dense = GetParam();
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> sparse(dense);
+  const auto transposed = sparse.transpose();
+  EXPECT_EQ(transposed.transpose(), sparse);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    krylov_m_crs_mmul_test_generic, krylov_m_crs_mmul_test_generic,
+    ::testing::Values(krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.00f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.10f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.25f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.30f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.50f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.64f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.75f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.90f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 1.00f)));

--- a/tasks/mpi/krylov_m_crs_mmul/include/matrix.hpp
+++ b/tasks/mpi/krylov_m_crs_mmul/include/matrix.hpp
@@ -1,0 +1,179 @@
+#include <cassert>
+#include <iostream>
+#include <optional>
+#include <ostream>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+namespace krylov_m_crs_mmul {
+
+namespace utils {
+template <class InputIt, class Delimiter = char>
+void iprint(std::ostream& os, InputIt first, InputIt last, Delimiter delimiter = ' ') {
+  if (last == first) return;
+  auto range = std::ranges::subrange{first, last};
+  for (const auto& e : range | std::views::take(last - first - 1)) {
+    os << e << delimiter;
+  }
+  os << range.back();
+}
+}  // namespace utils
+
+template <class T>
+struct Matrix {
+  template <class TT>
+  using Container = std::vector<TT>;
+
+  size_t rows;
+  size_t cols;
+  Container<T> storage;
+
+  bool check_integrity() const noexcept { return storage.size() == (rows * cols); }
+
+  const T& at(size_t row, size_t col) const noexcept {
+    const size_t idx = row * cols + col;
+    assert(idx < storage.size());
+    return storage[idx];
+  }
+  T& at(size_t row, size_t col) noexcept { return const_cast<T&>(std::as_const(*this).at(row, col)); }
+
+  bool operator==(const Matrix& other) const noexcept {
+    return rows == other.rows && cols == other.cols && storage == other.storage;
+  }
+
+  Matrix operator*(const Matrix& rhs) const {
+    auto res = create(this->rows, rhs.cols);
+    for (size_t i = 0; i < this->rows; i++) {
+      for (size_t j = 0; j < rhs.cols; j++) {
+        res.at(i, j) = 0;
+        for (size_t k = 0; k < rhs.rows; k++) {
+          res.at(i, j) += this->at(i, k) * rhs.at(k, j);
+        }
+      }
+    }
+    return res;
+  }
+
+  void read(const T* src) { storage.assign(src, src + rows * cols); }
+
+  friend std::ostream& operator<<(std::ostream& os, const Matrix& m) {
+    os << "M(" << m.rows << "," << m.cols << "): [";
+    utils::iprint(os, m.storage.begin(), m.storage.end());
+    os << ']';
+    return os;
+  }
+
+  static Matrix create(size_t rows, size_t cols) { return {rows, cols, Container<T>(rows * cols)}; }
+};
+
+template <typename T>
+struct CRSMatrix {
+  std::vector<size_t> row_pointers;
+  std::vector<size_t> col_indices;
+  std::vector<T> data;
+  size_t cols_;
+
+  //
+
+  CRSMatrix() = default;
+  CRSMatrix(size_t rows, size_t cols) : row_pointers(rows + 1, 0), cols_(cols) {}
+  CRSMatrix(std::vector<size_t> row_pointers_, std::vector<size_t> col_indices_, std::vector<T> data_, size_t cols)
+      : row_pointers(std::move(row_pointers_)),
+        col_indices(std::move(col_indices_)),
+        data(std::move(data_)),
+        cols_(cols) {}
+
+  explicit CRSMatrix(const Matrix<T>& dense) : CRSMatrix(dense.rows, dense.cols) {
+    size_t idx = 0;
+    for (size_t i = 0; i < dense.rows; ++i) {
+      size_t nz = 0;
+      for (size_t j = 0; j < dense.cols; ++j) {
+        const auto& el = dense.storage[idx++];
+        if (el == 0) {
+          continue;
+        }
+        ++nz;
+        col_indices.push_back(j);
+        data.push_back(el);
+      }
+      row_pointers[i + 1] = row_pointers[i] + nz;
+    }
+  }
+
+  size_t rows() const { return row_pointers.size() - 1; }
+  size_t cols() const { return cols_; }
+
+  bool operator==(const CRSMatrix& other) const noexcept {
+    return cols_ == other.cols_ && row_pointers == other.row_pointers && col_indices == other.col_indices &&
+           data == other.data;
+  }
+
+  std::optional<const T&> at(size_t row, size_t col) const {
+    for (size_t i = row_pointers[row]; i < row_pointers[row + 1]; ++i) {
+      if (col_indices[i] == col) {
+        return data[i];
+      }
+    }
+    return std::nullopt;
+  }
+
+  CRSMatrix transpose() const {
+    const auto [n, m] = std::make_pair(rows(), cols());
+
+    CRSMatrix res{m + 1, n};
+    res.col_indices.resize(col_indices.size(), 0);
+    res.data.resize(data.size(), 0);
+
+    for (size_t i = 0; i < data.size(); ++i) {
+      ++res.row_pointers[col_indices[i] + 2];
+    }
+
+    for (size_t i = 2; i < res.row_pointers.size(); ++i) {
+      res.row_pointers[i] += res.row_pointers[i - 1];
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+      for (size_t j = row_pointers[i]; j < row_pointers[i + 1]; ++j) {
+        const auto translated_idx = res.row_pointers[col_indices[j] + 1]++;
+        res.data[translated_idx] = data[j];
+        res.col_indices[translated_idx] = i;
+      }
+    }
+    res.row_pointers.pop_back();
+
+    return res;
+  }
+
+  Matrix<T> densify() const {
+    auto dense = Matrix<T>::create(rows(), cols());
+    for (size_t row = 0; row < dense.rows; ++row) {
+      for (size_t i = row_pointers[row]; i < row_pointers[row + 1]; ++i) {
+        dense.at(row, col_indices[i]) = data[i];
+      }
+    }
+    return dense;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const CRSMatrix& m) {
+    os << "CRS(" << m.rows() << "," << m.cols() << "): ";
+    os << "R/[";
+    utils::iprint(os, m.row_pointers.begin(), m.row_pointers.end());
+    os << "], C/[";
+    utils::iprint(os, m.col_indices.begin(), m.col_indices.end());
+    os << "], D/[";
+    utils::iprint(os, m.data.begin(), m.data.end());
+    os << "]";
+    return os;
+  }
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar & row_pointers;
+    ar & col_indices;
+    ar & data;
+    ar & cols_;
+  }
+};
+
+}  // namespace krylov_m_crs_mmul

--- a/tasks/mpi/krylov_m_crs_mmul/include/smmul_mpi.hpp
+++ b/tasks/mpi/krylov_m_crs_mmul/include/smmul_mpi.hpp
@@ -76,12 +76,7 @@ struct CRSMatrixChunk {
     }
   } offsets;
 
-  struct Storage {
-    std::vector<index_type_mut> row_pointers;
-    std::vector<index_type_mut> col_indices;
-    std::vector<std::remove_const_t<T>> data;
-  };
-  std::optional<Storage> storage{std::nullopt};
+  std::optional<CRSMatrix<std::remove_const_t<T>>> storage{std::nullopt};
 
   static CRSMatrixChunk from(std::span<index_type> row_pointers_, std::span<index_type> col_indices_,
                              std::span<T> data_, size_t cols_, const std::pair<index_type, index_type>& roff,
@@ -226,9 +221,6 @@ class TaskParallel : public TaskCommon<T> {
       partial_res.row_pointers[row + 1 - roff] = partial_res.data.size();
     }
 
-    if (world.rank() == 0) {
-      res_partials.clear();
-    }
     boost::mpi::gather(world, partial_res, res_partials, 0);
 
     return true;

--- a/tasks/mpi/krylov_m_crs_mmul/include/smmul_mpi.hpp
+++ b/tasks/mpi/krylov_m_crs_mmul/include/smmul_mpi.hpp
@@ -226,9 +226,8 @@ class TaskParallel : public TaskCommon<T> {
       partial_res.row_pointers[row + 1 - roff] = partial_res.data.size();
     }
 
-    if (world.size() == 0) {
+    if (world.rank() == 0) {
       res_partials.clear();
-      res_partials.resize(world.size());
     }
     boost::mpi::gather(world, partial_res, res_partials, 0);
 

--- a/tasks/mpi/krylov_m_crs_mmul/include/smmul_mpi.hpp
+++ b/tasks/mpi/krylov_m_crs_mmul/include/smmul_mpi.hpp
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <boost/serialization/vector.hpp>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <numeric>
+#include <span>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "./matrix.hpp"
+#include "boost/mpi/collectives/broadcast.hpp"
+#include "boost/mpi/collectives/gather.hpp"
+#include "boost/mpi/communicator.hpp"
+#include "boost/serialization/array_wrapper.hpp"
+#include "core/task/include/task.hpp"
+
+namespace krylov_m_crs_mmul {
+
+template <typename T>
+class TaskCommon : public ppc::core::Task {
+ public:
+  explicit TaskCommon(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+
+  bool validation() override {
+    internal_order_test();
+
+    return taskData->inputs.size() == 2 && taskData->inputs_count.size() == 4 && taskData->outputs.size() == 1 &&
+           // (lhs.cols == rhs.rows)
+           (taskData->inputs_count[1] == taskData->inputs_count[2]) &&
+           // lhs.rows > 0 && lhs.cols > 0 && rhs.rows > 0 [&& rhs.cols > 0] - true by definition
+           (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[2] > 0);
+  }
+
+  bool pre_processing() override {
+    internal_order_test();
+
+    input = {*reinterpret_cast<CRSMatrix<T>*>(taskData->inputs[0]),
+             reinterpret_cast<CRSMatrix<T>*>(taskData->inputs[1])->transpose()};
+
+    return true;
+  }
+
+  bool post_processing() override {
+    internal_order_test();
+
+    *reinterpret_cast<CRSMatrix<T>*>(taskData->outputs[0]) = res;
+
+    return true;
+  }
+
+ protected:
+  std::pair<CRSMatrix<T>, CRSMatrix<T>> input;
+  CRSMatrix<T> res;
+};
+
+template <typename T, typename index_type = size_t>
+struct CRSMatrixChunk {
+  using index_type_mut = std::remove_const_t<index_type>;
+
+  std::span<index_type> row_pointers;
+  std::span<index_type> col_indices;
+  std::span<T> data;
+  index_type_mut cols;
+  //
+  struct {
+    index_type_mut row;
+    index_type_mut idx;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version) {
+      ar & row;
+      ar & idx;
+    }
+  } offsets;
+
+  struct Storage {
+    std::vector<index_type_mut> row_pointers;
+    std::vector<index_type_mut> col_indices;
+    std::vector<std::remove_const_t<T>> data;
+  };
+  std::optional<Storage> storage{std::nullopt};
+
+  static CRSMatrixChunk from(std::span<index_type> row_pointers_, std::span<index_type> col_indices_,
+                             std::span<T> data_, size_t cols_, const std::pair<index_type, index_type>& roff,
+                             const std::pair<index_type, index_type>& off) {
+    const auto& [rbegin, rend] = roff;
+    const auto& [begin, end] = off;
+    return {.row_pointers = {row_pointers_.begin() + rbegin, rend - rbegin + 1},
+            .col_indices = {col_indices_.begin() + begin, end - begin},
+            .data = {data_.begin() + begin, end - begin},
+            .cols = cols_,
+            .offsets = {.row = rbegin, .idx = begin}};
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const CRSMatrixChunk& m) {
+    os << "CRSc(" << m.row_pointers.size() << "," << m.cols << "): ";
+    os << "R/[";
+    utils::iprint(os, m.row_pointers.begin(), m.row_pointers.end());
+    os << "], C/[";
+    utils::iprint(os, m.col_indices.begin(), m.col_indices.end());
+    os << "], D/[";
+    utils::iprint(os, m.data.begin(), m.data.end());
+    os << "]";
+    return os;
+  }
+
+ public:
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    size_t rows = row_pointers.size();
+    size_t nz = data.size();
+    //
+    ar & rows;
+    ar & nz;
+
+    if constexpr (Archive::is_loading::value) {
+      storage.emplace();
+      //
+      storage->row_pointers.resize(rows);
+      storage->col_indices.resize(nz);
+      storage->data.resize(nz);
+      //
+      row_pointers = storage->row_pointers;
+      col_indices = storage->col_indices;
+      data = storage->data;
+    }
+
+    ar & cols;
+    ar & offsets;
+    ar& boost::serialization::make_array(as_mut(row_pointers.data()), row_pointers.size());
+    ar& boost::serialization::make_array(as_mut(col_indices.data()), col_indices.size());
+    ar& boost::serialization::make_array(as_mut(data.data()), data.size());
+  }
+
+ private:
+  // better to put it as a lambda to ::serialize, but compiler in CI is not fresh enough
+  template <typename V>
+  static constexpr V* as_mut(const V* v) {
+    return const_cast<V*>(v);
+  };
+};
+
+template <typename T>
+class TaskParallel : public TaskCommon<T> {
+ public:
+  explicit TaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : TaskParallel::TaskCommon(std::move(taskData_)) {}
+
+  bool validation() override {
+    if (world.rank() != 0) {
+      this->internal_order_test();
+      return true;
+    }
+    return TaskParallel::TaskCommon::validation();
+  }
+
+  bool pre_processing() override {
+    if (world.rank() != 0) {
+      this->internal_order_test();
+      return true;
+    }
+    return TaskParallel::TaskCommon::pre_processing();
+  }
+
+  bool run() override {
+    this->internal_order_test();
+
+    boost::mpi::broadcast(world, this->input.second, 0);
+    //
+    CRSMatrixChunk<const T, const size_t> partial_lhs;
+    const auto& rhs = this->input.second;
+
+    if (world.rank() == 0) {
+      const auto& lhs = this->input.first;
+
+      const auto distrib = distribute(lhs.rows(), world.size());
+
+      const auto initial_roff = std::make_pair(0, distrib[0]);
+      auto roff = initial_roff;
+      auto& [rbegin, rend] = roff;
+
+      const auto world_size = world.size();
+      for (int p = 1; p < world_size; p++) {
+        rbegin = rend;
+        rend += distrib[p];
+
+        const auto off = std::make_pair(lhs.row_pointers[rbegin], lhs.row_pointers[rend]);
+        partial_lhs = decltype(partial_lhs)::from(lhs.row_pointers, lhs.col_indices, lhs.data, lhs.cols_, roff, off);
+        world.send(p, 0, partial_lhs);
+      }
+      partial_lhs = decltype(partial_lhs)::from(
+          lhs.row_pointers, lhs.col_indices, lhs.data, lhs.cols_, initial_roff,
+          std::make_pair(lhs.row_pointers[initial_roff.first], lhs.row_pointers[initial_roff.second]));
+    } else {
+      world.recv(0, 0, partial_lhs);
+    }
+
+    const auto [partial_rows, cols] =
+        std::make_pair(partial_lhs.row_pointers.size() - 1, rhs.rows());  // rhs was transposed
+    const auto& [roff, ioff] = partial_lhs.offsets;
+    CRSMatrix<T> partial_res(partial_rows, cols);
+
+    for (size_t row = roff; row < roff + partial_rows; row++) {
+      for (size_t col = 0; col < cols; col++) {
+        auto [il, ir] = std::make_pair(partial_lhs.row_pointers[row - roff], rhs.row_pointers[col]);
+        T sum{};
+        while (il < partial_lhs.row_pointers[row + 1 - roff] && ir < rhs.row_pointers[col + 1]) {
+          if (partial_lhs.col_indices[il - ioff] < rhs.col_indices[ir]) {
+            il++;
+          } else if (partial_lhs.col_indices[il - ioff] > rhs.col_indices[ir]) {
+            ir++;
+          } else {  // ==
+            sum += partial_lhs.data[il - ioff] * rhs.data[ir];
+            il++;
+            ir++;
+          }
+        }
+        if (sum != 0) {
+          partial_res.data.push_back(sum);
+          partial_res.col_indices.push_back(col);
+        }
+      }
+      partial_res.row_pointers[row + 1 - roff] = partial_res.data.size();
+    }
+
+    if (world.size() == 0) {
+      res_partials.clear();
+      res_partials.resize(world.size());
+    }
+    boost::mpi::gather(world, partial_res, res_partials, 0);
+
+    return true;
+  }
+
+  bool post_processing() override {
+    if (world.rank() != 0) {
+      this->internal_order_test();
+      return true;
+    }
+
+    const auto size = std::accumulate(res_partials.begin(), res_partials.end(), size_t(0),
+                                      [](size_t acc, CRSMatrix<T> chunks) { return acc + chunks.data.size(); });
+
+    // REQUIREMENT: CRSMatrix::row_pointers capacity should be adjusted by the constructor below
+    this->res = decltype(this->res)(this->input.first.rows(), this->input.second.rows());  // rhs was transposed
+    this->res.col_indices.resize(size);
+    this->res.data.resize(size);
+
+    auto it_rowp = this->res.row_pointers.begin() + 1;
+    auto it_cols = this->res.col_indices.begin();
+    auto it_data = this->res.data.begin();
+    //
+    size_t nz = 0;
+    for (const auto& chunk : res_partials) {
+      auto prev_it_rowp = it_rowp;
+
+      it_rowp = std::copy(chunk.row_pointers.begin() + 1, chunk.row_pointers.end(), it_rowp);
+      it_cols = std::copy(chunk.col_indices.begin(), chunk.col_indices.end(), it_cols);
+      it_data = std::copy(chunk.data.begin(), chunk.data.end(), it_data);
+
+      for (auto& rp : std::ranges::subrange{prev_it_rowp, it_rowp}) {
+        rp += nz;
+      }
+      nz = *(it_rowp - 1);
+    }
+
+    return TaskParallel::TaskCommon::post_processing();
+  }
+
+ private:
+  static std::vector<size_t> distribute(size_t amount, size_t subject) {
+    const auto avg = amount / subject;
+    const auto ext = amount % subject;
+
+    std::vector<size_t> distr(subject, avg);
+    std::for_each(distr.begin(), distr.begin() + ext, [](auto& e) { ++e; });
+
+    return distr;
+  }
+
+  boost::mpi::communicator world;
+  std::vector<CRSMatrix<T>> res_partials;
+};
+
+template <class T>
+void fill_task_data(ppc::core::TaskData& data, const CRSMatrix<T>& lhs, const CRSMatrix<T>& rhs, CRSMatrix<T>& out) {
+  data.inputs.emplace_back(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&lhs)));
+  data.inputs_count.emplace_back(lhs.rows());
+  data.inputs_count.emplace_back(lhs.cols());
+  //
+  data.inputs.emplace_back(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&rhs)));
+  data.inputs_count.emplace_back(rhs.rows());
+  data.inputs_count.emplace_back(rhs.cols());
+
+  data.outputs.emplace_back(reinterpret_cast<uint8_t*>(&out));
+}
+
+}  // namespace krylov_m_crs_mmul

--- a/tasks/mpi/krylov_m_crs_mmul/perf_tests/main.cpp
+++ b/tasks/mpi/krylov_m_crs_mmul/perf_tests/main.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <memory>
+#include <random>
+
+#include "../include/smmul_mpi.hpp"
+#include "boost/mpi/communicator.hpp"
+#include "core/perf/include/perf.hpp"
+
+class krylov_m_crs_mmul_mpi_test : public ::testing::Test {
+  using TestElementType = double;
+  static constexpr float Density = 0.10f;
+
+  static constexpr size_t lrows = 411;
+  static constexpr size_t lcols = 411;
+  static constexpr size_t rcols = 411;
+  //
+  static constexpr TestElementType emin = -128;
+  static constexpr TestElementType emax = 128;
+
+ protected:
+  boost::mpi::communicator world;
+
+  void run_perf_test(
+      const std::function<void(ppc::core::Perf &perfAnalyzer, const std::shared_ptr<ppc::core::PerfAttr> &perfAttr,
+                               const std::shared_ptr<ppc::core::PerfResults> &perfResults)> &runner) {
+    std::pair<krylov_m_crs_mmul::Matrix<TestElementType>, krylov_m_crs_mmul::Matrix<TestElementType>> in;
+    //
+
+    std::pair<krylov_m_crs_mmul::CRSMatrix<TestElementType>, krylov_m_crs_mmul::CRSMatrix<TestElementType>> sin;
+    krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+    auto taskData = std::make_shared<ppc::core::TaskData>();
+    if (world.rank() == 0) {
+      in = {generate_random_matrix<TestElementType>(lrows, lcols, emin, emax, Density),
+            generate_random_matrix<TestElementType>(lcols, rcols, emin, emax, Density)};
+      //
+      sin = {krylov_m_crs_mmul::CRSMatrix<TestElementType>(in.first),
+             krylov_m_crs_mmul::CRSMatrix<TestElementType>(in.second)};
+
+      krylov_m_crs_mmul::fill_task_data(*taskData, sin.first, sin.second, sout);
+    }
+
+    //
+    auto task = std::make_shared<krylov_m_crs_mmul::TaskParallel<TestElementType>>(taskData);
+
+    //
+    auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+    perfAttr->num_running = 10;
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    perfAttr->current_timer = [&] {
+      auto current_time_point = std::chrono::high_resolution_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+      return static_cast<double>(duration) * 1e-9;
+    };
+
+    //
+    auto perfResults = std::make_shared<ppc::core::PerfResults>();
+    ppc::core::Perf perfAnalyzer(task);
+    runner(perfAnalyzer, perfAttr, perfResults);
+    if (world.rank() == 0) {
+      ppc::core::Perf::print_perf_statistic(perfResults);
+    }
+  }
+
+  template <typename T>
+  static krylov_m_crs_mmul::Matrix<T> generate_random_matrix(size_t rows, size_t cols, T emin, T emax, float density) {
+    const T threshold = emin + ((emax - emin) * density);
+
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(emin, emax);
+
+    auto matrix = krylov_m_crs_mmul::Matrix<T>::create(rows, cols);
+    std::generate(matrix.storage.begin(), matrix.storage.end(), [&]() {
+      auto val = distr(gen);
+      return (val < threshold) ? val : 0;
+    });
+
+    return matrix;
+  }
+};
+
+TEST_F(krylov_m_crs_mmul_mpi_test, test_pipeline_run) {
+  run_perf_test([](auto &perfAnalyzer, const auto &perfAttr, const auto &perfResults) {
+    perfAnalyzer.pipeline_run(perfAttr, perfResults);
+  });
+}
+
+TEST_F(krylov_m_crs_mmul_mpi_test, test_task_run) {
+  run_perf_test([](auto &perfAnalyzer, const auto &perfAttr, const auto &perfResults) {
+    perfAnalyzer.task_run(perfAttr, perfResults);
+  });
+}

--- a/tasks/mpi/krylov_m_crs_mmul/src/smmul_mpi.cpp
+++ b/tasks/mpi/krylov_m_crs_mmul/src/smmul_mpi.cpp
@@ -1,0 +1,1 @@
+#include "../include/smmul_mpi.hpp"

--- a/tasks/seq/krylov_m_crs_mmul/func_tests/main.cpp
+++ b/tasks/seq/krylov_m_crs_mmul/func_tests/main.cpp
@@ -1,0 +1,258 @@
+#include <gtest/gtest.h>
+
+#include <random>
+#include <tuple>
+
+#include "../include/smmul_seq.hpp"
+
+using TestElementType = double;
+
+class krylov_m_crs_mmul_test : public ::testing::TestWithParam<std::tuple<std::pair<size_t, size_t>, float>> {
+ protected:
+  static krylov_m_crs_mmul::Matrix<TestElementType> generate_random_matrix(size_t rows, size_t cols,
+                                                                           TestElementType emin, TestElementType emax,
+                                                                           float density) {
+    const auto threshold = emin + ((emax - emin) * density);
+
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(emin, emax);
+
+    auto matrix = krylov_m_crs_mmul::Matrix<TestElementType>::create(rows, cols);
+    std::generate(matrix.storage.begin(), matrix.storage.end(), [&]() {
+      auto val = distr(gen);
+      return (val < threshold) ? val : 0;
+    });
+
+    return matrix;
+  }
+
+  static void peform_mul_test(size_t lrows, size_t lcols, size_t rcols, TestElementType emin, TestElementType emax,
+                              float density) {
+    const auto lhs = generate_random_matrix(lrows, lcols, emin, emax, density);
+    const auto rhs = generate_random_matrix(lcols, rcols, emin, emax, density);
+
+    const krylov_m_crs_mmul::CRSMatrix<TestElementType> slhs(lhs);
+    const krylov_m_crs_mmul::CRSMatrix<TestElementType> srhs(rhs);
+    krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+    //
+    auto taskData = std::make_shared<ppc::core::TaskData>();
+    krylov_m_crs_mmul::fill_task_data(*taskData, slhs, srhs, sout);
+
+    //
+    krylov_m_crs_mmul::TaskSequential<TestElementType> task(taskData);
+    ASSERT_TRUE(task.validation());
+    task.pre_processing();
+    task.run();
+    task.post_processing();
+
+    EXPECT_EQ(sout.densify(), lhs * rhs);
+  }
+
+  static void perform_dimen_randomized_mul_test(size_t dmin, size_t dmax, TestElementType emin, TestElementType emax,
+                                                float density) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(dmin, dmax);
+
+    //
+    peform_mul_test(distr(gen), distr(gen), distr(gen), emin, emax, density);
+  }
+};
+
+TEST_P(krylov_m_crs_mmul_test, random_dimen_random_density) {
+  const auto &[dimens, density] = GetParam();
+  perform_dimen_randomized_mul_test(dimens.first, dimens.second, -128, 128, density);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, krylov_m_crs_mmul_test,
+    ::testing::Combine(
+      testing::Values(
+        std::make_pair(1, 2),
+        std::make_pair(2, 4),
+        std::make_pair(4, 8),
+        std::make_pair(8, 16),
+        std::make_pair(16, 24),
+        std::make_pair(24, 32),
+        std::make_pair(32, 48),
+        std::make_pair(48, 64)
+      ),
+      testing::Values(0.00f, 0.05f, 0.10f, 0.15f, 0.25f, 0.30f, 0.50f, 0.64f, 0.75f, 0.80f, 0.90, 1.00f)
+    )
+);
+// clang-format on
+
+TEST_F(krylov_m_crs_mmul_test, random_3_7_13) { peform_mul_test(3, 7, 13, -128, 128, 0.5f); }
+
+TEST_F(krylov_m_crs_mmul_test, bad_task_fail_validation) {
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> slhs{1, 3};
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> srhs{2, 2};
+
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  krylov_m_crs_mmul::fill_task_data(*taskData, slhs, srhs, sout);
+
+  krylov_m_crs_mmul::TaskSequential<TestElementType> task(taskData);
+  EXPECT_FALSE(task.validation());
+}
+
+// clang-format off
+using MulTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* ref */
+>;
+// clang-format on
+
+class determined : public ::testing::TestWithParam<MulTestParam> {
+ protected:
+  void SetUp() override {
+    const auto &[lhs, rhs, ref] = GetParam();
+
+    ASSERT_TRUE(lhs.check_integrity());
+    ASSERT_TRUE(rhs.check_integrity());
+    ASSERT_TRUE(ref.check_integrity());
+  }
+};
+
+TEST_P(determined, yields_correct_result) {
+  const auto &[lhs, rhs, ref] = GetParam();
+
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> slhs(lhs);
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> srhs(rhs);
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+  //
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  krylov_m_crs_mmul::fill_task_data(*taskData, slhs, srhs, sout);
+
+  //
+  krylov_m_crs_mmul::TaskSequential<TestElementType> task(taskData);
+  ASSERT_TRUE(task.validation());
+  task.pre_processing();
+  task.run();
+  task.post_processing();
+
+  EXPECT_EQ(sout.densify(), ref);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, determined,
+    ::testing::Values(
+      MulTestParam(
+        { 2, 2,
+          {
+            0, 0,
+            0, 0
+          }
+        },
+        { 2, 2,
+          {
+            0, 0,
+            0, 0
+          }
+        },
+        { 2, 2,
+          {
+            0, 0,
+            0, 0
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 2, 2,
+          {
+            4, 3,
+            7, 5
+          }
+        },
+        { 2, 2,
+          {
+            -28, 93,
+            38, -126
+          }
+        },
+        { 2, 2,
+          {
+            2, -6,
+            -6, 21
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 3, 3,
+          {
+            5, 3, -7,
+            -1, 6, -3,
+            2, -4, 1
+          }
+        },
+        { 3, 3,
+          {
+            4, -1, 3,
+            4, -2, -6,
+            2, 0, 3
+          }
+        },
+        { 3, 3,
+          {
+            18, -11, -24,
+            14, -11, -48,
+            -6, 6, 33
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 2, 3,
+          {
+            2, 4, 1,
+            1, 0, -2
+          }
+        },
+        { 3, 3,
+          {
+            7, 3, 2,
+            4, 1, 0,
+            2, -1, 6
+          }
+        },
+        { 2, 3,
+          {
+            32, 9, 10,
+            3, 5, -10
+          }
+        }
+      ),
+      //
+      MulTestParam(
+        { 3, 3,
+          {
+            1,  0,  0,
+            1, -1,  0,
+            1,  0,  1
+          }
+        },
+        { 3, 3,
+          {
+            1,  0,  0,
+            1, -1,  0,
+            -1,  0,  1
+          }
+        },
+        { 3, 3,
+          {
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+          }
+        }
+      )
+    )
+);
+// clang-format on

--- a/tasks/seq/krylov_m_crs_mmul/func_tests/matrix.cpp
+++ b/tasks/seq/krylov_m_crs_mmul/func_tests/matrix.cpp
@@ -1,0 +1,268 @@
+#include "../include/matrix.hpp"
+
+#include <gtest/gtest.h>
+
+#include <random>
+#include <tuple>
+
+using TestElementType = int16_t;
+
+//
+
+// clang-format off
+using DenseMulTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* lhs */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* ref */
+>;
+// clang-format on
+
+class dense_mul : public ::testing::TestWithParam<DenseMulTestParam> {
+ protected:
+  void SetUp() override {
+    const auto &[lhs, rhs, ref] = GetParam();
+
+    ASSERT_TRUE(lhs.check_integrity());
+    ASSERT_TRUE(rhs.check_integrity());
+    ASSERT_TRUE(ref.check_integrity());
+    //
+    ASSERT_TRUE(ref.rows == lhs.rows);
+    ASSERT_TRUE(ref.cols == rhs.rows);
+  }
+};
+
+TEST_P(dense_mul, yields_correct_result) {
+  const auto &[lhs, rhs, ref] = GetParam();
+  EXPECT_EQ(lhs * rhs, ref);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, dense_mul,
+    ::testing::Values(
+      DenseMulTestParam(
+        { 2, 2,
+          {
+            4, 3,
+            7, 5
+          }
+        },
+        { 2, 2,
+          {
+            -28, 93,
+            38, -126
+          }
+        },
+        { 2, 2,
+          {
+            2, -6,
+            -6, 21
+          }
+        }
+      ),
+      //
+      DenseMulTestParam(
+        { 3, 3,
+          {
+            5, 3, -7,
+            -1, 6, -3,
+            2, -4, 1
+          }
+        },
+        { 3, 3,
+          {
+            4, -1, 3,
+            4, -2, -6,
+            2, 0, 3
+          }
+        },
+        { 3, 3,
+          {
+            18, -11, -24,
+            14, -11, -48,
+            -6, 6, 33
+          }
+        }
+      ),
+      //
+      DenseMulTestParam(
+        { 2, 3,
+          {
+            2, 4, 1,
+            1, 0, -2
+          }
+        },
+        { 3, 3,
+          {
+            7, 3, 2,
+            4, 1, 0,
+            2, -1, 6
+          }
+        },
+        { 2, 3,
+          {
+            32, 9, 10,
+            3, 5, -10
+          }
+        }
+      )
+    )
+);
+// clang-format on
+
+//
+
+// clang-format off
+using SparseConversionTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType>    /* dense  */,
+  krylov_m_crs_mmul::CRSMatrix<TestElementType> /* sparse_ref */
+>;
+// clang-format on
+
+//
+
+class sparse_conversion : public ::testing::TestWithParam<SparseConversionTestParam> {
+  void SetUp() override {
+    const auto &[dense, sparse_ref] = GetParam();
+
+    ASSERT_TRUE(dense.check_integrity());
+    //
+    ASSERT_TRUE(dense.rows == sparse_ref.rows());
+    ASSERT_TRUE(dense.cols == sparse_ref.cols());
+  }
+};
+
+TEST_P(sparse_conversion, conversion_is_correct) {
+  const auto &[dense, sparse_ref] = GetParam();
+  EXPECT_EQ(krylov_m_crs_mmul::CRSMatrix<TestElementType>(dense), sparse_ref);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, sparse_conversion,
+    ::testing::Values(
+      SparseConversionTestParam(
+        { 7, 5,
+          {
+            8, 0, 2, 0, 0,
+            0, 0, 5, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 7, 1, 2,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 9, 0
+          }
+        },
+        {
+            { 0, 2, 3, 3, 3, 6, 6, 7}, 
+            { 0, 2, 2, 2, 3, 4, 3 },
+            { 8, 2, 5, 7, 1, 2, 9 },
+            5
+        }
+      )
+    )
+);
+// clang-format on
+
+//
+
+// clang-format off
+using SparseTranspositionTestParam = std::tuple<
+  krylov_m_crs_mmul::Matrix<TestElementType> /* dense_mat */,
+  krylov_m_crs_mmul::Matrix<TestElementType> /* dense_ref */
+>;
+// clang-format on
+
+//
+
+class sparse_transposition : public ::testing::TestWithParam<SparseTranspositionTestParam> {};
+
+TEST_P(sparse_transposition, conversion_is_correct) {
+  const auto &[dense_mat, dense_ref] = GetParam();
+  EXPECT_EQ(krylov_m_crs_mmul::CRSMatrix<TestElementType>(dense_mat).transpose(),
+            krylov_m_crs_mmul::CRSMatrix<TestElementType>(dense_ref));
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_crs_mmul_test, sparse_transposition,
+    ::testing::Values(
+      SparseTranspositionTestParam(
+        { 7, 5,
+          {
+            8, 0, 2, 0, 0,
+            0, 0, 5, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 7, 1, 2,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 9, 0
+          }
+        },
+        { 5, 7,
+          {
+            8, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,
+            2, 5, 0, 0, 7, 0, 0,
+            0, 0, 0, 0, 1, 0, 9,
+            0, 0, 0, 0, 2, 0, 0
+          }
+        }
+      )
+    )
+);
+// clang-format on
+
+//
+
+class krylov_m_crs_mmul_test_generic : public ::testing::TestWithParam<krylov_m_crs_mmul::Matrix<TestElementType>> {
+ public:
+  static krylov_m_crs_mmul::Matrix<TestElementType> generate_random_matrix(size_t rows, size_t cols,
+                                                                           TestElementType emin, TestElementType emax,
+                                                                           float density) {
+    const TestElementType threshold = emin + ((emax - emin) * density);
+
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(emin, emax);
+
+    auto matrix = krylov_m_crs_mmul::Matrix<TestElementType>::create(rows, cols);
+    std::generate(matrix.storage.begin(), matrix.storage.end(), [&]() {
+      auto val = distr(gen);
+      return (val < threshold) ? val : 0;
+    });
+
+    return matrix;
+  }
+  static krylov_m_crs_mmul::Matrix<TestElementType> generate_random_size_matrix(size_t dmin, size_t dmax,
+                                                                                TestElementType emin,
+                                                                                TestElementType emax, float density) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(dmin, dmax);
+
+    return generate_random_matrix(distr(gen), distr(gen), emin, emax, density);
+  }
+};
+
+TEST_P(krylov_m_crs_mmul_test_generic, random_sparse_tests_conversion_is_idempotent) {
+  const auto dense = GetParam();
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> sparse(dense);
+  EXPECT_EQ(sparse.densify(), dense);
+}
+
+TEST_P(krylov_m_crs_mmul_test_generic, random_sparse_tests_transposition_is_idempotent) {
+  const auto dense = GetParam();
+  const krylov_m_crs_mmul::CRSMatrix<TestElementType> sparse(dense);
+  const auto transposed = sparse.transpose();
+  EXPECT_EQ(transposed.transpose(), sparse);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    krylov_m_crs_mmul_test_generic, krylov_m_crs_mmul_test_generic,
+    ::testing::Values(krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.00f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.10f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.25f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.30f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.50f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.64f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.75f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 0.90f),
+                      krylov_m_crs_mmul_test_generic::generate_random_size_matrix(1, 16, -128, 128, 1.00f)));

--- a/tasks/seq/krylov_m_crs_mmul/include/matrix.hpp
+++ b/tasks/seq/krylov_m_crs_mmul/include/matrix.hpp
@@ -1,0 +1,171 @@
+#include <cassert>
+#include <iostream>
+#include <optional>
+#include <ostream>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+namespace krylov_m_crs_mmul {
+
+namespace utils {
+template <class InputIt, class Delimiter = char>
+void iprint(std::ostream& os, InputIt first, InputIt last, Delimiter delimiter = ' ') {
+  if (last == first) return;
+  auto range = std::ranges::subrange{first, last};
+  for (const auto& e : range | std::views::take(last - first - 1)) {
+    os << e << delimiter;
+  }
+  os << range.back();
+}
+}  // namespace utils
+
+template <class T>
+struct Matrix {
+  template <class TT>
+  using Container = std::vector<TT>;
+
+  size_t rows;
+  size_t cols;
+  Container<T> storage;
+
+  bool check_integrity() const noexcept { return storage.size() == (rows * cols); }
+
+  const T& at(size_t row, size_t col) const noexcept {
+    const size_t idx = row * cols + col;
+    assert(idx < storage.size());
+    return storage[idx];
+  }
+  T& at(size_t row, size_t col) noexcept { return const_cast<T&>(std::as_const(*this).at(row, col)); }
+
+  bool operator==(const Matrix& other) const noexcept {
+    return rows == other.rows && cols == other.cols && storage == other.storage;
+  }
+
+  Matrix operator*(const Matrix& rhs) const {
+    auto res = create(this->rows, rhs.cols);
+    for (size_t i = 0; i < this->rows; i++) {
+      for (size_t j = 0; j < rhs.cols; j++) {
+        res.at(i, j) = 0;
+        for (size_t k = 0; k < rhs.rows; k++) {
+          res.at(i, j) += this->at(i, k) * rhs.at(k, j);
+        }
+      }
+    }
+    return res;
+  }
+
+  void read(const T* src) { storage.assign(src, src + rows * cols); }
+
+  friend std::ostream& operator<<(std::ostream& os, const Matrix& m) {
+    os << "M(" << m.rows << "," << m.cols << "): [";
+    utils::iprint(os, m.storage.begin(), m.storage.end());
+    os << ']';
+    return os;
+  }
+
+  static Matrix create(size_t rows, size_t cols) { return {rows, cols, Container<T>(rows * cols)}; }
+};
+
+template <typename T>
+struct CRSMatrix {
+  std::vector<size_t> row_pointers;
+  std::vector<size_t> col_indices;
+  std::vector<T> data;
+  size_t cols_;
+
+  //
+
+  CRSMatrix() = default;
+  CRSMatrix(size_t rows, size_t cols) : row_pointers(rows + 1, 0), cols_(cols) {}
+  CRSMatrix(std::vector<size_t> row_pointers_, std::vector<size_t> col_indices_, std::vector<T> data_, size_t cols)
+      : row_pointers(std::move(row_pointers_)),
+        col_indices(std::move(col_indices_)),
+        data(std::move(data_)),
+        cols_(cols) {}
+
+  explicit CRSMatrix(const Matrix<T>& dense) : CRSMatrix(dense.rows, dense.cols) {
+    size_t idx = 0;
+    for (size_t i = 0; i < dense.rows; ++i) {
+      size_t nz = 0;
+      for (size_t j = 0; j < dense.cols; ++j) {
+        const auto& el = dense.storage[idx++];
+        if (el == 0) {
+          continue;
+        }
+        ++nz;
+        col_indices.push_back(j);
+        data.push_back(el);
+      }
+      row_pointers[i + 1] = row_pointers[i] + nz;
+    }
+  }
+
+  size_t rows() const { return row_pointers.size() - 1; }
+  size_t cols() const { return cols_; }
+
+  bool operator==(const CRSMatrix& other) const noexcept {
+    return cols_ == other.cols_ && row_pointers == other.row_pointers && col_indices == other.col_indices &&
+           data == other.data;
+  }
+
+  std::optional<const T&> at(size_t row, size_t col) const {
+    for (size_t i = row_pointers[row]; i < row_pointers[row + 1]; ++i) {
+      if (col_indices[i] == col) {
+        return data[i];
+      }
+    }
+    return std::nullopt;
+  }
+
+  CRSMatrix transpose() const {
+    const auto [n, m] = std::make_pair(rows(), cols());
+
+    CRSMatrix res{m + 1, n};
+    res.col_indices.resize(col_indices.size(), 0);
+    res.data.resize(data.size(), 0);
+
+    for (size_t i = 0; i < data.size(); ++i) {
+      ++res.row_pointers[col_indices[i] + 2];
+    }
+
+    for (size_t i = 2; i < res.row_pointers.size(); ++i) {
+      res.row_pointers[i] += res.row_pointers[i - 1];
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+      for (size_t j = row_pointers[i]; j < row_pointers[i + 1]; ++j) {
+        const auto translated_idx = res.row_pointers[col_indices[j] + 1]++;
+        res.data[translated_idx] = data[j];
+        res.col_indices[translated_idx] = i;
+      }
+    }
+    res.row_pointers.pop_back();
+
+    return res;
+  }
+
+  Matrix<T> densify() const {
+    auto dense = Matrix<T>::create(rows(), cols());
+    for (size_t row = 0; row < dense.rows; ++row) {
+      for (size_t i = row_pointers[row]; i < row_pointers[row + 1]; ++i) {
+        dense.at(row, col_indices[i]) = data[i];
+      }
+    }
+    return dense;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const CRSMatrix& m) {
+    os << "CRS(" << m.rows() << "," << m.cols() << "): ";
+    os << "R/[";
+    utils::iprint(os, m.row_pointers.begin(), m.row_pointers.end());
+    os << "], C/[";
+    utils::iprint(os, m.col_indices.begin(), m.col_indices.end());
+    os << "], D/[";
+    utils::iprint(os, m.data.begin(), m.data.end());
+    os << "]";
+    return os;
+  }
+};
+
+}  // namespace krylov_m_crs_mmul

--- a/tasks/seq/krylov_m_crs_mmul/include/smmul_seq.hpp
+++ b/tasks/seq/krylov_m_crs_mmul/include/smmul_seq.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <utility>
+#include <vector>
+
+#include "./matrix.hpp"
+#include "core/task/include/task.hpp"
+
+namespace krylov_m_crs_mmul {
+
+template <typename T>
+class TaskCommon : public ppc::core::Task {
+ public:
+  explicit TaskCommon(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+
+  bool validation() override {
+    internal_order_test();
+
+    return taskData->inputs.size() == 2 && taskData->inputs_count.size() == 4 && taskData->outputs.size() == 1 &&
+           // (lhs.cols == rhs.rows)
+           (taskData->inputs_count[1] == taskData->inputs_count[2]) &&
+           // lhs.rows > 0 && lhs.cols > 0 && rhs.rows > 0 [&& rhs.cols > 0] - true by definition
+           (taskData->inputs_count[0] > 0 && taskData->inputs_count[1] > 0 && taskData->inputs_count[2] > 0);
+  }
+
+  bool pre_processing() override {
+    internal_order_test();
+
+    input = {*reinterpret_cast<CRSMatrix<T>*>(taskData->inputs[0]),
+             reinterpret_cast<CRSMatrix<T>*>(taskData->inputs[1])->transpose()};
+
+    return true;
+  }
+
+  bool post_processing() override {
+    internal_order_test();
+
+    *reinterpret_cast<CRSMatrix<T>*>(taskData->outputs[0]) = res;
+
+    return true;
+  }
+
+ protected:
+  std::pair<CRSMatrix<T>, CRSMatrix<T>> input;
+  CRSMatrix<T> res;
+};
+
+template <typename T>
+class TaskSequential : public TaskCommon<T> {
+ public:
+  explicit TaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : TaskSequential::TaskCommon(std::move(taskData_)) {}
+
+  bool run() override {
+    this->internal_order_test();
+
+    const auto& [lhs, rhs] = this->input;
+
+    const auto [rows, cols] = std::make_pair(lhs.rows(), rhs.rows());  // rhs was transposed
+    this->res = decltype(this->res)(rows, cols);
+
+    for (size_t row = 0; row < rows; row++) {
+      for (size_t col = 0; col < cols; col++) {
+        auto [il, ir] = std::make_pair(lhs.row_pointers[row], rhs.row_pointers[col]);
+        T sum{};
+        while (il < lhs.row_pointers[row + 1] && ir < rhs.row_pointers[col + 1]) {
+          if (lhs.col_indices[il] < rhs.col_indices[ir]) {
+            il++;
+          } else if (lhs.col_indices[il] > rhs.col_indices[ir]) {
+            ir++;
+          } else {  // ==
+            sum += lhs.data[il] * rhs.data[ir];
+            il++;
+            ir++;
+          }
+        }
+        if (sum != 0) {
+          this->res.data.push_back(sum);
+          this->res.col_indices.push_back(col);
+        }
+      }
+      this->res.row_pointers[row + 1] = this->res.data.size();
+    }
+
+    return true;
+  }
+};
+
+template <class T>
+void fill_task_data(ppc::core::TaskData& data, const CRSMatrix<T>& lhs, const CRSMatrix<T>& rhs, CRSMatrix<T>& out) {
+  data.inputs.emplace_back(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&lhs)));
+  data.inputs_count.emplace_back(lhs.rows());
+  data.inputs_count.emplace_back(lhs.cols());
+  //
+  data.inputs.emplace_back(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&rhs)));
+  data.inputs_count.emplace_back(rhs.rows());
+  data.inputs_count.emplace_back(rhs.cols());
+
+  data.outputs.emplace_back(reinterpret_cast<uint8_t*>(&out));
+}
+
+}  // namespace krylov_m_crs_mmul

--- a/tasks/seq/krylov_m_crs_mmul/perf_tests/main.cpp
+++ b/tasks/seq/krylov_m_crs_mmul/perf_tests/main.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <random>
+
+#include "../include/smmul_seq.hpp"
+#include "core/perf/include/perf.hpp"
+
+class krylov_m_crs_mmul_seq_test : public ::testing::Test {
+  using TestElementType = double;
+  static constexpr float Density = 0.10f;
+
+  static constexpr size_t lrows = 411;
+  static constexpr size_t lcols = 411;
+  static constexpr size_t rcols = 411;
+  //
+  static constexpr TestElementType emin = -128;
+  static constexpr TestElementType emax = 128;
+
+ protected:
+  static void run_perf_test(
+      const std::function<void(ppc::core::Perf &perfAnalyzer, const std::shared_ptr<ppc::core::PerfAttr> &perfAttr,
+                               const std::shared_ptr<ppc::core::PerfResults> &perfResults)> &runner) {
+    const krylov_m_crs_mmul::Matrix<TestElementType> lhs =
+        generate_random_matrix<TestElementType>(lrows, lcols, emin, emax, Density);
+    const krylov_m_crs_mmul::Matrix<TestElementType> rhs =
+        generate_random_matrix<TestElementType>(lcols, rcols, emin, emax, Density);
+    //
+
+    krylov_m_crs_mmul::CRSMatrix<TestElementType> slhs(lhs);
+    krylov_m_crs_mmul::CRSMatrix<TestElementType> srhs(rhs);
+    krylov_m_crs_mmul::CRSMatrix<TestElementType> sout;
+
+    auto taskData = std::make_shared<ppc::core::TaskData>();
+    krylov_m_crs_mmul::fill_task_data(*taskData, slhs, srhs, sout);
+
+    //
+    auto task = std::make_shared<krylov_m_crs_mmul::TaskSequential<TestElementType>>(taskData);
+
+    //
+    auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+    perfAttr->num_running = 10;
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    perfAttr->current_timer = [&] {
+      auto current_time_point = std::chrono::high_resolution_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+      return static_cast<double>(duration) * 1e-9;
+    };
+
+    //
+    auto perfResults = std::make_shared<ppc::core::PerfResults>();
+    ppc::core::Perf perfAnalyzer(task);
+    runner(perfAnalyzer, perfAttr, perfResults);
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+
+  template <typename T>
+  static krylov_m_crs_mmul::Matrix<T> generate_random_matrix(size_t rows, size_t cols, T emin, T emax, float density) {
+    const T threshold = emin + ((emax - emin) * density);
+
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<> distr(emin, emax);
+
+    auto matrix = krylov_m_crs_mmul::Matrix<T>::create(rows, cols);
+    std::generate(matrix.storage.begin(), matrix.storage.end(), [&]() {
+      auto val = distr(gen);
+      return (val < threshold) ? val : 0;
+    });
+
+    return matrix;
+  }
+};
+
+TEST_F(krylov_m_crs_mmul_seq_test, test_pipeline_run) {
+  run_perf_test([](auto &perfAnalyzer, const auto &perfAttr, const auto &perfResults) {
+    perfAnalyzer.pipeline_run(perfAttr, perfResults);
+  });
+}
+
+TEST_F(krylov_m_crs_mmul_seq_test, test_task_run) {
+  run_perf_test([](auto &perfAnalyzer, const auto &perfAttr, const auto &perfResults) {
+    perfAnalyzer.task_run(perfAttr, perfResults);
+  });
+}

--- a/tasks/seq/krylov_m_crs_mmul/src/smmul_seq.cpp
+++ b/tasks/seq/krylov_m_crs_mmul/src/smmul_seq.cpp
@@ -1,0 +1,1 @@
+#include "../include/smmul_seq.hpp"


### PR DESCRIPTION
**Описание последовательной задачи.** На вход задачи подаются две матрицы, представленные в формате CSR. Правая матрица транспонируется для организации доступа по столбцам, затем на нее умножается левая матрица.

**Описание MPI задачи.** Реализуется схема, напоминающая обобщенную ленточную схему с разбиением только левой матрицы, правая матрица рассылается всем процессам в коммуникаторе. Для оптимизации рассылки правой матрицы используются расширенные возможности `boost::serialization` - введен дополнительный класс, представляющий фрагмент CSR-матрицы, организующий доступ к членам по невладеющим ссылкам (точнее говоря, с помощью `std::span`, являющегося невладеющей оберткой над указателем на непрерывный блок памяти и размером этого блока). В классе спрятана структура, содержащая владеющие вектора для хранения этих же данных - при создании чанка из существующих данных, невладеющие ссылки указывают на переданные при создании данные, а при десериализации инстанцируются вышеупомянутые входящие в класс векторы, невладеющие ссылки начинают указывать на них - во избежание необходимости копирования фрагмента матрицы в корневом процессе. После перемножения всех фрагментов с помощью `gather` происходит сбор в корневой процесс всех частичных результатов (здесь использование сериализации для представления частей матрицы избавляет от необходимости координации сбора размеров перед сборкой непосредственно данных), а затем их реассемблирование с коррекцией указателей на строки, выражающейся в их смещении с учетом порядка фрагментов матрицы.

Верификация ответов в обеих версиях задачи производится с помощью конверсии матрицы из CSR-представления в плотное и наивного алгоритма матричного умножения. \
Тестируются всевозможные комбинации плотностей и размеров матриц, включая ряд граничных случаев.