### PR TITLE
Козлова Екатерина. Задача 3. Вариант 21. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/mpi/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -1,0 +1,188 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+
+#include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_simple_mas) {
+  boost::mpi::communicator world;
+  std::vector<double> mas = {-12.34, 45.67, 0.0, -98.76, 32.1, -0.01, 23.45, -56.78, 9.99, 0.001};
+  std::vector<double> resMPI(10, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ(10, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataSeq->inputs_count.emplace_back(mas.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(resSEQ.data()));
+    taskDataSeq->outputs_count.emplace_back(resSEQ.size());
+
+    kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential testMPITaskSequential(taskDataSeq);
+
+    ASSERT_EQ(testMPITaskSequential.validation(), true);
+    testMPITaskSequential.pre_processing();
+    testMPITaskSequential.run();
+    testMPITaskSequential.post_processing();
+
+    ASSERT_EQ(resSEQ, resMPI);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_sort_empty) {
+  boost::mpi::communicator world;
+  std::vector<double> mas = {};
+  std::vector<double> resMPI;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    ASSERT_TRUE(resMPI.empty());
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_single_element) {
+  boost::mpi::communicator world;
+  std::vector<double> mas = {42.0};
+  std::vector<double> resMPI(1, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(mas, resMPI);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_incorrect_size) {
+  boost::mpi::communicator world;
+  std::vector<double> mas = {1.1, 2.2, 3.3};
+  std::vector<double> resMPI(2);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_large_mas) {
+  boost::mpi::communicator world;
+  const int size = 10000;
+  std::vector<double> mas(size);
+  std::vector<double> resMPI(size);
+
+  std::generate(mas.begin(), mas.end(), []() { return static_cast<double>(rand()) / RAND_MAX; });
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ = mas;
+    std::sort(resSEQ.begin(), resSEQ.end());
+
+    ASSERT_EQ(resSEQ, resMPI);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_same_elements) {
+  boost::mpi::communicator world;
+  std::vector<double> mas = {0.000, 0.00, 0};
+  std::vector<double> resMPI(3);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ(3, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataSeq->inputs_count.emplace_back(mas.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(resSEQ.data()));
+    taskDataSeq->outputs_count.emplace_back(resSEQ.size());
+
+    kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential testMPITaskSequential(taskDataSeq);
+
+    ASSERT_EQ(testMPITaskSequential.validation(), true);
+    testMPITaskSequential.pre_processing();
+    testMPITaskSequential.run();
+    testMPITaskSequential.post_processing();
+
+    ASSERT_EQ(resSEQ, resMPI);
+  }
+}

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -9,11 +9,11 @@
 #include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
 
 namespace kozlova_e_utility_functions {
-std::vector<double> generate_random_double_vector(size_t size) {
+std::vector<double> generate_random_double_vector(size_t size, double min_val, double max_val) {
   std::vector<double> result(size);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+  std::uniform_real_distribution<double> dist(min_val, max_val);
 
   for (auto& value : result) {
     value = dist(gen);
@@ -135,10 +135,12 @@ TEST(kozlova_e_radix_batcher_sort_mpi, test_incorrect_size) {
 TEST(kozlova_e_radix_batcher_sort_mpi, test_large_mas) {
   boost::mpi::communicator world;
   const int size = 10000;
+  double min_val = -100.0;
+  double max_val = 100.0;
   std::vector<double> mas(size);
   std::vector<double> resMPI(size);
 
-  mas = kozlova_e_utility_functions::generate_random_double_vector(size);
+  mas = kozlova_e_utility_functions::generate_random_double_vector(size, min_val, max_val);
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
@@ -239,5 +241,142 @@ TEST(kozlova_e_radix_batcher_sort_mpi, test_identical_elements_with_diff_signs) 
 
     ASSERT_EQ(resSEQ, resMPI);
     ASSERT_EQ(resSEQ, expected);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_reverse_sort) {
+  boost::mpi::communicator world;
+  std::vector<double> mas = {5.1, 3.22, -3.34, -5.54};
+  std::vector<double> resMPI(4);
+  std::vector<double> expected = {-5.54, -3.34, 3.22, 5.1};
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ(4);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataSeq->inputs_count.emplace_back(mas.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(resSEQ.data()));
+    taskDataSeq->outputs_count.emplace_back(resSEQ.size());
+
+    kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential testMPITaskSequential(taskDataSeq);
+
+    ASSERT_EQ(testMPITaskSequential.validation(), true);
+    testMPITaskSequential.pre_processing();
+    testMPITaskSequential.run();
+    testMPITaskSequential.post_processing();
+
+    ASSERT_EQ(resSEQ, resMPI);
+    ASSERT_EQ(resSEQ, expected);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_mas_2_n) {
+  boost::mpi::communicator world;
+  const int size = 1024;
+  double min_val = -100.0;
+  double max_val = 100.0;
+  std::vector<double> mas(size);
+  std::vector<double> resMPI(size);
+
+  mas = kozlova_e_utility_functions::generate_random_double_vector(size, min_val, max_val);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ = mas;
+    std::sort(resSEQ.begin(), resSEQ.end());
+
+    ASSERT_EQ(resSEQ, resMPI);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_mas_3_n) {
+  boost::mpi::communicator world;
+  const int size = 2187;
+  double min_val = -100.0;
+  double max_val = 100.0;
+  std::vector<double> mas(size);
+  std::vector<double> resMPI(size);
+
+  mas = kozlova_e_utility_functions::generate_random_double_vector(size, min_val, max_val);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ = mas;
+    std::sort(resSEQ.begin(), resSEQ.end());
+
+    ASSERT_EQ(resSEQ, resMPI);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_mas_prime_value_size) {
+  boost::mpi::communicator world;
+  const int size = 97;
+  double min_val = -100.0;
+  double max_val = 100.0;
+  std::vector<double> mas(size);
+  std::vector<double> resMPI(size);
+
+  mas = kozlova_e_utility_functions::generate_random_double_vector(size, min_val, max_val);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(mas.data()));
+    taskDataPar->inputs_count.emplace_back(mas.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> resSEQ = mas;
+    std::sort(resSEQ.begin(), resSEQ.end());
+
+    ASSERT_EQ(resSEQ, resMPI);
   }
 }

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -3,9 +3,24 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
+#include <random>
 #include <vector>
 
 #include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
+
+namespace kozlova_e_utility_functions {
+std::vector<double> generate_random_double_vector(size_t size) {
+  std::vector<double> result(size);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+
+  for (auto& value : result) {
+    value = dist(gen);
+  }
+  return result;
+}
+}  // namespace kozlova_e_utility_functions
 
 TEST(kozlova_e_radix_batcher_sort_mpi, test_simple_mas) {
   boost::mpi::communicator world;
@@ -123,8 +138,7 @@ TEST(kozlova_e_radix_batcher_sort_mpi, test_large_mas) {
   std::vector<double> mas(size);
   std::vector<double> resMPI(size);
 
-  std::generate(mas.begin(), mas.end(), []() { return static_cast<double>(rand()) / RAND_MAX; });
-
+  mas = kozlova_e_utility_functions::generate_random_double_vector(size);
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp
@@ -7,7 +7,6 @@
 #include <boost/mpi/communicator.hpp>
 #include <memory>
 #include <numeric>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp
@@ -1,0 +1,51 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kozlova_e_radix_batcher_sort_mpi {
+
+class RadixBatcherSortSequential : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  int input_size{};
+  std::vector<double> data;
+
+  void radixSort(std::vector<double>& a);
+};
+
+class RadixBatcherSortMPI : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortMPI(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> input_;
+  int input_size{};
+  std::string ops;
+  boost::mpi::communicator world;
+
+  void radixSort(std::vector<double>& a);
+  void RadixSortWithOddEvenMerge(std::vector<double>& a);
+};
+
+}  // namespace kozlova_e_radix_batcher_sort_mpi

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp
@@ -27,7 +27,7 @@ class RadixBatcherSortSequential : public ppc::core::Task {
   int input_size{};
   std::vector<double> data;
 
-  void radixSort(std::vector<double>& a);
+  static void radixSort(std::vector<double>& a);
 };
 
 class RadixBatcherSortMPI : public ppc::core::Task {
@@ -41,10 +41,9 @@ class RadixBatcherSortMPI : public ppc::core::Task {
  private:
   std::vector<double> input_;
   int input_size{};
-  std::string ops;
   boost::mpi::communicator world;
 
-  void radixSort(std::vector<double>& a);
+  static void radixSort(std::vector<double>& a);
   void RadixSortWithOddEvenMerge(std::vector<double>& a);
 };
 

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/perf_tests/main.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/perf_tests/main.cpp
@@ -9,11 +9,11 @@
 #include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
 
 namespace kozlova_e_utility_functions {
-std::vector<double> generate_random_double_vector(size_t size) {
+std::vector<double> generate_random_double_vector(size_t size, double min_val, double max_val) {
   std::vector<double> result(size);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+  std::uniform_real_distribution<double> dist(min_val, max_val);
 
   for (auto& value : result) {
     value = dist(gen);
@@ -32,7 +32,7 @@ TEST(kozlova_e_radix_batcher_sort_mpi, test_pipeline_run) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    global_vec = kozlova_e_utility_functions::generate_random_double_vector(size);
+    global_vec = kozlova_e_utility_functions::generate_random_double_vector(size, -100.0, 100.0);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
     taskDataPar->inputs_count.emplace_back(global_vec.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
@@ -89,7 +89,7 @@ TEST(kozlova_e_radix_batcher_sort_mpi, test_task_run) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    global_vec = kozlova_e_utility_functions::generate_random_double_vector(size);
+    global_vec = kozlova_e_utility_functions::generate_random_double_vector(size, -100.0, 100.0);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
     taskDataPar->inputs_count.emplace_back(global_vec.size());
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/perf_tests/main.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/perf_tests/main.cpp
@@ -1,0 +1,137 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
+
+namespace kozlova_e_utility_functions {
+std::vector<double> generate_random_double_vector(size_t size) {
+  std::vector<double> result(size);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+
+  for (auto& value : result) {
+    value = dist(gen);
+  }
+  return result;
+}
+}  // namespace kozlova_e_utility_functions
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  const int size = 100000;
+  std::vector<double> global_vec;
+  std::vector<double> resMPI(size, 0);
+  std::vector<double> resSeq;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    global_vec = kozlova_e_utility_functions::generate_random_double_vector(size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  if (world.rank() == 0) {
+    resSeq.resize(size);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(resSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(resSeq.size());
+
+    kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential testMPITaskSequential(taskDataSeq);
+
+    ASSERT_EQ(testMPITaskSequential.validation(), true);
+    testMPITaskSequential.pre_processing();
+    testMPITaskSequential.run();
+    testMPITaskSequential.post_processing();
+  }
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(resSeq, resMPI);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  const int size = 100000;
+  std::vector<double> global_vec;
+  std::vector<double> resMPI(size, 0);
+  std::vector<double> resSeq;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    global_vec = kozlova_e_utility_functions::generate_random_double_vector(size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataPar->inputs_count.emplace_back(global_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(resMPI.data()));
+    taskDataPar->outputs_count.emplace_back(resMPI.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  if (world.rank() == 0) {
+    resSeq.resize(size);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec.data()));
+    taskDataSeq->inputs_count.emplace_back(global_vec.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(resSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(resSeq.size());
+
+    kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential testMPITaskSequential(taskDataSeq);
+
+    ASSERT_EQ(testMPITaskSequential.validation(), true);
+    testMPITaskSequential.pre_processing();
+    testMPITaskSequential.run();
+    testMPITaskSequential.post_processing();
+  }
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(resSeq, resMPI);
+  }
+}

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
@@ -1,12 +1,7 @@
 #include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
 
-#include <algorithm>
 #include <boost/serialization/vector.hpp>
 #include <cstring>
-#include <functional>
-#include <random>
-#include <string>
-#include <thread>
 #include <vector>
 
 bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::pre_processing() {

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
@@ -71,7 +71,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::radixSort(std
     } else {
       bits = ~bits;
     }
-    a[i] = *reinterpret_cast<double*>(&bits);
+    std::memcpy(&a[i], &bits, sizeof(double));
   }
 }
 
@@ -145,7 +145,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::radixSort(std::vecto
     } else {
       bits = ~bits;
     }
-    a[i] = *reinterpret_cast<double*>(&bits);
+    std::memcpy(&a[i], &bits, sizeof(double));
   }
 }
 

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <boost/serialization/vector.hpp>
+#include <cstring>
 #include <functional>
 #include <random>
 #include <string>

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
@@ -71,7 +71,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::radixSort(std
     } else {
       bits = ~bits;
     }
-    std::memcpy(&a[i], &bits, sizeof(double));
+    memcpy(&a[i], &bits, sizeof(double));
   }
 }
 
@@ -145,7 +145,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::radixSort(std::vecto
     } else {
       bits = ~bits;
     }
-    std::memcpy(&a[i], &bits, sizeof(double));
+    memcpy(&a[i], &bits, sizeof(double));
   }
 }
 

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
@@ -1,0 +1,222 @@
+#include "mpi/kozlova_e_radix_batcher_sort/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <boost/serialization/vector.hpp>
+#include <functional>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::pre_processing() {
+  internal_order_test();
+  input_size = taskData->inputs_count[0];
+  data.resize(input_size);
+  auto* mas = reinterpret_cast<double*>(taskData->inputs[0]);
+  for (int i = 0; i < input_size; i++) data[i] = mas[i];
+  return true;
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::validation() {
+  internal_order_test();
+  return taskData->inputs_count[0] == taskData->outputs_count[0] && taskData->inputs_count[0] >= 0;
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::run() {
+  internal_order_test();
+  radixSort(data);
+  return true;
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::post_processing() {
+  internal_order_test();
+  for (size_t i = 0; i < data.size(); i++) reinterpret_cast<double*>(taskData->outputs[0])[i] = data[i];
+  return true;
+}
+
+void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::radixSort(std::vector<double>& a) {
+  std::vector<uint64_t> bit_representation(a.size());
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    uint64_t bits = *reinterpret_cast<uint64_t*>(&a[i]);
+    if (bits >> 63) {
+      bit_representation[i] = ~bits;
+    } else {
+      bit_representation[i] = bits | 0x8000000000000000;
+    }
+  }
+
+  for (int bit = 0; bit < 64; ++bit) {
+    std::vector<uint64_t> output(a.size());
+    int count[2] = {0};
+
+    for (size_t i = 0; i < bit_representation.size(); ++i) {
+      count[(bit_representation[i] >> bit) & 1]++;
+    }
+
+    count[1] += count[0];
+
+    for (int i = bit_representation.size() - 1; i >= 0; --i) {
+      int val = (bit_representation[i] >> bit) & 1;
+      output[--count[val]] = bit_representation[i];
+    }
+
+    bit_representation = output;
+  }
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    uint64_t bits = bit_representation[i];
+    if (bits & 0x8000000000000000) {
+      bits &= ~0x8000000000000000;
+    } else {
+      bits = ~bits;
+    }
+    a[i] = *reinterpret_cast<double*>(&bits);
+  }
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    input_size = taskData->inputs_count[0];
+    input_.resize(input_size);
+    auto* mas = reinterpret_cast<double*>(taskData->inputs[0]);
+    for (int i = 0; i < input_size; i++) input_[i] = mas[i];
+  }
+  return true;
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::validation() {
+  internal_order_test();
+  return world.rank() == 0 ? (taskData->inputs_count[0] == taskData->outputs_count[0] && taskData->inputs_count[0] >= 0)
+                           : true;
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::run() {
+  internal_order_test();
+  boost::mpi::broadcast(world, input_size, 0);
+  RadixSortWithOddEvenMerge(input_);
+  return true;
+}
+
+bool kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    auto* output = reinterpret_cast<double*>(taskData->outputs[0]);
+    for (size_t i = 0; i < input_.size(); i++) output[i] = input_[i];
+  }
+  return true;
+}
+
+void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::radixSort(std::vector<double>& a) {
+  std::vector<uint64_t> bit_representation(a.size());
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    uint64_t bits = *reinterpret_cast<uint64_t*>(&a[i]);
+    if (bits >> 63) {
+      bit_representation[i] = ~bits;
+    } else {
+      bit_representation[i] = bits | 0x8000000000000000;
+    }
+  }
+
+  for (int bit = 0; bit < 64; ++bit) {
+    std::vector<uint64_t> output(a.size());
+    int count[2] = {0};
+
+    for (size_t i = 0; i < bit_representation.size(); ++i) {
+      count[(bit_representation[i] >> bit) & 1]++;
+    }
+
+    count[1] += count[0];
+
+    for (int i = bit_representation.size() - 1; i >= 0; --i) {
+      int val = (bit_representation[i] >> bit) & 1;
+      output[--count[val]] = bit_representation[i];
+    }
+
+    bit_representation = output;
+  }
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    uint64_t bits = bit_representation[i];
+    if (bits & 0x8000000000000000) {
+      bits &= ~0x8000000000000000;
+    } else {
+      bits = ~bits;
+    }
+    a[i] = *reinterpret_cast<double*>(&bits);
+  }
+}
+
+void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::RadixSortWithOddEvenMerge(std::vector<double>& a) {
+  a.resize(input_size);
+  boost::mpi::broadcast(world, a.data(), a.size(), 0);
+
+  int total_size = a.size();
+  int num_processes = world.size();
+  int local_size = total_size / num_processes;
+  int remainder = total_size % num_processes;
+
+  std::vector<int> send_counts(num_processes, local_size);
+  for (int i = 0; i < remainder; ++i) {
+    send_counts[i]++;
+  }
+
+  std::vector<int> send_displacements(num_processes, 0);
+  for (int i = 1; i < num_processes; ++i) {
+    send_displacements[i] = send_displacements[i - 1] + send_counts[i - 1];
+  }
+
+  std::vector<double> local_input(send_counts[world.rank()]);
+
+  boost::mpi::scatterv(world, a.data(), send_counts, send_displacements, local_input.data(), send_counts[world.rank()],
+                       0);
+
+  radixSort(local_input);
+
+  int step = 1;
+  bool is_even_phase = true;
+
+  while (step <= world.size()) {
+    int partner = -1;
+    radixSort(local_input);
+    if (is_even_phase) {
+      if (world.rank() % 2 == 0 && world.rank() + 1 < world.size()) {
+        partner = world.rank() + 1;
+      } else if (world.rank() % 2 != 0) {
+        partner = world.rank() - 1;
+      }
+    } else {
+      if (world.rank() % 2 != 0 && world.rank() + 1 < world.size()) {
+        partner = world.rank() + 1;
+      } else if (world.rank() % 2 == 0 && world.rank() > 0) {
+        partner = world.rank() - 1;
+      }
+    }
+
+    if (partner != -1) {
+      std::vector<double> recv_data(local_input.size());
+      world.sendrecv(partner, 0, local_input, partner, 0, recv_data);
+
+      std::vector<double> merged(local_input.size() + recv_data.size());
+      std::merge(local_input.begin(), local_input.end(), recv_data.begin(), recv_data.end(), merged.begin());
+
+      radixSort(merged);
+
+      int local_keep = send_counts[world.rank()];
+
+      if (world.rank() < partner) {
+        local_input.assign(merged.begin(), merged.begin() + local_keep);
+      } else {
+        local_input.assign(merged.end() - local_keep, merged.end());
+      }
+    }
+
+    is_even_phase = !is_even_phase;
+    step++;
+  }
+
+  boost::mpi::gatherv(world, local_input.data(), send_counts[world.rank()], a.data(), send_counts, send_displacements,
+                      0);
+}

--- a/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
+++ b/tasks/mpi/kozlova_e_radix_batcher_sort/src/ops_mpi.cpp
@@ -40,7 +40,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::radixSort(std
 
   for (size_t i = 0; i < a.size(); ++i) {
     uint64_t bits = *reinterpret_cast<uint64_t*>(&a[i]);
-    if (bits >> 63) {
+    if ((bits >> 63) != 0u) {
       bit_representation[i] = ~bits;
     } else {
       bit_representation[i] = bits | 0x8000000000000000;
@@ -67,7 +67,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortSequential::radixSort(std
 
   for (size_t i = 0; i < a.size(); ++i) {
     uint64_t bits = bit_representation[i];
-    if (bits & 0x8000000000000000) {
+    if ((bits & 0x8000000000000000) != 0u) {
       bits &= ~0x8000000000000000;
     } else {
       bits = ~bits;
@@ -114,7 +114,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::radixSort(std::vecto
 
   for (size_t i = 0; i < a.size(); ++i) {
     uint64_t bits = *reinterpret_cast<uint64_t*>(&a[i]);
-    if (bits >> 63) {
+    if ((bits >> 63) != 0u) {
       bit_representation[i] = ~bits;
     } else {
       bit_representation[i] = bits | 0x8000000000000000;
@@ -141,7 +141,7 @@ void kozlova_e_radix_batcher_sort_mpi::RadixBatcherSortMPI::radixSort(std::vecto
 
   for (size_t i = 0; i < a.size(); ++i) {
     uint64_t bits = bit_representation[i];
-    if (bits & 0x8000000000000000) {
+    if ((bits & 0x8000000000000000) != 0u) {
       bits &= ~0x8000000000000000;
     } else {
       bits = ~bits;

--- a/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -71,7 +71,7 @@ TEST(kozlova_e_radix_batcher_sort_seq, test_empty_mas) {
   testTaskSequential.run();
   testTaskSequential.post_processing();
 
-  ASSERT_EQ(res.size(), 0);
+  ASSERT_TRUE(res.empty());
 }
 
 TEST(kozlova_e_radix_batcher_sort_seq, test_single_element) {

--- a/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -46,7 +46,7 @@ TEST(kozlova_e_radix_batcher_sort_seq, test_simple_mas) {
 TEST(kozlova_e_radix_batcher_sort_seq, test_remainder_vector) {
   const int count = 10;
 
-  std::vector<double> mas = {3.175, 3.141, 3.256, 3.879, 3.334, 3.667, 3.987, 3.432, 3.254, 3.876};
+  std::vector<double> mas = {3.175, 3.1234, 3.256, 3.879, 3.334, 3.667, 3.987, 3.432, 3.254, 3.876};
   std::vector<double> res(count, 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -91,7 +91,7 @@ TEST(kozlova_e_radix_batcher_sort_seq, test_empty_mas) {
 TEST(kozlova_e_radix_batcher_sort_seq, test_single_element) {
   const int count = 1;
 
-  std::vector<double> mas = {3.1415};
+  std::vector<double> mas = {3.5234};
   std::vector<double> res(count, 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -107,7 +107,7 @@ TEST(kozlova_e_radix_batcher_sort_seq, test_single_element) {
   testTaskSequential.run();
   testTaskSequential.post_processing();
 
-  ASSERT_EQ(res[0], 3.1415);
+  ASSERT_EQ(res[0], 3.5234);
 }
 
 TEST(kozlova_e_radix_batcher_sort_seq, test_negative_numbers) {
@@ -175,5 +175,5 @@ TEST(kozlova_e_radix_batcher_sort_seq, test_remaind) {
   testTaskSequential.run();
   testTaskSequential.post_processing();
 
-  ASSERT_EQ(res, expect);
+  ASSERT_EQ(expect, res);
 }

--- a/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -6,6 +6,20 @@
 
 #include "seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp"
 
+namespace kozlova_e_utility_functions {
+std::vector<double> generate_random_double_vector(size_t size) {
+  std::vector<double> result(size);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+
+  for (auto &value : result) {
+    value = dist(gen);
+  }
+  return result;
+}
+}  // namespace kozlova_e_utility_functions
+
 TEST(kozlova_e_radix_batcher_sort_seq, test_simple_mas) {
   const int count = 10;
 
@@ -122,8 +136,7 @@ TEST(kozlova_e_radix_batcher_sort_seq, test_negative_numbers) {
 TEST(kozlova_e_radix_batcher_sort_seq, Test_LargeDataSet) {
   const int count = 1000;
 
-  std::vector<double> mas(count);
-  std::generate(mas.begin(), mas.end(), []() { return (rand() % 1000) / 1000.0; });
+  std::vector<double> mas = kozlova_e_utility_functions::generate_random_double_vector(count);
   std::vector<double> res(count, 0);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/func_tests/main.cpp
@@ -1,0 +1,166 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp"
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_simple_mas) {
+  const int count = 10;
+
+  std::vector<double> mas = {2.354, -4.789, 1, -1.456, 3.987, -0.456, 7.234, -8.654, 9.876, 5.432};
+  std::vector<double> res(count, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (int i = 1; i < count; i++) {
+    ASSERT_LE(res[i - 1], res[i]);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_remainder_vector) {
+  const int count = 10;
+
+  std::vector<double> mas = {3.175, 3.141, 3.256, 3.879, 3.334, 3.667, 3.987, 3.432, 3.254, 3.876};
+  std::vector<double> res(count, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (int i = 1; i < count; i++) {
+    ASSERT_LE(res[i - 1], res[i]);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_empty_mas) {
+  const int count = 0;
+
+  std::vector<double> mas;
+  std::vector<double> res(count, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  ASSERT_EQ(res.size(), 0);
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_single_element) {
+  const int count = 1;
+
+  std::vector<double> mas = {3.1415};
+  std::vector<double> res(count, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  ASSERT_EQ(res[0], 3.1415);
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_negative_numbers) {
+  const int count = 6;
+
+  std::vector<double> mas = {-1.234, -3.456, -2.345, -0.123, -5.678, -4.567};
+  std::vector<double> res(count, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (int i = 1; i < count; i++) {
+    ASSERT_LE(res[i - 1], res[i]);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, Test_LargeDataSet) {
+  const int count = 1000;
+
+  std::vector<double> mas(count);
+  std::generate(mas.begin(), mas.end(), []() { return (rand() % 1000) / 1000.0; });
+  std::vector<double> res(count, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  for (int i = 1; i < count; i++) {
+    ASSERT_LE(res[i - 1], res[i]);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_remaind) {
+  const int count = 2;
+
+  std::vector<double> mas = {1.0001, 1};
+  std::vector<double> res(count, 0);
+  std::vector<double> expect = {1, 1.0001};
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  kozlova_e_radix_batcher_sort_seq::RadixSortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  ASSERT_EQ(res, expect);
+}

--- a/tasks/seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp
@@ -19,7 +19,7 @@ class RadixSortSequential : public ppc::core::Task {
   int input_size{};
   std::vector<double> data;
 
-  void radixSort(std::vector<double>& a);
+  static void radixSort(std::vector<double>& a);
 };
 
 }  // namespace kozlova_e_radix_batcher_sort_seq

--- a/tasks/seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kozlova_e_radix_batcher_sort_seq {
+
+class RadixSortSequential : public ppc::core::Task {
+ public:
+  explicit RadixSortSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  int input_size{};
+  std::vector<double> data;
+
+  void radixSort(std::vector<double>& a);
+};
+
+}  // namespace kozlova_e_radix_batcher_sort_seq

--- a/tasks/seq/kozlova_e_radix_batcher_sort/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/perf_tests/main.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp"
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_pipeline_run) {
+  const size_t count = 100000;
+
+  std::vector<double> mas(count);
+  std::vector<double> res(count);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(-1e6, 1e6);
+
+  for (size_t i = 0; i < count; ++i) {
+    mas[i] = dist(gen);
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  // Create Task
+  auto testTaskSequential = std::make_shared<kozlova_e_radix_batcher_sort_seq::RadixSortSequential>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  for (size_t i = 1; i < count; ++i) {
+    ASSERT_LE(res[i - 1], res[i]);
+  }
+}
+
+TEST(kozlova_e_radix_batcher_sort_seq, test_task_run) {
+  const size_t count = 100000;
+
+  std::vector<double> mas(count);
+  std::vector<double> res(count);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(-1e6, 1e6);
+
+  for (size_t i = 0; i < count; ++i) {
+    mas[i] = dist(gen);
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(mas.data()));
+  taskDataSeq->inputs_count.emplace_back(mas.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(res.data()));
+  taskDataSeq->outputs_count.emplace_back(res.size());
+
+  // Create Task
+  auto testTaskSequential = std::make_shared<kozlova_e_radix_batcher_sort_seq::RadixSortSequential>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  for (size_t i = 1; i < count; ++i) {
+    ASSERT_LE(res[i - 1], res[i]);
+  }
+}

--- a/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
@@ -1,0 +1,68 @@
+#include "seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp"
+
+bool kozlova_e_radix_batcher_sort_seq::RadixSortSequential::pre_processing() {
+  internal_order_test();
+  input_size = taskData->inputs_count[0];
+  data.resize(input_size);
+  auto* mas = reinterpret_cast<double*>(taskData->inputs[0]);
+  for (int i = 0; i < input_size; i++) data[i] = mas[i];
+  return true;
+}
+
+bool kozlova_e_radix_batcher_sort_seq::RadixSortSequential::validation() {
+  internal_order_test();
+  return taskData->inputs_count[0] == taskData->outputs_count[0];
+}
+
+bool kozlova_e_radix_batcher_sort_seq::RadixSortSequential::run() {
+  internal_order_test();
+  radixSort(data);
+  return true;
+}
+
+bool kozlova_e_radix_batcher_sort_seq::RadixSortSequential::post_processing() {
+  internal_order_test();
+  for (size_t i = 0; i < data.size(); i++) reinterpret_cast<double*>(taskData->outputs[0])[i] = data[i];
+  return true;
+}
+
+void kozlova_e_radix_batcher_sort_seq::RadixSortSequential::radixSort(std::vector<double>& a) {
+  std::vector<uint64_t> bit_representation(a.size());
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    uint64_t bits = *reinterpret_cast<uint64_t*>(&a[i]);
+    if (bits >> 63) {
+      bit_representation[i] = ~bits;
+    } else {
+      bit_representation[i] = bits | 0x8000000000000000;
+    }
+  }
+
+  for (int bit = 0; bit < 64; ++bit) {
+    std::vector<uint64_t> output(a.size());
+    int count[2] = {0};
+
+    for (size_t i = 0; i < bit_representation.size(); ++i) {
+      count[(bit_representation[i] >> bit) & 1]++;
+    }
+
+    count[1] += count[0];
+
+    for (int i = bit_representation.size() - 1; i >= 0; --i) {
+      int val = (bit_representation[i] >> bit) & 1;
+      output[--count[val]] = bit_representation[i];
+    }
+
+    bit_representation = output;
+  }
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    uint64_t bits = bit_representation[i];
+    if (bits & 0x8000000000000000) {
+      bits &= ~0x8000000000000000;
+    } else {
+      bits = ~bits;
+    }
+    a[i] = *reinterpret_cast<double*>(&bits);
+  }
+}

--- a/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
@@ -63,6 +63,6 @@ void kozlova_e_radix_batcher_sort_seq::RadixSortSequential::radixSort(std::vecto
     } else {
       bits = ~bits;
     }
-    std::memcpy(&a[i], &bits, sizeof(double));
+    memcpy(&a[i], &bits, sizeof(double));
   }
 }

--- a/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
@@ -33,7 +33,7 @@ void kozlova_e_radix_batcher_sort_seq::RadixSortSequential::radixSort(std::vecto
 
   for (size_t i = 0; i < a.size(); ++i) {
     uint64_t bits = *reinterpret_cast<uint64_t*>(&a[i]);
-    if (bits >> 63) {
+    if ((bits >> 63) != 0u) {
       bit_representation[i] = ~bits;
     } else {
       bit_representation[i] = bits | 0x8000000000000000;
@@ -60,7 +60,7 @@ void kozlova_e_radix_batcher_sort_seq::RadixSortSequential::radixSort(std::vecto
 
   for (size_t i = 0; i < a.size(); ++i) {
     uint64_t bits = bit_representation[i];
-    if (bits & 0x8000000000000000) {
+    if ((bits & 0x8000000000000000) != 0u) {
       bits &= ~0x8000000000000000;
     } else {
       bits = ~bits;

--- a/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
@@ -1,5 +1,7 @@
 #include "seq/kozlova_e_radix_batcher_sort/include/ops_seq.hpp"
 
+#include <cstring>
+
 bool kozlova_e_radix_batcher_sort_seq::RadixSortSequential::pre_processing() {
   internal_order_test();
   input_size = taskData->inputs_count[0];

--- a/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_radix_batcher_sort/src/ops_seq.cpp
@@ -63,6 +63,6 @@ void kozlova_e_radix_batcher_sort_seq::RadixSortSequential::radixSort(std::vecto
     } else {
       bits = ~bits;
     }
-    a[i] = *reinterpret_cast<double*>(&bits);
+    std::memcpy(&a[i], &bits, sizeof(double));
   }
 }


### PR DESCRIPTION
### Реализация последовательной версии.
В классе реализована поразрядная сортировка для чисел с плавающей точкой типа double. Каждый элемент массива преобразуется в его 64-битное целочисленное представление, что позволяет работать с числами на уровне их битов. Для корректной сортировки отрицательных чисел старший бит (бит знака) инвертируется, чтобы все отрицательные числа были обработаны как положительные, не нарушая общей логики сортировки. Алгоритм выполняет сортировку, начиная с младшего бита и постепенно переходя к более старшим. На каждом шаге происходит разделение данных на две группы в зависимости от значения текущего бита (0 или 1). После завершения сортировки по всем битам, 64-битные целые числа преобразуются обратно в значения типа double, и отрицательные числа восстанавливают своё исходное состояние.
### Реализация параллельной версии.
С помощью функции scatterv исходный массив разбивается на части, после этого они отправляются на различные процессы. Каждый процесс сортирует свою часть данных, используя алгоритм поразрядной сортировки из последовательной версии. Затем происходит обмен данными между процессами по принципу четно нечетного слияния Бэтчера. Суть метода заключается в чередующемся слиянии данных между процессами на разных этапах.
На каждом шаге один процесс будет обмениваться данными с другим, причем очередность этого обмена зависит от фазы слияния (чётная или нечётная). После каждого обмена данные сортируются локально на каждом процессе. Этот процесс повторяется несколько раз (в зависимости от количества процессов), постепенно улучшая сортировку всего набора данных. Когда все этапы сортировки завершены, главный процесс собирает все части массива в один полностью отсортированный массив с помощью функции gatherv.