### PR TITLE
Revert "Revert "Бессонов Егор. Задача 1. Вариант 21. Интегрирование – метод Монте-Карло.""

### DIFF
--- a/tasks/mpi/bessonov_e_integration_monte_carlo/func_tests/main.cpp
+++ b/tasks/mpi/bessonov_e_integration_monte_carlo/func_tests/main.cpp
@@ -1,0 +1,410 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <memory>
+#include <numbers>
+#include <random>
+
+#include "mpi/bessonov_e_integration_monte_carlo/include/ops_mpi.hpp"
+
+TEST(bessonov_e_integration_monte_carlo_mpi, PositiveRangeTestMPI_sin) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = 0.0;
+  double b = std::numbers::pi;
+  int num_points = 1000000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::sin(x); };
+
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::sin(x); };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 1e-1);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, PositiveRangeTestMPI_log_x_plus_1) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = 1.0;
+  double b = 4.0;
+  int num_points = 1000000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::log(x + 1); };
+
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::log(x + 1); };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 1e-1);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, NegativeRangeTestMPI) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = -(std::numbers::pi);
+  double b = 0.0;
+  int num_points = 100000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::cos(x); };
+
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::cos(x); };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 1e-1);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, VerySmallRangeTestMPI) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = 0.1;
+  double b = 0.11;
+  int num_points = 100000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::cos(x) + std::sin(x); };
+
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::cos(x) + std::sin(x); };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 5e-7);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, LongRangeTestMPI) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = -10.0;
+  double b = 15.0;
+  int num_points = 100000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::cos(x) + x * x; };
+
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::cos(x) + x * x; };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 1e3);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, VeryLongRangeTestMPI) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = -40.0;
+  double b = 50.0;
+  int num_points = 1000000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::sin(x) * std::sin(x) + std::cos(x) * x; };
+
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::sin(x) * std::sin(x) + std::cos(x) * x; };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 3e4);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, EqualRangeTestMPI) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  double a = -1.5;
+  double b = 1.5;
+  int num_points = 100000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::sin(x) * std::sin(x); };
+
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::sin(x) * std::sin(x); };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 3e-1);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, RandomTestMPI) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(-7.0, 7.0);
+  double a = dis(gen);
+  double b = dis(gen);
+
+  if (a > b) std::swap(a, b);
+
+  if (a == b) b += 1.0;
+
+  int num_points = 100000;
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+
+  bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  testMpiTaskParallel.exampl_func = [](double x) { return std::sin(x) * std::cos(x); };
+
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return std::sin(x) * std::cos(x); };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_NEAR(reference_result[0], global_result[0], 3e1);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, TestMpi_InputLess3) {
+  std::shared_ptr<ppc::core::TaskData> taskDataMPIParallel = std::make_shared<ppc::core::TaskData>();
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    double a = -1.0;
+    double b = 1.0;
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    double result = 0.0;
+    taskDataMPIParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(&result));
+
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testTaskMPIParallel(taskDataMPIParallel);
+    ASSERT_EQ(testTaskMPIParallel.validation(), false);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, TestMpi_InputMore3) {
+  std::shared_ptr<ppc::core::TaskData> taskDataMPIParallel = std::make_shared<ppc::core::TaskData>();
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    double a = -1.0;
+    double b = 1.0;
+    int num_points = 1000;
+    double extra_input = 5.0;
+
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&extra_input));
+
+    double result = 0.0;
+    taskDataMPIParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(&result));
+
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testTaskMPIParallel(taskDataMPIParallel);
+    ASSERT_EQ(testTaskMPIParallel.validation(), false);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, TestMpi_OutputLess1) {
+  std::shared_ptr<ppc::core::TaskData> taskDataMPIParallel = std::make_shared<ppc::core::TaskData>();
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    double a = -1.0;
+    double b = 1.0;
+    int num_points = 1000;
+
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testTaskMPIParallel(taskDataMPIParallel);
+    ASSERT_EQ(testTaskMPIParallel.validation(), false);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, TestMpi_OutputMore1) {
+  std::shared_ptr<ppc::core::TaskData> taskDataMPIParallel = std::make_shared<ppc::core::TaskData>();
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    double a = -1.0;
+    double b = 1.0;
+    int num_points = 1000;
+
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataMPIParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+
+    double result1 = 0.0;
+    double result2 = 0.0;
+    taskDataMPIParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(&result1));
+    taskDataMPIParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(&result2));
+
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel testTaskMPIParallel(taskDataMPIParallel);
+    ASSERT_EQ(testTaskMPIParallel.validation(), false);
+  }
+}

--- a/tasks/mpi/bessonov_e_integration_monte_carlo/include/ops_mpi.hpp
+++ b/tasks/mpi/bessonov_e_integration_monte_carlo/include/ops_mpi.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <functional>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace bessonov_e_integration_monte_carlo_mpi {
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  double a, b;
+  int num_points;
+  std::function<double(double)> exampl_func;
+
+ private:
+  double res{};
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  double a, b;
+  int num_points;
+  std::function<double(double)> exampl_func;
+
+ private:
+  double res;
+  boost::mpi::communicator world;
+};
+
+}  // namespace bessonov_e_integration_monte_carlo_mpi

--- a/tasks/mpi/bessonov_e_integration_monte_carlo/perf_tests/main.cpp
+++ b/tasks/mpi/bessonov_e_integration_monte_carlo/perf_tests/main.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/bessonov_e_integration_monte_carlo/include/ops_mpi.hpp"
+
+TEST(bessonov_e_integration_monte_carlo_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  double a = 0.0;
+  double b = 2.0;
+  int num_points = 50000000;
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  auto testMpiTaskParallel = std::make_shared<bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel>(taskDataPar);
+  testMpiTaskParallel->exampl_func = [](double x) { return x * x; };
+
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    std::vector<double> reference_result(1, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_result.data()));
+    bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    testMpiTaskSequential.exampl_func = [](double x) { return x * x; };
+
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+    ASSERT_NEAR(reference_result[0], global_result[0], 40e-1);
+  }
+}
+
+TEST(bessonov_e_integration_monte_carlo_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  std::vector<double> global_result(1, 0.0);
+  double a = 0.0;
+  double b = 2.0;
+  int num_points = 50000000;
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&a));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&b));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&num_points));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_result.data()));
+  }
+  auto testMpiTaskParallel = std::make_shared<bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel>(taskDataPar);
+  testMpiTaskParallel->exampl_func = [](double x) { return x * x; };
+
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    double reference_result = 4.0;
+    ASSERT_NEAR(reference_result, global_result[0], 40e-1);
+  }
+}

--- a/tasks/mpi/bessonov_e_integration_monte_carlo/src/ops_mpi.cpp
+++ b/tasks/mpi/bessonov_e_integration_monte_carlo/src/ops_mpi.cpp
@@ -1,0 +1,95 @@
+#include "mpi/bessonov_e_integration_monte_carlo/include/ops_mpi.hpp"
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  return (taskData->inputs.size() == 3 && taskData->outputs.size() == 1);
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+  a = *reinterpret_cast<double*>(taskData->inputs[0]);
+  b = *reinterpret_cast<double*>(taskData->inputs[1]);
+  num_points = *reinterpret_cast<int*>(taskData->inputs[2]);
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(a, b);
+
+  double sum = 0.0;
+  for (int i = 0; i < num_points; ++i) {
+    double x = dis(gen);
+    sum += exampl_func(x);
+  }
+  res = (b - a) * (sum / num_points);
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    if ((taskData->inputs.size() != 3) || (taskData->outputs.size() != 1)) {
+      return false;
+    }
+    num_points = *reinterpret_cast<int*>(taskData->inputs[2]);
+    if (num_points <= 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    a = *reinterpret_cast<double*>(taskData->inputs[0]);
+    b = *reinterpret_cast<double*>(taskData->inputs[1]);
+    num_points = *reinterpret_cast<int*>(taskData->inputs[2]);
+  }
+
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel::run() {
+  internal_order_test();
+
+  boost::mpi::broadcast(world, a, 0);
+  boost::mpi::broadcast(world, b, 0);
+  boost::mpi::broadcast(world, num_points, 0);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(a, b);
+
+  int remainder = num_points % world.size();
+  int num_points_for_process = num_points / world.size() + (world.rank() < remainder ? 1 : 0);
+
+  double sum = 0.0;
+  for (int i = 0; i < num_points_for_process; ++i) {
+    double x = dis(gen);
+    sum += exampl_func(x);
+  }
+
+  boost::mpi::reduce(world, sum, res, std::plus<>(), 0);
+  if (world.rank() == 0) {
+    res = (b - a) * res / num_points;
+  }
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_mpi::TestMPITaskParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    *reinterpret_cast<double*>(taskData->outputs[0]) = res;
+  }
+  return true;
+}

--- a/tasks/seq/bessonov_e_integration_monte_carlo/func_tests/main.cpp
+++ b/tasks/seq/bessonov_e_integration_monte_carlo/func_tests/main.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "seq/bessonov_e_integration_monte_carlo/include/ops_seq.hpp"
+
+TEST(bessonov_e_integration_monte_carlo_seq, PositiveRangeTest) {
+  double a = 0.0;
+  double b = std::numbers::pi;
+  int num_points = 100000;
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&num_points));
+  double output = 0.0;
+  taskData->outputs.push_back(reinterpret_cast<uint8_t *>(&output));
+  bessonov_e_integration_monte_carlo_seq::TestTaskSequential task(taskData);
+  task.exampl_func = [](double x) { return std::sin(x); };
+
+  ASSERT_TRUE(task.validation());
+  task.pre_processing();
+  task.run();
+  task.post_processing();
+  double expected_result = 2.0;
+  ASSERT_NEAR(output, expected_result, 5e-1);
+}
+
+TEST(bessonov_e_integration_monte_carlo_seq, NegativeRangeTest) {
+  double a = -(std::numbers::pi);
+  double b = 0.0;
+  int num_points = 100000;
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&num_points));
+  double output = 0.0;
+  taskData->outputs.push_back(reinterpret_cast<uint8_t *>(&output));
+  bessonov_e_integration_monte_carlo_seq::TestTaskSequential task(taskData);
+  task.exampl_func = [](double x) { return std::sin(x); };
+
+  ASSERT_TRUE(task.validation());
+  task.pre_processing();
+  task.run();
+  task.post_processing();
+  double expected_result = -2.0;
+  ASSERT_NEAR(output, expected_result, 5e-1);
+}
+
+TEST(bessonov_e_integration_monte_carlo_seq, FullRangeTest) {
+  double a = -1.0;
+  double b = 2.0;
+  int num_points = 100000;
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&num_points));
+  double output = 0.0;
+  taskData->outputs.push_back(reinterpret_cast<uint8_t *>(&output));
+  bessonov_e_integration_monte_carlo_seq::TestTaskSequential task(taskData);
+  task.exampl_func = [](double x) { return std::exp(x); };
+
+  ASSERT_TRUE(task.validation());
+  task.pre_processing();
+  task.run();
+  task.post_processing();
+  double expected_result = 7.02;
+  ASSERT_NEAR(output, expected_result, 5e-1);
+}
+
+TEST(bessonov_e_integration_monte_carlo_seq, InputSizeLessThan3) {
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  double a = 0.0;
+  double b = 1.0;
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  double output = 0.0;
+  taskData->outputs.push_back(reinterpret_cast<uint8_t *>(&output));
+  bessonov_e_integration_monte_carlo_seq::TestTaskSequential task(taskData);
+  task.exampl_func = [](double x) { return std::exp(x); };
+  ASSERT_FALSE(task.validation());
+}
+
+TEST(bessonov_e_integration_monte_carlo_seq, OutputSizeLessThan1) {
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  double a = 0.0;
+  double b = 1.0;
+  int num_points = 10000;
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&num_points));
+  bessonov_e_integration_monte_carlo_seq::TestTaskSequential task(taskData);
+  task.exampl_func = [](double x) { return std::exp(x); };
+  ASSERT_FALSE(task.validation());
+}

--- a/tasks/seq/bessonov_e_integration_monte_carlo/include/ops_seq.hpp
+++ b/tasks/seq/bessonov_e_integration_monte_carlo/include/ops_seq.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <functional>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace bessonov_e_integration_monte_carlo_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  double a, b;
+  int num_points;
+  std::function<double(double)> exampl_func;
+
+ private:
+  double res{};
+};
+
+}  // namespace bessonov_e_integration_monte_carlo_seq

--- a/tasks/seq/bessonov_e_integration_monte_carlo/perf_tests/main.cpp
+++ b/tasks/seq/bessonov_e_integration_monte_carlo/perf_tests/main.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/bessonov_e_integration_monte_carlo/include/ops_seq.hpp"
+
+TEST(bessonov_e_integration_monte_carlo_seq, TestPipelineRun) {
+  double a = 0.0;
+  double b = 3.0;
+  int num_points = 10000000;
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&num_points));
+  double output = 9.0;
+  taskData->outputs.push_back(reinterpret_cast<uint8_t *>(&output));
+  auto testTaskSequential = std::make_shared<bessonov_e_integration_monte_carlo_seq::TestTaskSequential>(taskData);
+  testTaskSequential->exampl_func = [](double x) { return x * x; };
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  double expected_result = 9.0;
+  ASSERT_NEAR(output, expected_result, 1e-1);
+}
+
+TEST(bessonov_e_integration_monte_carlo_seq, TestTaskRun) {
+  double a = 0.0;
+  double b = 3.0;
+  int num_points = 10000000;
+  auto taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&a));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&b));
+  taskData->inputs.push_back(reinterpret_cast<uint8_t *>(&num_points));
+  double output = 9.0;
+  taskData->outputs.push_back(reinterpret_cast<uint8_t *>(&output));
+  auto testTaskSequential = std::make_shared<bessonov_e_integration_monte_carlo_seq::TestTaskSequential>(taskData);
+  testTaskSequential->exampl_func = [](double x) { return x * x; };
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  double expected_result = 9.0;
+  ASSERT_NEAR(output, expected_result, 1e-1);
+}

--- a/tasks/seq/bessonov_e_integration_monte_carlo/src/ops_seq.cpp
+++ b/tasks/seq/bessonov_e_integration_monte_carlo/src/ops_seq.cpp
@@ -1,0 +1,36 @@
+#include "seq/bessonov_e_integration_monte_carlo/include/ops_seq.hpp"
+
+bool bessonov_e_integration_monte_carlo_seq::TestTaskSequential::validation() {
+  internal_order_test();
+  return (taskData->inputs.size() == 3 && taskData->outputs.size() == 1);
+}
+
+bool bessonov_e_integration_monte_carlo_seq::TestTaskSequential::pre_processing() {
+  internal_order_test();
+  a = *reinterpret_cast<double*>(taskData->inputs[0]);
+  b = *reinterpret_cast<double*>(taskData->inputs[1]);
+  num_points = *reinterpret_cast<int*>(taskData->inputs[2]);
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_seq::TestTaskSequential::run() {
+  internal_order_test();
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(a, b);
+
+  double sum = 0.0;
+  for (int i = 0; i < num_points; ++i) {
+    double x = dis(gen);
+    sum += exampl_func(x);
+  }
+
+  res = (b - a) * (sum / num_points);
+  return true;
+}
+
+bool bessonov_e_integration_monte_carlo_seq::TestTaskSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+  return true;
+}


### PR DESCRIPTION
SEQ:
Метод pre_processing() извлекает границы интегрирования a и b, а также количество случайных точек num_points из входных данных.
Интегрирование:
Метод run() выполняет следующие действия:

Инициализирует генератор случайных чисел.
Генерирует num_points случайных значений x в диапазоне [a, b].
Для каждого x вычисляет значение функции и суммирует результаты.
Вычисляет итоговый результат интегрирования как произведение диапазона интегрирования (b - a) на среднее значение вычисленных функций.
MPI
Метод run() выполняет следующие действия на каждом процессе:

Определяет количество точек num_points_for_process, которое необходимо обработать текущему процессу, учитывая общее количество процессов и возможный остаток.
Генерирует num_points_for_process случайных значений x в диапазоне [a, b].
Вычисляет_ значение функции для каждого x и суммирует результаты в переменную sum.
Сбор результатов:
reduce() суммирует все результаты.
В корневом процессе вычисляется итоговый результат интегрирования как (b - a) * (res / num_points)


**Второй реверт** произошёл из-за perf тестов, сейчас я их исправил