### PR TITLE
FIX Revert Плеханов Даниил. Задача 2. Вариант 7. Реализация all_reduce.

### DIFF
--- a/tasks/mpi/plekhanov_d_allreduce_boost/func_tests/main.cpp
+++ b/tasks/mpi/plekhanov_d_allreduce_boost/func_tests/main.cpp
@@ -1,0 +1,606 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+
+#include "mpi/plekhanov_d_allreduce_boost/include/ops_mpi.hpp"
+
+static std::vector<int> getRandomMatrix(int size) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<int> vec(size);
+  for (int i = 0; i < size; i++) {
+    int value = gen() % 1000 - 100;
+    if (value <= 0) {
+      continue;
+    }
+    vec[i] = value;
+  }
+  return vec;
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_Empty_Matrix_0x0) {
+  boost::mpi::communicator world;
+
+  int cols = 0;
+  int rows = 0;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_Empty_Matrix_5x5) {
+  boost::mpi::communicator world;
+
+  int cols = 5;
+  int rows = 5;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_Negative_Matrix_5x5) {
+  boost::mpi::communicator world;
+
+  int cols = -5;
+  int rows = -5;
+
+  if (cols < 0 || rows < 0) {
+    return;
+  }
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_3x17_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 3;
+  int rows = 17;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_9x9_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 9;
+  int rows = 9;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_1x1_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 1;
+  int rows = 1;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_50x50_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 50;
+  int rows = 50;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_30x120_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 30;
+  int rows = 120;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_Negative_30x120_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = -30;
+  int rows = -120;
+
+  if (cols < 0 || rows < 0) {
+    return;
+  }
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_512x512_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 512;
+  int rows = 512;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_1024x1024_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 1024;
+  int rows = 1024;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_func_test, Test_5000x5000_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 5000;
+  int rows = 5000;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<int> res_seq(cols, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    // Create Task
+    plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}

--- a/tasks/mpi/plekhanov_d_allreduce_boost/include/ops_mpi.hpp
+++ b/tasks/mpi/plekhanov_d_allreduce_boost/include/ops_mpi.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <iomanip>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace plekhanov_d_allreduce_boost_mpi {
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> inputData_;
+  std::vector<int> resultData_;
+  int columnCount{};
+  int rowCount{};
+  std::vector<int> countAboveMin_;
+};
+
+class TestMPITaskBoostParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskBoostParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> inputData_;
+  std::vector<int> resultData_;
+  std::vector<int> countAboveMin_;
+  std::vector<int> count_greater;
+  std::vector<int> localInputData_;
+  int columnCount{};
+  int rowCount{};
+  boost::mpi::communicator world;
+};
+
+}  // namespace plekhanov_d_allreduce_boost_mpi

--- a/tasks/mpi/plekhanov_d_allreduce_boost/perf_tests/main.cpp
+++ b/tasks/mpi/plekhanov_d_allreduce_boost/perf_tests/main.cpp
@@ -1,0 +1,98 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/plekhanov_d_allreduce_boost/include/ops_mpi.hpp"
+
+TEST(plekhanov_d_allreduce_boost_perf_test, test_pipeline_run) {
+  int rows = 5000;
+  int columns = 5000;
+  boost::mpi::communicator world;
+  std::vector<int> matrix;
+  std::vector<int32_t> max_vec_mpi(columns, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    matrix = std::vector<int>(rows * columns, 1);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(columns);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(max_vec_mpi.data()));
+    taskDataPar->outputs_count.emplace_back(max_vec_mpi.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    for (unsigned i = 0; i < max_vec_mpi.size(); i++) {
+      EXPECT_EQ(0, max_vec_mpi[0]);
+    }
+  }
+}
+
+TEST(plekhanov_d_allreduce_boost_perf_test, test_task_run) {
+  int rows = 5000;
+  int columns = 5000;
+  boost::mpi::communicator world;
+  std::vector<int> matrix;
+  std::vector<int32_t> max_vec_mpi(columns, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    matrix = std::vector<int>(rows * columns, 1);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(columns);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(max_vec_mpi.data()));
+    taskDataPar->outputs_count.emplace_back(max_vec_mpi.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    for (unsigned i = 0; i < max_vec_mpi.size(); i++) {
+      EXPECT_EQ(0, max_vec_mpi[0]);
+    }
+  }
+}

--- a/tasks/mpi/plekhanov_d_allreduce_boost/src/ops_mpi.cpp
+++ b/tasks/mpi/plekhanov_d_allreduce_boost/src/ops_mpi.cpp
@@ -1,0 +1,145 @@
+#include "mpi/plekhanov_d_allreduce_boost/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+  columnCount = taskData->inputs_count[1];
+  rowCount = taskData->inputs_count[2];
+
+  auto* tempPtr = reinterpret_cast<int*>(taskData->inputs[0]);
+  inputData_.assign(tempPtr, tempPtr + taskData->inputs_count[0]);
+
+  resultData_.resize(columnCount, 0);
+  countAboveMin_.resize(columnCount, 0);
+
+  return true;
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  return (taskData->inputs_count[1] != 0 && taskData->inputs_count[2] != 0 && !taskData->inputs.empty() &&
+          taskData->inputs_count[0] > 0 && (taskData->inputs_count[1] == taskData->outputs_count[0]));
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+
+  for (int column = 0; column < columnCount; column++) {
+    int columnMin = inputData_[column];
+    for (int row = 1; row < rowCount; row++) {
+      int value = inputData_[row * columnCount + column];
+      if (value < columnMin) {
+        columnMin = value;
+      }
+    }
+    resultData_[column] = columnMin;
+  }
+
+  for (int column = 0; column < columnCount; column++) {
+    for (int row = 0; row < rowCount; row++) {
+      if (inputData_[row * columnCount + column] > resultData_[column]) {
+        countAboveMin_[column]++;
+      }
+    }
+  }
+  return true;
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  for (int i = 0; i < columnCount; i++) {
+    reinterpret_cast<int*>(taskData->outputs[0])[i] = countAboveMin_[i];
+  }
+  return true;
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel::pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    columnCount = taskData->inputs_count[1];
+    rowCount = taskData->inputs_count[2];
+  }
+
+  if (world.rank() == 0) {
+    // init vectors
+    auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+    inputData_.assign(tmp_ptr, tmp_ptr + taskData->inputs_count[0]);
+  } else {
+    inputData_ = std::vector<int>(columnCount * rowCount, 0);
+  }
+
+  return true;
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    return (taskData->inputs_count[1] != 0 && taskData->inputs_count[2] != 0 && !taskData->inputs.empty() &&
+            taskData->inputs_count[0] > 0 && (taskData->inputs_count[1] == taskData->outputs_count[0]));
+  }
+  return true;
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel::run() {
+  internal_order_test();
+
+  broadcast(world, rowCount, 0);
+  broadcast(world, columnCount, 0);
+
+  int lambda_1 = rowCount / world.size();
+  int lambda_2 = rowCount % world.size();
+
+  broadcast(world, lambda_1, 0);
+  broadcast(world, lambda_2, 0);
+
+  std::vector<int> size(world.size(), (lambda_1 * columnCount));
+  for (int i = 0; i < lambda_2; i++) size[world.size() - i - 1] += columnCount;
+
+  localInputData_.resize(size[world.rank()]);
+  scatterv(world, inputData_, size, localInputData_.data(), 0);
+
+  std::vector<int> min_by_cols(columnCount, std::numeric_limits<int>::max());
+  std::vector<int> local_min_by_cols(columnCount, std::numeric_limits<int>::max());
+  count_greater.resize(columnCount, 0);
+  std::vector<int> local_count_greater(columnCount, 0);
+
+  if (!localInputData_.empty()) {
+    for (size_t j = 0; j < localInputData_.size() / columnCount; j++) {
+      for (int i = 0; i < columnCount; i++) {
+        int value = localInputData_[j * columnCount + i];
+        if (value < local_min_by_cols[i]) local_min_by_cols[i] = value;
+      }
+    }
+  }
+  boost::mpi::all_reduce(world, local_min_by_cols.data(), columnCount, min_by_cols.data(), boost::mpi::minimum<int>());
+
+  if (!localInputData_.empty()) {
+    for (size_t j = 0; j < localInputData_.size() / columnCount; j++) {
+      for (int i = 0; i < columnCount; i++) {
+        if (localInputData_[j * columnCount + i] > min_by_cols[i]) {
+          local_count_greater[i]++;
+        }
+      }
+    }
+  }
+  boost::mpi::all_reduce(world, local_count_greater.data(), columnCount, count_greater.data(), std::plus<>());
+
+  return true;
+}
+
+bool plekhanov_d_allreduce_boost_mpi::TestMPITaskBoostParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    for (int i = 0; i < columnCount; i++) {
+      reinterpret_cast<int*>(taskData->outputs[0])[i] = count_greater[i];
+    }
+  }
+  return true;
+}

--- a/tasks/mpi/plekhanov_d_allreduce_mine/func_tests/main.cpp
+++ b/tasks/mpi/plekhanov_d_allreduce_mine/func_tests/main.cpp
@@ -1,0 +1,506 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+
+#include "mpi/plekhanov_d_allreduce_mine/include/ops_mpi.hpp"
+
+static std::vector<int> getRandomMatrix1(int size) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<int> vec(size);
+  for (int i = 0; i < size; i++) {
+    int value = gen() % 1000 - 100;
+    if (value <= 0) {
+      continue;
+    }
+    vec[i] = value;
+  }
+  return vec;
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_Empty_Matrix_0x0) {
+  boost::mpi::communicator world;
+
+  int cols = 0;
+  int rows = 0;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_1x1_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 1;
+  int rows = 1;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_Empty_Matrix_5x5) {
+  boost::mpi::communicator world;
+
+  int cols = 5;
+  int rows = 5;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_Empty_Negative_Matrix_5x5) {
+  boost::mpi::communicator world;
+
+  int cols = -5;
+  int rows = -5;
+
+  if (cols < 0 || rows < 0) {
+    return;
+  }
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_3x20_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 3;
+  int rows = 20;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_50x50_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 50;
+  int rows = 50;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_30x120_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 30;
+  int rows = 120;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_Negative_30x120_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = -30;
+  int rows = -120;
+
+  if (cols < 0 || rows < 0) {
+    return;
+  }
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_512x512_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 512;
+  int rows = 512;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_1024x1024_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 1024;
+  int rows = 1024;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_func_test, Test_5000x5000_Matrix) {
+  boost::mpi::communicator world;
+
+  int cols = 5000;
+  int rows = 5000;
+
+  std::vector<int> matrix;
+  std::vector<int> res_par(cols, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    const int count_size_vector = cols * rows;
+    matrix = getRandomMatrix1(count_size_vector);
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(cols);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_par.data()));
+    taskDataPar->outputs_count.emplace_back(res_par.size());
+  }
+
+  plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int> res_seq(cols, 0);
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataSeq->inputs_count.emplace_back(matrix.size());
+    taskDataSeq->inputs_count.emplace_back(cols);
+    taskDataSeq->inputs_count.emplace_back(rows);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(res_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(res_seq.size());
+    plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(res_seq, res_par);
+  }
+}

--- a/tasks/mpi/plekhanov_d_allreduce_mine/include/ops_mpi.hpp
+++ b/tasks/mpi/plekhanov_d_allreduce_mine/include/ops_mpi.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <iomanip>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace plekhanov_d_allreduce_mine_mpi {
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> inputData_;
+  std::vector<int> resultData_;
+  int columnCount{};
+  int rowCount{};
+  std::vector<int> countAboveMin_;
+};
+
+class TestMPITaskMyOwnParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskMyOwnParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+  template <typename T>
+  void my_all_reduce(const boost::mpi::communicator& world, const T* in_values, T* out_values, int n);
+
+ private:
+  std::vector<int> inputData_;
+  std::vector<int> resultData_;
+  std::vector<int> countAboveMin_;
+  std::vector<int> count_greater;
+  std::vector<int> localInputData_;
+  int columnCount{};
+  int rowCount{};
+  boost::mpi::communicator world;
+};
+
+}  // namespace plekhanov_d_allreduce_mine_mpi

--- a/tasks/mpi/plekhanov_d_allreduce_mine/perf_tests/main.cpp
+++ b/tasks/mpi/plekhanov_d_allreduce_mine/perf_tests/main.cpp
@@ -1,0 +1,87 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/plekhanov_d_allreduce_mine/include/ops_mpi.hpp"
+
+TEST(plekhanov_d_allreduce_mine_perf_test, test_pipeline_run) {
+  int rows = 5000;
+  int columns = 5000;
+  boost::mpi::communicator world;
+  std::vector<int> matrix;
+  std::vector<int32_t> max_vec_mpi(columns, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    matrix = std::vector<int>(rows * columns, 1);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(columns);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(max_vec_mpi.data()));
+    taskDataPar->outputs_count.emplace_back(max_vec_mpi.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    for (unsigned i = 0; i < max_vec_mpi.size(); i++) {
+      EXPECT_EQ(0, max_vec_mpi[0]);
+    }
+  }
+}
+
+TEST(plekhanov_d_allreduce_mine_perf_test, test_task_run) {
+  int rows = 5000;
+  int columns = 5000;
+  boost::mpi::communicator world;
+  std::vector<int> matrix;
+  std::vector<int32_t> max_vec_mpi(columns, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    matrix = std::vector<int>(rows * columns, 1);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+    taskDataPar->inputs_count.emplace_back(matrix.size());
+    taskDataPar->inputs_count.emplace_back(columns);
+    taskDataPar->inputs_count.emplace_back(rows);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(max_vec_mpi.data()));
+    taskDataPar->outputs_count.emplace_back(max_vec_mpi.size());
+  }
+
+  auto testMpiTaskParallel = std::make_shared<plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    for (unsigned i = 0; i < max_vec_mpi.size(); i++) {
+      EXPECT_EQ(0, max_vec_mpi[0]);
+    }
+  }
+}

--- a/tasks/mpi/plekhanov_d_allreduce_mine/src/ops_mpi.cpp
+++ b/tasks/mpi/plekhanov_d_allreduce_mine/src/ops_mpi.cpp
@@ -1,0 +1,185 @@
+#include "mpi/plekhanov_d_allreduce_mine/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <string>
+#include <vector>
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+
+  columnCount = taskData->inputs_count[1];
+  rowCount = taskData->inputs_count[2];
+
+  auto *tempPtr = reinterpret_cast<int *>(taskData->inputs[0]);
+  inputData_.assign(tempPtr, tempPtr + taskData->inputs_count[0]);
+
+  resultData_ = std::vector<int>(columnCount, 0);
+  countAboveMin_ = std::vector<int>(columnCount, 0);
+
+  return true;
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  return (taskData->inputs_count[1] != 0 && taskData->inputs_count[2] != 0 && !taskData->inputs.empty() &&
+          taskData->inputs_count[0] > 0 && (taskData->inputs_count[1] == taskData->outputs_count[0]));
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+  for (int column = 0; column < columnCount; column++) {
+    int columnMin = inputData_[column];
+    for (int row = 1; row < rowCount; row++) {
+      if (inputData_[row * columnCount + column] < columnMin) {
+        columnMin = inputData_[row * columnCount + column];
+      }
+    }
+    resultData_[column] = columnMin;
+  }
+  for (int column = 0; column < columnCount; column++) {
+    for (int row = 0; row < rowCount; row++) {
+      if (inputData_[row * columnCount + column] > resultData_[column]) {
+        countAboveMin_[column]++;
+      }
+    }
+  }
+  return true;
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  for (int i = 0; i < columnCount; i++) {
+    reinterpret_cast<int *>(taskData->outputs[0])[i] = countAboveMin_[i];
+  }
+  return true;
+}
+
+template <typename T>
+void plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel::my_all_reduce(const boost::mpi::communicator &world,
+                                                                             const T *in_values, T *out_values, int n) {
+  int root = world.rank();
+  std::vector<T> left_values(n);
+  std::vector<T> right_values(n);
+
+  int left_child = 2 * root + 1;
+  int right_child = 2 * root + 2;
+
+  std::copy(in_values, in_values + n, out_values);
+
+  if (left_child < world.size()) {
+    world.recv(left_child, 0, left_values.data(), n);
+  }
+
+  if (right_child < world.size()) {
+    world.recv(right_child, 0, right_values.data(), n);
+  }
+
+  for (int i = 0; i < n; ++i) {
+    if (left_child < world.size()) {
+      out_values[i] = std::min(out_values[i], left_values[i]);
+    }
+    if (right_child < world.size()) {
+      out_values[i] = std::min(out_values[i], right_values[i]);
+    }
+  }
+  if (root != 0) {
+    int parent = (root - 1) / 2;
+    world.send(parent, 0, out_values, n);
+    world.recv(parent, 0, out_values, n);
+  }
+
+  if (left_child < world.size()) {
+    world.send(left_child, 0, out_values, n);
+  }
+
+  if (right_child < world.size()) {
+    world.send(right_child, 0, out_values, n);
+  }
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel::pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    columnCount = taskData->inputs_count[1];
+    rowCount = taskData->inputs_count[2];
+  }
+
+  if (world.rank() == 0) {
+    // init vectors
+    auto *tmp_ptr = reinterpret_cast<int *>(taskData->inputs[0]);
+    inputData_.assign(tmp_ptr, tmp_ptr + taskData->inputs_count[0]);
+  } else {
+    inputData_ = std::vector<int>(columnCount * rowCount, 0);
+  }
+
+  return true;
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    return (taskData->inputs_count[1] != 0 && taskData->inputs_count[2] != 0 && !taskData->inputs.empty() &&
+            taskData->inputs_count[0] > 0 && (taskData->inputs_count[1] == taskData->outputs_count[0]));
+  }
+  return true;
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel::run() {
+  internal_order_test();
+
+  broadcast(world, rowCount, 0);
+  broadcast(world, columnCount, 0);
+
+  int lambda_1 = rowCount / world.size();
+  int lambda_2 = rowCount % world.size();
+
+  broadcast(world, lambda_1, 0);
+  broadcast(world, lambda_2, 0);
+
+  std::vector<int> size(world.size(), (lambda_1 * columnCount));
+  for (int i = 0; i < lambda_2; i++) size[world.size() - i - 1] += columnCount;
+
+  localInputData_.resize(size[world.rank()]);
+  scatterv(world, inputData_, size, localInputData_.data(), 0);
+
+  std::vector<int> min_by_cols(columnCount, std::numeric_limits<int>::max());
+  std::vector<int> local_min_by_cols(columnCount, std::numeric_limits<int>::max());
+  count_greater.resize(columnCount, 0);
+  std::vector<int> local_count_greater(columnCount, 0);
+
+  if (!localInputData_.empty()) {
+    for (size_t j = 0; j < localInputData_.size() / columnCount; j++) {
+      for (int i = 0; i < columnCount; i++) {
+        int value = localInputData_[j * columnCount + i];
+        if (value < local_min_by_cols[i]) local_min_by_cols[i] = value;
+      }
+    }
+  }
+  boost::mpi::all_reduce(world, local_min_by_cols.data(), columnCount, min_by_cols.data(), boost::mpi::minimum<int>());
+
+  if (!localInputData_.empty()) {
+    for (size_t j = 0; j < localInputData_.size() / columnCount; j++) {
+      for (int i = 0; i < columnCount; i++) {
+        if (localInputData_[j * columnCount + i] > min_by_cols[i]) {
+          local_count_greater[i]++;
+        }
+      }
+    }
+  }
+  boost::mpi::all_reduce(world, local_count_greater.data(), columnCount, count_greater.data(), std::plus<>());
+
+  return true;
+}
+
+bool plekhanov_d_allreduce_mine_mpi::TestMPITaskMyOwnParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    for (int i = 0; i < columnCount; i++) {
+      reinterpret_cast<int *>(taskData->outputs[0])[i] = count_greater[i];
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
### **Я форкнул репозиторий с нового аккаунта, на основном не собирается ветка. Я уже был в мастере**

https://github.com/learning-process/ppc-2024-autumn/pull/412#event-15651011898 - мой основной PR

Последовательное решение
В последовательном подходе мы начинаем с того, что проходим по каждому столбцу матрицы и находим минимальное значение в каждом из них. Для этого мы инициализируем переменную, которая будет хранить текущее минимальное значение, и сравниваем её с каждым элементом столбца. Как только мы определили минимум для столбца, мы переходим к следующему этапу — подсчету количества элементов, которые больше найденного минимума. Мы снова проходим по этому столбцу, увеличивая счетчик каждый раз, когда находим элемент, больший, чем минимум. В итоге мы получаем массив минимумов и массивы с количеством элементов, которые больше этих минимумов для каждого столбца.

MPI решение
В параллельном решении с использованием MPI мы разбиваем матрицу на части, распределяя её между несколькими потоками (процессами). Каждый поток получает определенное количество столбцов для обработки. Затем каждый процесс ищет минимумы в своих локальных столбцах. После того, как все процессы завершили поиск минимумов, мы используем операцию all_reduce, чтобы собрать и сравнить результаты от всех потоков. Эта операция позволяет получить глобальные минимумы, которые затем передаются всем процессам.

Следующим шагом каждый поток снова проходит по своим столбцам, но теперь он сравнивает элементы с глобальными минимумами, чтобы подсчитать количество значений, которые больше этих минимумов.