### PR TITLE
Fix "Revert "Ковалев Константин. Задача 1. Вариант 6. Нахождение числа нарушений упорядоченности соседних элементов вектора.""

### DIFF
--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/func_tests/main.cpp
@@ -1,0 +1,241 @@
+#include <gtest/gtest.h>
+
+#include "mpi/kovalev_k_num_of_orderly_violations/include/header.hpp"
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, zero_length) {
+  std::vector<int> in;
+  std::vector<size_t> out;
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int> tmpTaskPar(tmpPar);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(tmpTaskPar.validation());
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_viol_0_int_) {
+  const size_t length = 100;
+  std::srand(std::time(nullptr));
+  const int alpha = rand();
+  std::vector<int> in(length, alpha);
+  std::vector<size_t> out(1, 0);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  size_t result = 0;
+  if (world.rank() == 0) {
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_100_opposite_sort_int_) {
+  const size_t length = 100;
+  std::srand(std::time(nullptr));
+  const int alpha = rand();
+  std::vector<int> in(length, alpha);
+  std::vector<size_t> out(1, 0);
+  for (size_t i = 0; i < length; i++) {
+    in[i] = 2 * length - i;
+  }
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  size_t result = length - 1;
+  if (world.rank() == 0) {
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10_rand_int_) {
+  const size_t length = 10;
+  std::vector<int> in(length);
+  std::vector<size_t> out(1, 0);
+  std::srand(std::time(nullptr));
+  for (size_t i = 0; i < length; i++) in[i] = rand() * std::pow(-1, rand());
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    size_t result = 0;
+    for (size_t i = 1; i < length; i++)
+      if (in[i - 1] > in[i]) result++;
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10000_rand_int_) {
+  const size_t length = 10000;
+  std::vector<int> in(length);
+  std::vector<size_t> out(1, 0);
+  std::srand(std::time(nullptr));
+  for (size_t i = 0; i < length; i++) in[i] = rand() * std::pow(-1, rand());
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    size_t result = 0;
+    for (size_t i = 1; i < length; i++)
+      if (in[i - 1] > in[i]) result++;
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_viol_0_double_) {
+  const size_t length = 100;
+  auto max = static_cast<double>(1000000);
+  auto min = static_cast<double>(-1000000);
+  std::srand(std::time(nullptr));
+  const double alpha = min + static_cast<double>(rand()) / RAND_MAX * (max - min);
+  std::vector<double> in(length, alpha);
+  std::vector<size_t> out(1, 0);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  size_t result = 0;
+  if (world.rank() == 0) {
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_100_opposite_sort_double_) {
+  const size_t length = 100;
+  std::srand(std::time(nullptr));
+  const double alpha = (static_cast<double>(rand()) - 1) / (RAND_MAX);
+  std::vector<double> in(length);
+  std::vector<size_t> out(1, 0);
+  in[0] = static_cast<double>(length);
+  for (size_t i = 1; i < length; i++) {
+    in[i] = in[i - 1] * alpha;
+  }
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  size_t result = length - 1;
+  if (world.rank() == 0) {
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10_rand_double_) {
+  const size_t length = 10;
+  std::vector<double> in(length);
+  auto max = static_cast<double>(1000000);
+  auto min = static_cast<double>(-1000000);
+  std::srand(std::time(nullptr));
+  for (size_t i = 0; i < length; i++) in[i] = min + static_cast<double>(rand()) / RAND_MAX * (max - min);
+  std::vector<size_t> out(1, 0);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    size_t result = 0;
+    for (size_t i = 1; i < length; i++)
+      if (in[i - 1] > in[i]) result++;
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10000_rand_double_) {
+  const size_t length = 10000;
+  std::vector<double> in(length);
+  auto max = static_cast<double>(1000000);
+  auto min = static_cast<double>(-1000000);
+  std::srand(std::time(nullptr));
+  for (size_t i = 0; i < length; i++) in[i] = min + static_cast<double>(rand()) / RAND_MAX * (max - min);
+  std::vector<size_t> out(1, 0);
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  if (world.rank() == 0) {
+    size_t result = 0;
+    for (size_t i = 1; i < length; i++)
+      if (in[i - 1] > in[i]) result++;
+    ASSERT_EQ(result, out[0]);
+  }
+}

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/func_tests/main.cpp
@@ -153,15 +153,14 @@ TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_viol_0_double_) {
   }
 }
 
-TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_100_opposite_sort_double_) {
+TEST(kovalev_k_num_of_orderly_violations_mpi, len_100_opposite_sort_double_) {
   const size_t length = 100;
   std::srand(std::time(nullptr));
   const double alpha = (static_cast<double>(rand()) - 1) / (RAND_MAX);
   std::vector<double> in(length);
   std::vector<size_t> out(1, 0);
-  in[0] = static_cast<double>(length);
-  for (size_t i = 1; i < length; i++) {
-    in[i] = in[i - 1] * alpha;
+  for (size_t i = 0; i < length; i++) {
+    in[i] = (length - i) * 1.0;
   }
   boost::mpi::communicator world;
   std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
@@ -182,11 +181,39 @@ TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_100_opposite_sort_do
   }
 }
 
-TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10_rand_double_) {
+TEST(kovalev_k_num_of_orderly_violations_mpi, len_10000_opposite_sort_double_) {
+  const size_t length = 10000;
+  std::srand(std::time(nullptr));
+  const double alpha = (static_cast<double>(rand()) - 1) / (RAND_MAX);
+  std::vector<double> in(length);
+  std::vector<size_t> out(1, 0);
+  for (size_t i = 0; i < length; i++) {
+    in[i] = (length - i) * 1.0;
+  }
+  boost::mpi::communicator world;
+  std::shared_ptr<ppc::core::TaskData> tmpPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    tmpPar->inputs_count.emplace_back(in.size());
+    tmpPar->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    tmpPar->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    tmpPar->outputs_count.emplace_back(out.size());
+  }
+  kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double> tmpTaskPar(tmpPar);
+  ASSERT_TRUE(tmpTaskPar.validation());
+  tmpTaskPar.pre_processing();
+  tmpTaskPar.run();
+  tmpTaskPar.post_processing();
+  size_t result = length - 1;
+  if (world.rank() == 0) {
+    ASSERT_EQ(result, out[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, len_10_rand_double_) {
   const size_t length = 10;
   std::vector<double> in(length);
-  auto max = static_cast<double>(1000000);
-  auto min = static_cast<double>(-1000000);
+  double max = 1000000.0;
+  double min = -1000000.0;
   std::srand(std::time(nullptr));
   for (size_t i = 0; i < length; i++) in[i] = min + static_cast<double>(rand()) / RAND_MAX * (max - min);
   std::vector<size_t> out(1, 0);
@@ -211,11 +238,11 @@ TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10_rand_double_) {
   }
 }
 
-TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_len_10000_rand_double_) {
+TEST(kovalev_k_num_of_orderly_violations_mpi, len_10000_rand_double_) {
   const size_t length = 10000;
   std::vector<double> in(length);
-  auto max = static_cast<double>(1000000);
-  auto min = static_cast<double>(-1000000);
+  double max = 1000000.0;
+  double min = -1000000.0;
   std::srand(std::time(nullptr));
   for (size_t i = 0; i < length; i++) in[i] = min + static_cast<double>(rand()) / RAND_MAX * (max - min);
   std::vector<size_t> out(1, 0);

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/func_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/func_tests/main.cpp
@@ -156,7 +156,6 @@ TEST(kovalev_k_num_of_orderly_violations_mpi, Test_NoOV_viol_0_double_) {
 TEST(kovalev_k_num_of_orderly_violations_mpi, len_100_opposite_sort_double_) {
   const size_t length = 100;
   std::srand(std::time(nullptr));
-  const double alpha = (static_cast<double>(rand()) - 1) / (RAND_MAX);
   std::vector<double> in(length);
   std::vector<size_t> out(1, 0);
   for (size_t i = 0; i < length; i++) {
@@ -184,7 +183,6 @@ TEST(kovalev_k_num_of_orderly_violations_mpi, len_100_opposite_sort_double_) {
 TEST(kovalev_k_num_of_orderly_violations_mpi, len_10000_opposite_sort_double_) {
   const size_t length = 10000;
   std::srand(std::time(nullptr));
-  const double alpha = (static_cast<double>(rand()) - 1) / (RAND_MAX);
   std::vector<double> in(length);
   std::vector<size_t> out(1, 0);
   for (size_t i = 0; i < length; i++) {

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/include/header.hpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/include/header.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <boost/mpi.hpp>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalev_k_num_of_orderly_violations_mpi {
+template <class T>
+class NumOfOrderlyViolationsPar : public ppc::core::Task {
+ private:
+  std::vector<T> glob_v;
+  std::vector<T> loc_v;
+  size_t n = 0, l_res = 0, g_res = 0;
+  int rank, size;
+  boost::mpi::communicator world;
+
+ public:
+  explicit NumOfOrderlyViolationsPar(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(taskData_) {}
+  bool count_num_of_orderly_violations_mpi();
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+};
+}  // namespace kovalev_k_num_of_orderly_violations_mpi

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/perf_tests/main.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/perf_tests/main.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <cmath>
+#include <ctime>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/kovalev_k_num_of_orderly_violations/include/header.hpp"
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  int rank = world.rank();
+  std::vector<int> g_vec;
+  std::vector<size_t> g_num_viol(1, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  size_t length;
+  const int alpha = 1;
+  if (rank == 0) {
+    length = 10;
+    g_vec = std::vector<int>(length, alpha);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(g_vec.data()));
+    taskDataPar->inputs_count.emplace_back(g_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(g_num_viol.data()));
+    taskDataPar->outputs_count.emplace_back(g_num_viol.size());
+  }
+  auto testMpiParallel =
+      std::make_shared<kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int>>(taskDataPar);
+  ASSERT_TRUE(testMpiParallel->validation());
+  testMpiParallel->pre_processing();
+  testMpiParallel->run();
+  testMpiParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (rank == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    size_t res = 0;
+    ASSERT_EQ(res, g_num_viol[0]);
+  }
+}
+
+TEST(kovalev_k_num_of_orderly_violations_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  int rank = world.rank();
+  std::vector<double> g_vec;
+  std::vector<size_t> g_num_viol(1, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  size_t length = 1000000;
+  if (rank == 0) {
+    g_vec = std::vector<double>(length);
+    auto max = static_cast<double>(1000000);
+    auto min = static_cast<double>(-1000000);
+    std::srand(std::time(nullptr));
+    for (size_t i = 0; i < length; i++) g_vec[i] = min + static_cast<double>(rand()) / RAND_MAX * (max - min);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(g_vec.data()));
+    taskDataPar->inputs_count.emplace_back(g_vec.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(g_num_viol.data()));
+    taskDataPar->outputs_count.emplace_back(g_num_viol.size());
+  }
+  auto testMpiParallel =
+      std::make_shared<kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double>>(taskDataPar);
+  ASSERT_TRUE(testMpiParallel->validation());
+  testMpiParallel->pre_processing();
+  testMpiParallel->run();
+  testMpiParallel->post_processing();
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (rank == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    size_t res = 0;
+    for (size_t i = 1; i < length; i++)
+      if (g_vec[i - 1] > g_vec[i]) res++;
+    ASSERT_EQ(res, g_num_viol[0]);
+  }
+}

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/src/sourse.cpp
@@ -1,0 +1,72 @@
+#include "mpi/kovalev_k_num_of_orderly_violations/include/header.hpp"
+
+template <class T>
+bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::count_num_of_orderly_violations_mpi() {
+  for (size_t i = 1; i < loc_v.size(); i++) {
+    if (loc_v[i - 1] > loc_v[i]) {
+      l_res++;
+    }
+  }
+  return true;
+}
+
+template <class T>
+bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::pre_processing() {
+  internal_order_test();
+  g_res = l_res = 0;
+  rank = world.rank();
+  size = world.size();
+  if (rank == 0) {
+    n = taskData->inputs_count[0];
+    glob_v.resize(n);
+    void* ptr_vec = glob_v.data();
+    void* ptr_input = taskData->inputs[0];
+    memcpy(ptr_vec, ptr_input, sizeof(T) * n);
+  }
+  return true;
+}
+
+template <class T>
+bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    if (taskData->inputs.empty() || taskData->outputs.empty() || taskData->inputs_count[0] <= 0 ||
+        taskData->outputs_count[0] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <class T>
+bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::run() {
+  internal_order_test();
+  boost::mpi::broadcast(world, n, 0);
+  int scratter_length = n / size;
+  loc_v.resize(scratter_length);
+  std::vector<int> sendcounts(size, scratter_length);
+  std::vector<int> displs(size, 0);
+  for (int i = 1; i < size; i++) displs[i] = displs[i] + scratter_length;
+  boost::mpi::scatter(world, glob_v.data(), loc_v.data(), scratter_length, 0);
+  count_num_of_orderly_violations_mpi();
+  boost::mpi::reduce(world, l_res, g_res, std::plus<unsigned long>(), 0);
+  if (rank == 0) {
+    for (int i = 1; i < size; i++)
+      if (glob_v[i * (n / size) - 1] > glob_v[i * (n / size)]) g_res++;
+    for (size_t i = n - n % size; i < n; i++)
+      if (glob_v[i - 1] > glob_v[i]) g_res++;
+  }
+  return true;
+}
+
+template <class T>
+bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::post_processing() {
+  internal_order_test();
+  if (rank == 0) {
+    reinterpret_cast<size_t*>(taskData->outputs[0])[0] = g_res;
+  }
+  return true;
+}
+
+template class kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<int>;
+template class kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<double>;

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/src/sourse.cpp
@@ -62,7 +62,7 @@ bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::run(
 template <class T>
 bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::post_processing() {
   internal_order_test();
-  world.barrier()
+  world.barrier();
   if (rank == 0) {
     reinterpret_cast<size_t*>(taskData->outputs[0])[0] = g_res;
   }

--- a/tasks/mpi/kovalev_k_num_of_orderly_violations/src/sourse.cpp
+++ b/tasks/mpi/kovalev_k_num_of_orderly_violations/src/sourse.cpp
@@ -62,6 +62,7 @@ bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::run(
 template <class T>
 bool kovalev_k_num_of_orderly_violations_mpi::NumOfOrderlyViolationsPar<T>::post_processing() {
   internal_order_test();
+  world.barrier()
   if (rank == 0) {
     reinterpret_cast<size_t*>(taskData->outputs[0])[0] = g_res;
   }


### PR DESCRIPTION
Reverts learning-process/ppc-2024-autumn#604

Проблема, предположительно, была в рассинхроне процессов (гипотеза подтверждается тем, что в learning-process/ppc-2024-autumn#564 количество недостающих до правильного ответа элементов как раз и было равно количеству, которое 1 процесс должен был подсчитать). MPI_Barrier() добавлен, неоднократные запуски показали, что проблема решена. Код тривиальный, что ещё может ломаться - не знаю. Допускаю также, что моя работа падала вследствие ошибки у другого студента