### PR TITLE
Вавилов Виталий. Задача 3. Вариант 23. Алгоритм Беллмана-Форда

### DIFF
--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -10,7 +10,7 @@ namespace mpi = boost::mpi;
 static std::vector<int> generate_linear_graph(int num_vertices) {
   std::vector<int> matrix(num_vertices * num_vertices, 0);
   std::random_device rd;
-  std::mt19937 gen(rd()); 
+  std::mt19937 gen(rd());
   std::uniform_int_distribution<> dist(-20, 20);
   for (int i = 0; i < num_vertices - 1; ++i) {
     matrix[i * num_vertices + i + 1] = dist(gen);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -35,7 +35,7 @@ TEST(vavilov_v_bellman_ford_mpi, Random_sparse_graph) {
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
   int vertices = 500;
-  int edges_count = 515;
+  int edges_count = 100;
   int source = 0;
   std::vector<int> output(vertices);
   std::vector<int> expected_output(vertices);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -13,8 +13,8 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_seq) {
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5;
-  edges_count = 8;
-  source = 0;
+  int edges_count = 8;
+  int source = 0;
   taskDataSeq->inputs_count.emplace_back(vertices);
   taskDataSeq->inputs_count.emplace_back(edges_count);
   taskDataSeq->inputs_count.emplace_back(source);
@@ -42,8 +42,8 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths) {
   std::vector<int> output(5);
   std::vector<int> expected_output(5);
   int vertices = 5;
-  edges_count = 8;
-  source = 0;
+  int edges_count = 8;
+  int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -80,8 +80,8 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1) {
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5;
-  edges_count = 8;
-  source = 0;
+  int edges_count = 8;
+  int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -107,8 +107,8 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_2) {
   std::vector<int> matrix = {0, -1, 4, 0, 0, 0, 0, 3, 2, 0, 0, 0, 0, 5, -3, 2, 0, -1, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5;
-  edges_count = 6;
-  source = 0;
+  int edges_count = 6;
+  int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -135,8 +135,8 @@ TEST(vavilov_v_bellman_ford_mpi, DisconnectedGraph) {
   std::vector<int> matrix = {0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5;
-  edges_count = 3;
-  source = 0;
+  int edges_count = 3;
+  int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -161,9 +161,9 @@ TEST(vavilov_v_bellman_ford_mpi, NegativeCycle) {
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   std::vector<int> matrix = {0, 1, 0, 0, 0, -1, -1, 0, 0};
   std::vector<int> output(3);
-  int vertices = 3; 
-  edges_count = 3; 
-  source = 0;
+  int vertices = 3;
+  int edges_count = 3; 
+  int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -184,8 +184,8 @@ TEST(vavilov_v_bellman_ford_mpi, SingleVertexGraph) {
   std::vector<int> matrix = {0};
   std::vector<int> output(1, 0);
   int vertices = 1;
-  edges_count = 0;
-  source = 0;
+  int edges_count = 0;
+  int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -7,23 +7,6 @@
 
 namespace mpi = boost::mpi;
 
-static std::vector<int> generate_random_complete_graph(int vertices) {
-  std::vector<int> graph(vertices * vertices, 0);
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_int_distribution<int> weight_dist(-20, 20);
-
-  for (int u = 0; u < vertices; ++u) {
-    for (int v = u + 1; v < vertices; ++v) {
-      int weight = weight_dist(gen);
-      graph[u * vertices + v] = weight;
-      graph[v * vertices + u] = weight;
-    }
-  }
-
-  return graph;
-}
-
 static std::vector<int> generate_random_sparse_graph(int vertices, int edges_count) {
   std::vector<int> graph(vertices * vertices, 0);
   std::random_device rd;
@@ -44,46 +27,6 @@ static std::vector<int> generate_random_sparse_graph(int vertices, int edges_cou
   }
 
   return graph;
-}
-
-TEST(vavilov_v_bellman_ford_mpi, Random_complete_graph) {
-  mpi::communicator world;
-  auto taskDataPar = std::make_shared<ppc::core::TaskData>();
-  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
-
-  int vertices = 100;
-  int edges_count = 4950;
-  int source = 0;
-  std::vector<int> output(vertices);
-  std::vector<int> expected_output(vertices);
-  std::vector<int> matrix = generate_random_complete_graph(vertices);
-  taskDataPar->inputs_count.emplace_back(vertices);
-  taskDataPar->inputs_count.emplace_back(edges_count);
-  taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
-  taskDataPar->outputs_count.emplace_back(output.size());
-  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-
-  taskDataSeq->inputs_count.emplace_back(vertices);
-  taskDataSeq->inputs_count.emplace_back(edges_count);
-  taskDataSeq->inputs_count.emplace_back(source);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
-  taskDataSeq->outputs_count.emplace_back(expected_output.size());
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_output.data()));
-
-  vavilov_v_bellman_ford_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-  ASSERT_TRUE(testMpiTaskParallel.validation());
-  ASSERT_TRUE(testMpiTaskParallel.pre_processing());
-  ASSERT_TRUE(testMpiTaskParallel.run());
-  ASSERT_TRUE(testMpiTaskParallel.post_processing());
-  if (world.rank() == 0) {
-    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
-    ASSERT_TRUE(testMpiTaskSequential.validation());
-    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
-    ASSERT_TRUE(testMpiTaskSequential.run());
-    ASSERT_TRUE(testMpiTaskSequential.post_processing());
-    EXPECT_EQ(output, expected_output);
-  }
 }
 
 TEST(vavilov_v_bellman_ford_mpi, Random_sparse_graph) {

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -12,7 +12,9 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_seq) {
 
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
-  int vertices = 5, edges_count = 8, source = 0;
+  int vertices = 5;
+  edges_count = 8;
+  source = 0;
   taskDataSeq->inputs_count.emplace_back(vertices);
   taskDataSeq->inputs_count.emplace_back(edges_count);
   taskDataSeq->inputs_count.emplace_back(source);
@@ -39,7 +41,9 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths) {
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   std::vector<int> expected_output(5);
-  int vertices = 5, edges_count = 8, source = 0;
+  int vertices = 5;
+  edges_count = 8;
+  source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -75,7 +79,9 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1) {
 
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
-  int vertices = 5, edges_count = 8, source = 0;
+  int vertices = 5;
+  edges_count = 8;
+  source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -100,8 +106,9 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_2) {
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   std::vector<int> matrix = {0, -1, 4, 0, 0, 0, 0, 3, 2, 0, 0, 0, 0, 5, -3, 2, 0, -1, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
-  int vertices = 5, edges_count = 6, source = 0;
-
+  int vertices = 5;
+  edges_count = 6;
+  source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -127,8 +134,9 @@ TEST(vavilov_v_bellman_ford_mpi, DisconnectedGraph) {
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   std::vector<int> matrix = {0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
-  int vertices = 5, edges_count = 3, source = 0;
-
+  int vertices = 5;
+  edges_count = 3;
+  source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -153,8 +161,9 @@ TEST(vavilov_v_bellman_ford_mpi, NegativeCycle) {
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   std::vector<int> matrix = {0, 1, 0, 0, 0, -1, -1, 0, 0};
   std::vector<int> output(3);
-  int vertices = 3, edges_count = 3, source = 0;
-
+  int vertices = 3; 
+  edges_count = 3; 
+  source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
@@ -174,8 +183,9 @@ TEST(vavilov_v_bellman_ford_mpi, SingleVertexGraph) {
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   std::vector<int> matrix = {0};
   std::vector<int> output(1, 0);
-  int vertices = 1, edges_count = 0, source = 0;
-
+  int vertices = 1;
+  edges_count = 0;
+  source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -7,6 +7,18 @@
 
 namespace mpi = boost::mpi;
 
+static std::vector<int> generate_linear_graph(int num_vertices) {
+    std::vector<int> matrix(num_vertices * num_vertices, 0);
+    std::random_device rd;
+    std::mt19937 gen(rd()); 
+    std::uniform_int_distribution<> dist(-20, 20);
+    for (int i = 0; i < num_vertices - 1; ++i) {
+        matrix[i * num_vertices + i + 1] = dist(gen);
+    }
+
+    return matrix;
+}
+
 static std::vector<int> generate_random_sparse_graph(int vertices, int edges_count) {
   std::vector<int> graph(vertices * vertices, 0);
   std::random_device rd;
@@ -27,6 +39,46 @@ static std::vector<int> generate_random_sparse_graph(int vertices, int edges_cou
   }
 
   return graph;
+}
+
+TEST(vavilov_v_bellman_ford_mpi, Random_linear_graph) {
+  mpi::communicator world;
+  auto taskDataPar = std::make_shared<ppc::core::TaskData>();
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  int vertices = 300;
+  int edges_count = 299;
+  int source = 0;
+  std::vector<int> output(vertices);
+  std::vector<int> expected_output(vertices);
+  std::vector<int> matrix = generate_linear_graph(vertices);
+  taskDataPar->inputs_count.emplace_back(vertices);
+  taskDataPar->inputs_count.emplace_back(edges_count);
+  taskDataPar->inputs_count.emplace_back(source);
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataPar->outputs_count.emplace_back(output.size());
+  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataSeq->outputs_count.emplace_back(expected_output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_output.data()));
+
+  vavilov_v_bellman_ford_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  ASSERT_TRUE(testMpiTaskParallel.pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel.run());
+  ASSERT_TRUE(testMpiTaskParallel.post_processing());
+  if (world.rank() == 0) {
+    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSequential.validation());
+    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+    ASSERT_TRUE(testMpiTaskSequential.run());
+    ASSERT_TRUE(testMpiTaskSequential.post_processing());
+    EXPECT_EQ(output, expected_output);
+  }
 }
 
 TEST(vavilov_v_bellman_ford_mpi, Random_sparse_graph) {

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -42,9 +42,7 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_2) {
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
   taskDataPar->outputs_count.emplace_back(output.size());
   taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
 
@@ -71,9 +69,7 @@ TEST(vavilov_v_bellman_ford_mpi, DisconnectedGraph) {
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
   taskDataPar->outputs_count.emplace_back(output.size());
   taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
 
@@ -99,9 +95,7 @@ TEST(vavilov_v_bellman_ford_mpi, NegativeCycle) {
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
   taskDataPar->outputs_count.emplace_back(output.size());
   taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
 
@@ -122,9 +116,7 @@ TEST(vavilov_v_bellman_ford_mpi, SingleVertexGraph) {
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
   taskDataPar->outputs_count.emplace_back(output.size());
   taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
 

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -7,7 +7,7 @@
 
 namespace mpi = boost::mpi;
 
-std::vector<int> generate_random_crs_graph(int vertices, int edges_count) {
+static std::vector<int> generate_random_crs_graph(int vertices, int edges_count) {
   std::vector<int> graph(vertices * vertices, 0);
   std::random_device rd;
   std::mt19937 gen(rd());

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -154,7 +154,7 @@ TEST(vavilov_v_bellman_ford_mpi, Random_sparse_graph) {
   int source = 0;
   std::vector<int> output(vertices);
   std::vector<int> expected_output(vertices);
-  std::vector<int> matrix = generate_random_crs_graph(vertices, edges_count);
+  std::vector<int> matrix = generate_random_sparse_graph(vertices, edges_count);
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -162,7 +162,7 @@ TEST(vavilov_v_bellman_ford_mpi, NegativeCycle) {
   std::vector<int> matrix = {0, 1, 0, 0, 0, -1, -1, 0, 0};
   std::vector<int> output(3);
   int vertices = 3;
-  int edges_count = 3; 
+  int edges_count = 3;
   int source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -16,9 +16,7 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1) {
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);
   taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
   taskDataPar->outputs_count.emplace_back(output.size());
   taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
 

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -6,6 +6,33 @@
 
 namespace mpi = boost::mpi;
 
+TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1_seq) {
+  mpi::communicator world;
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  std::vector<int> row_offsets = {0, 2, 5, 7, 8, 8};
+  std::vector<int> col_indices = {1, 2, 2, 3, 3, 4, 1, 2};
+  std::vector<int> weights = {10, 5, 2, 1, 9, 2, 1, 4};
+  std::vector<int> output(5);
+  int vertices = 5, edges_count = 8, source = 0;
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
+  taskDataSeq->outputs_count.emplace_back(output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+  ASSERT_TRUE(testMpiTaskSequential.validation());
+  ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+  ASSERT_TRUE(testMpiTaskSequential.run());
+  ASSERT_TRUE(testMpiTaskSequential.post_processing());
+  std::vector<int> expected_output = {0, 8, 5, 9, 7};
+  EXPECT_EQ(output, expected_output);
+}
+
 TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi.hpp>
-
 #include <random>
 
 #include "mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp"
@@ -32,7 +31,7 @@ TEST(vavilov_v_bellman_ford_mpi, Random_1) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
-  
+
   int vertices = 100;
   int edges_count = 15;
   int source = 0;
@@ -72,7 +71,7 @@ TEST(vavilov_v_bellman_ford_mpi, Random_2) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
-  
+
   int vertices = 200;
   int edges_count = 50;
   int source = 0;
@@ -112,7 +111,7 @@ TEST(vavilov_v_bellman_ford_mpi, Random_3) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
-  
+
   int vertices = 500;
   int edges_count = 100;
   int source = 0;

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -6,40 +6,11 @@
 
 namespace mpi = boost::mpi;
 
-TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1_seq) {
-  mpi::communicator world;
-  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
-
-  std::vector<int> row_offsets = {0, 2, 5, 7, 8, 8};
-  std::vector<int> col_indices = {1, 2, 2, 3, 3, 4, 1, 2};
-  std::vector<int> weights = {10, 5, 2, 1, 9, 2, 1, 4};
-  std::vector<int> output(5);
-  int vertices = 5, edges_count = 8, source = 0;
-  taskDataSeq->inputs_count.emplace_back(vertices);
-  taskDataSeq->inputs_count.emplace_back(edges_count);
-  taskDataSeq->inputs_count.emplace_back(source);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
-  taskDataSeq->outputs_count.emplace_back(output.size());
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-
-  vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
-  ASSERT_TRUE(testMpiTaskSequential.validation());
-  ASSERT_TRUE(testMpiTaskSequential.pre_processing());
-  ASSERT_TRUE(testMpiTaskSequential.run());
-  ASSERT_TRUE(testMpiTaskSequential.post_processing());
-  std::vector<int> expected_output = {0, 8, 5, 9, 7};
-  EXPECT_EQ(output, expected_output);
-}
-
 TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
 
-  std::vector<int> row_offsets = {0, 2, 5, 7, 8, 8};
-  std::vector<int> col_indices = {1, 2, 2, 3, 3, 4, 1, 2};
-  std::vector<int> weights = {10, 5, 2, 1, 9, 2, 1, 4};
+  std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5, edges_count = 8, source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -13,12 +13,12 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_seq) {
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5, edges_count = 8, source = 0;
-  taskDataPar->inputs_count.emplace_back(vertices);
-  taskDataPar->inputs_count.emplace_back(edges_count);
-  taskDataPar->inputs_count.emplace_back(source);
-  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
-  taskDataPar->outputs_count.emplace_back(output.size());
-  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataSeq->outputs_count.emplace_back(output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
   if (world.rank() == 0) {
     vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
     ASSERT_TRUE(testMpiTaskSequential.validation());

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -13,7 +13,7 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths) {
 
   std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
-  std::vector<int> expected_output(5)
+  std::vector<int> expected_output(5);
   int vertices = 5, edges_count = 8, source = 0;
   taskDataPar->inputs_count.emplace_back(vertices);
   taskDataPar->inputs_count.emplace_back(edges_count);

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -53,7 +53,7 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_2) {
   ASSERT_TRUE(testMpiTaskParallel.post_processing());
 
   if (world.rank() == 0) {
-    std::vector<int> expected_output = {0, -1, 2, 1, -2};
+    std::vector<int> expected_output = {0, -1, 0, 1, -3};
     EXPECT_EQ(output, expected_output);
   }
 }

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -8,15 +8,15 @@
 namespace mpi = boost::mpi;
 
 static std::vector<int> generate_linear_graph(int num_vertices) {
-    std::vector<int> matrix(num_vertices * num_vertices, 0);
-    std::random_device rd;
-    std::mt19937 gen(rd()); 
-    std::uniform_int_distribution<> dist(-20, 20);
-    for (int i = 0; i < num_vertices - 1; ++i) {
-        matrix[i * num_vertices + i + 1] = dist(gen);
-    }
+  std::vector<int> matrix(num_vertices * num_vertices, 0);
+  std::random_device rd;
+  std::mt19937 gen(rd()); 
+  std::uniform_int_distribution<> dist(-20, 20);
+  for (int i = 0; i < num_vertices - 1; ++i) {
+    matrix[i * num_vertices + i + 1] = dist(gen);
+  }
 
-    return matrix;
+  return matrix;
 }
 
 static std::vector<int> generate_random_sparse_graph(int vertices, int edges_count) {

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -6,6 +6,44 @@
 
 namespace mpi = boost::mpi;
 
+TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths) {
+  mpi::communicator world;
+  auto taskDataPar = std::make_shared<ppc::core::TaskData>();
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
+  std::vector<int> output(5);
+  std::vector<int> expected_output(5)
+  int vertices = 5, edges_count = 8, source = 0;
+  taskDataPar->inputs_count.emplace_back(vertices);
+  taskDataPar->inputs_count.emplace_back(edges_count);
+  taskDataPar->inputs_count.emplace_back(source);
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataPar->outputs_count.emplace_back(output.size());
+  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataSeq->outputs_count.emplace_back(expected_output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_output.data()));
+
+  vavilov_v_bellman_ford_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  ASSERT_TRUE(testMpiTaskParallel.pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel.run());
+  ASSERT_TRUE(testMpiTaskParallel.post_processing());
+  if (world.rank() == 0) {
+    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSequential.validation());
+    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+    ASSERT_TRUE(testMpiTaskSequential.run());
+    ASSERT_TRUE(testMpiTaskSequential.post_processing());
+    EXPECT_EQ(output, expected_output);
+  }
+}
+
 TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_1) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -2,9 +2,151 @@
 
 #include <boost/mpi.hpp>
 
+#include <random>
+
 #include "mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp"
 
 namespace mpi = boost::mpi;
+
+std::vector<int> generate_random_crs_graph(int vertices, int edges_count) {
+  std::vector<int> graph(vertices * vertices, 0);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> weight_dist(-20, 20);
+  std::uniform_int_distribution<int> vertex_dist(0, vertices - 1);
+
+  int added_edges = 0;
+
+  while (added_edges < edges_count) {
+    int u = vertex_dist(gen);
+    int v = vertex_dist(gen);
+    if (u != v && graph[u * vertices + v] == 0) {
+      graph[u * vertices + v] = weight_dist(gen);
+      ++added_edges;
+    }
+  }
+  return graph;
+}
+
+TEST(vavilov_v_bellman_ford_mpi, Random_1) {
+  mpi::communicator world;
+  auto taskDataPar = std::make_shared<ppc::core::TaskData>();
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  
+  int vertices = 100;
+  int edges_count = 15;
+  int source = 0;
+  std::vector<int> output(vertices);
+  std::vector<int> expected_output(vertices);
+  std::vector<int> matrix = generate_random_crs_graph(vertices, edges_count);
+  taskDataPar->inputs_count.emplace_back(vertices);
+  taskDataPar->inputs_count.emplace_back(edges_count);
+  taskDataPar->inputs_count.emplace_back(source);
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataPar->outputs_count.emplace_back(output.size());
+  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataSeq->outputs_count.emplace_back(expected_output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_output.data()));
+
+  vavilov_v_bellman_ford_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  ASSERT_TRUE(testMpiTaskParallel.pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel.run());
+  ASSERT_TRUE(testMpiTaskParallel.post_processing());
+  if (world.rank() == 0) {
+    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSequential.validation());
+    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+    ASSERT_TRUE(testMpiTaskSequential.run());
+    ASSERT_TRUE(testMpiTaskSequential.post_processing());
+    EXPECT_EQ(output, expected_output);
+  }
+}
+
+TEST(vavilov_v_bellman_ford_mpi, Random_2) {
+  mpi::communicator world;
+  auto taskDataPar = std::make_shared<ppc::core::TaskData>();
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  
+  int vertices = 200;
+  int edges_count = 50;
+  int source = 0;
+  std::vector<int> output(vertices);
+  std::vector<int> expected_output(vertices);
+  std::vector<int> matrix = generate_random_crs_graph(vertices, edges_count);
+  taskDataPar->inputs_count.emplace_back(vertices);
+  taskDataPar->inputs_count.emplace_back(edges_count);
+  taskDataPar->inputs_count.emplace_back(source);
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataPar->outputs_count.emplace_back(output.size());
+  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataSeq->outputs_count.emplace_back(expected_output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_output.data()));
+
+  vavilov_v_bellman_ford_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  ASSERT_TRUE(testMpiTaskParallel.pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel.run());
+  ASSERT_TRUE(testMpiTaskParallel.post_processing());
+  if (world.rank() == 0) {
+    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSequential.validation());
+    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+    ASSERT_TRUE(testMpiTaskSequential.run());
+    ASSERT_TRUE(testMpiTaskSequential.post_processing());
+    EXPECT_EQ(output, expected_output);
+  }
+}
+
+TEST(vavilov_v_bellman_ford_mpi, Random_3) {
+  mpi::communicator world;
+  auto taskDataPar = std::make_shared<ppc::core::TaskData>();
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  
+  int vertices = 500;
+  int edges_count = 100;
+  int source = 0;
+  std::vector<int> output(vertices);
+  std::vector<int> expected_output(vertices);
+  std::vector<int> matrix = generate_random_crs_graph(vertices, edges_count);
+  taskDataPar->inputs_count.emplace_back(vertices);
+  taskDataPar->inputs_count.emplace_back(edges_count);
+  taskDataPar->inputs_count.emplace_back(source);
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataPar->outputs_count.emplace_back(output.size());
+  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataSeq->outputs_count.emplace_back(expected_output.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(expected_output.data()));
+
+  vavilov_v_bellman_ford_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  ASSERT_TRUE(testMpiTaskParallel.pre_processing());
+  ASSERT_TRUE(testMpiTaskParallel.run());
+  ASSERT_TRUE(testMpiTaskParallel.post_processing());
+  if (world.rank() == 0) {
+    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSequential.validation());
+    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+    ASSERT_TRUE(testMpiTaskSequential.run());
+    ASSERT_TRUE(testMpiTaskSequential.post_processing());
+    EXPECT_EQ(output, expected_output);
+  }
+}
 
 TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_seq) {
   mpi::communicator world;

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -6,6 +6,31 @@
 
 namespace mpi = boost::mpi;
 
+TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_seq) {
+  mpi::communicator world;
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  std::vector<int> matrix = {0, 10, 5, 0, 0, 0, 0, 2, 1, 0, 0, 3, 0, 9, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0};
+  std::vector<int> output(5);
+  int vertices = 5, edges_count = 8, source = 0;
+  taskDataPar->inputs_count.emplace_back(vertices);
+  taskDataPar->inputs_count.emplace_back(edges_count);
+  taskDataPar->inputs_count.emplace_back(source);
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
+  taskDataPar->outputs_count.emplace_back(output.size());
+  taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  if (world.rank() == 0) {
+    vavilov_v_bellman_ford_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSequential.validation());
+    ASSERT_TRUE(testMpiTaskSequential.pre_processing());
+    ASSERT_TRUE(testMpiTaskSequential.run());
+    ASSERT_TRUE(testMpiTaskSequential.post_processing());
+
+    std::vector<int> expected_output = {0, 8, 5, 9, 7};
+    EXPECT_EQ(output, expected_output);
+  }
+}
+
 TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths) {
   mpi::communicator world;
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -35,9 +35,7 @@ TEST(vavilov_v_bellman_ford_mpi, ValidInputWithMultiplePaths_2) {
   mpi::communicator world;
 
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
-  std::vector<int> row_offsets = {0, 2, 4, 5, 7, 8};
-  std::vector<int> col_indices = {1, 2, 2, 3, 3, 4, 1, 2};
-  std::vector<int> weights = {-1, 4, 3, 2, 5, -3, 2, -1};
+  std::vector<int> matrix = {0, -1, 4, 0, 0, 0, 0, 3, 2, 0, 0, 0, 0, 5, -3, 2, 0, -1, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5, edges_count = 6, source = 0;
 
@@ -66,9 +64,7 @@ TEST(vavilov_v_bellman_ford_mpi, DisconnectedGraph) {
   mpi::communicator world;
 
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
-  std::vector<int> row_offsets = {0, 2, 3, 3, 4, 4};
-  std::vector<int> col_indices = {1, 2, 3};
-  std::vector<int> weights = {4, 1, 2};
+  std::vector<int> matrix = {0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> output(5);
   int vertices = 5, edges_count = 3, source = 0;
 
@@ -96,9 +92,7 @@ TEST(vavilov_v_bellman_ford_mpi, NegativeCycle) {
   mpi::communicator world;
 
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
-  std::vector<int> row_offsets = {0, 1, 2, 3};
-  std::vector<int> col_indices = {1, 2, 0};
-  std::vector<int> weights = {1, -1, -1};
+  std::vector<int> matrix = {0, 1, 0, 0, 0, -1, -1, 0, 0};
   std::vector<int> output(3);
   int vertices = 3, edges_count = 3, source = 0;
 
@@ -121,9 +115,7 @@ TEST(vavilov_v_bellman_ford_mpi, SingleVertexGraph) {
   mpi::communicator world;
 
   auto taskDataPar = std::make_shared<ppc::core::TaskData>();
-  std::vector<int> row_offsets = {0};
-  std::vector<int> col_indices = {};
-  std::vector<int> weights = {};
+  std::vector<int> matrix = {0};
   std::vector<int> output(1, 0);
   int vertices = 1, edges_count = 0, source = 0;
 

--- a/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -79,7 +79,7 @@ TEST(vavilov_v_bellman_ford_mpi, DisconnectedGraph) {
   ASSERT_TRUE(testMpiTaskParallel.run());
   ASSERT_TRUE(testMpiTaskParallel.post_processing());
   if (world.rank() == 0) {
-    std::vector<int> expected_output = {0, 4, 1, 6, INT_MAX};
+    std::vector<int> expected_output = {0, 4, 1, 3, INT_MAX};
     EXPECT_EQ(output, expected_output);
   }
 }

--- a/tasks/mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp
@@ -28,6 +28,7 @@ class TestMPITaskSequential : public ppc::core::Task {
   std::vector<int> row_offsets_, col_indices_, weights_;
   std::vector<int> distances_;
   int vertices_{0}, edges_count_{0}, source_{0};
+  void CRS(const int* matrix);
 };
 
 class TestMPITaskParallel : public ppc::core::Task {
@@ -43,6 +44,7 @@ class TestMPITaskParallel : public ppc::core::Task {
   std::vector<int> row_offsets_, col_indices_, weights_;
   std::vector<int> distances_;
   int vertices_{0}, edges_count_{0}, source_{0};
+  void CRS(const int* matrix);
   boost::mpi::communicator world;
 };
 }  // namespace vavilov_v_bellman_ford_mpi

--- a/tasks/mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp
@@ -8,7 +8,6 @@
 #include <boost/serialization/vector.hpp>
 #include <limits>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -15,29 +15,35 @@ std::vector<int> generate_linear_graph(int num_vertices) {
 }
 
 std::vector<int> compute_expected_distances(int num_vertices) {
-  std::vector<int> distances(num_vertices, 0);
-  for (int i = 1; i < num_vertices; ++i) {
-    distances[i] = distances[i - 1] + i;
+  std::vector<int> distances(num_vertices);
+  for (int i = 0; i < num_vertices; ++i) {
+    distances[i] = i;
   }
   return distances;
 }
 
 TEST(vavilov_v_bellman_ford_mpi, test_task_run) {
+  boost::mpi::environment env;
   boost::mpi::communicator world;
 
   const int num_vertices = 1000;
+  const int edges_count = 999;
+  const int source = 0;
+
   auto matrix = generate_linear_graph(num_vertices);
   auto expected_distances = compute_expected_distances(num_vertices);
 
-  std::vector<int> distances(num_vertices, INT_MAX);
-  distances[0] = 0;
+  std::vector<int> distances(num_vertices);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
+    taskDataPar->inputs_count.emplace_back(num_vertices);
+    taskDataPar->inputs_count.emplace_back(edges_count);
+    taskDataPar->inputs_count.emplace_back(source);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
     taskDataPar->outputs_count.emplace_back(distances.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
   }
 
   auto testMpiTaskParallel = std::make_shared<vavilov_v_bellman_ford_mpi::TestMPITaskParallel>(taskDataPar);
@@ -62,21 +68,27 @@ TEST(vavilov_v_bellman_ford_mpi, test_task_run) {
 }
 
 TEST(vavilov_v_bellman_ford_mpi, test_pipeline_run) {
+  boost::mpi::environment env;
   boost::mpi::communicator world;
 
   const int num_vertices = 1000;
+  const int edges_count = 999;
+  const int source = 0;
+
   auto matrix = generate_linear_graph(num_vertices);
   auto expected_distances = compute_expected_distances(num_vertices);
 
-  std::vector<int> distances(num_vertices, INT_MAX);
-  distances[0] = 0;
+  std::vector<int> distances(num_vertices);
 
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
+    taskDataPar->inputs_count.emplace_back(num_vertices);
+    taskDataPar->inputs_count.emplace_back(edges_count);
+    taskDataPar->inputs_count.emplace_back(source);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
     taskDataPar->outputs_count.emplace_back(distances.size());
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
   }
 
   auto testMpiTaskParallel = std::make_shared<vavilov_v_bellman_ford_mpi::TestMPITaskParallel>(taskDataPar);

--- a/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -8,10 +8,10 @@
 
 std::vector<int> generate_linear_graph(int num_vertices) {
   std::vector<int> matrix(num_vertices * num_vertices, 0);
-    for (int i = 0; i < num_vertices - 1; ++i) {
-      matrix[i * num_vertices + i + 1] = 1;
-    }
-    return matrix;
+  for (int i = 0; i < num_vertices - 1; ++i) {
+    matrix[i * num_vertices + i + 1] = 1;
+  }
+  return matrix;
 }
 
 std::vector<int> compute_expected_distances(int num_vertices) {

--- a/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -6,29 +6,12 @@
 #include "core/perf/include/perf.hpp"
 #include "mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp"
 
-std::vector<int> generate_row_offsets(int num_vertices) {
-  std::vector<int> row_offsets(num_vertices + 1);
-  for (int i = 0; i < num_vertices; ++i) {
-    row_offsets[i] = i;
-  }
-  row_offsets[num_vertices] = num_vertices - 1;
-  return row_offsets;
-}
-
-std::vector<int> generate_col_indices(int num_vertices) {
-  std::vector<int> col_indices(num_vertices - 1);
-  for (int i = 0; i < num_vertices - 1; ++i) {
-    col_indices[i] = i + 1;
-  }
-  return col_indices;
-}
-
-std::vector<int> generate_weights(int num_vertices) {
-  std::vector<int> weights(num_vertices - 1);
-  for (int i = 0; i < num_vertices - 1; ++i) {
-    weights[i] = i + 1;
-  }
-  return weights;
+std::vector<int> generate_linear_graph(int num_vertices) {
+  std::vector<int> matrix(num_vertices * num_vertices, 0);
+    for (int i = 0; i < num_vertices - 1; ++i) {
+      matrix[i * num_vertices + i + 1] = 1;
+    }
+    return matrix;
 }
 
 std::vector<int> compute_expected_distances(int num_vertices) {
@@ -43,9 +26,7 @@ TEST(vavilov_v_bellman_ford_mpi, test_task_run) {
   boost::mpi::communicator world;
 
   const int num_vertices = 1000;
-  auto row_offsets = generate_row_offsets(num_vertices);
-  auto col_indices = generate_col_indices(num_vertices);
-  auto weights = generate_weights(num_vertices);
+  auto matrix = generate_linear_graph(num_vertices);
   auto expected_distances = compute_expected_distances(num_vertices);
 
   std::vector<int> distances(num_vertices, INT_MAX);
@@ -54,10 +35,7 @@ TEST(vavilov_v_bellman_ford_mpi, test_task_run) {
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
-    taskDataPar->inputs_count.emplace_back(row_offsets.size() - 1);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
     taskDataPar->outputs_count.emplace_back(distances.size());
   }
@@ -87,9 +65,7 @@ TEST(vavilov_v_bellman_ford_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
 
   const int num_vertices = 1000;
-  auto row_offsets = generate_row_offsets(num_vertices);
-  auto col_indices = generate_col_indices(num_vertices);
-  auto weights = generate_weights(num_vertices);
+  auto matrix = generate_linear_graph(num_vertices);
   auto expected_distances = compute_expected_distances(num_vertices);
 
   std::vector<int> distances(num_vertices, INT_MAX);
@@ -98,10 +74,7 @@ TEST(vavilov_v_bellman_ford_mpi, test_pipeline_run) {
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(row_offsets.data()));
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(col_indices.data()));
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(weights.data()));
-    taskDataPar->inputs_count.emplace_back(row_offsets.size() - 1);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(matrix.data()));
     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
     taskDataPar->outputs_count.emplace_back(distances.size());
   }

--- a/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -26,8 +26,8 @@ TEST(vavilov_v_bellman_ford_mpi, test_task_run) {
   boost::mpi::environment env;
   boost::mpi::communicator world;
 
-  const int num_vertices = 1000;
-  const int edges_count = 999;
+  const int num_vertices = 5000;
+  const int edges_count = 4999;
   const int source = 0;
 
   auto matrix = generate_linear_graph(num_vertices);
@@ -71,8 +71,8 @@ TEST(vavilov_v_bellman_ford_mpi, test_pipeline_run) {
   boost::mpi::environment env;
   boost::mpi::communicator world;
 
-  const int num_vertices = 1000;
-  const int edges_count = 999;
+  const int num_vertices = 5000;
+  const int edges_count = 4999;
   const int source = 0;
 
   auto matrix = generate_linear_graph(num_vertices);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -1,7 +1,7 @@
 #include "mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp"
 
 
-void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix){
+void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
   row_ptr.push_back(0);
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {
@@ -11,7 +11,7 @@ void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix){
       }
     }
     row_offsets_.push_back(values.size());
-  } 
+  }
 };
 
 bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::pre_processing() {
@@ -24,7 +24,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::pre_processing() {
   auto* matrix = reinterpret_cast<int*>(taskData->inputs[0]);
 
   CRS(matrix);
-  
+
   distances_.resize(vertices_, INT_MAX);
   distances_[source_] = 0;
 
@@ -69,7 +69,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::post_processing() {
   return true;
 }
 
-void vavilov_v_bellman_ford_mpi::TestMPITaskParallel::CRS(const int* matrix){
+void vavilov_v_bellman_ford_mpi::TestMPITaskParallel::CRS(const int* matrix) {
   row_ptr.push_back(0);
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {
@@ -79,7 +79,7 @@ void vavilov_v_bellman_ford_mpi::TestMPITaskParallel::CRS(const int* matrix){
       }
     }
     row_offsets_.push_back(values.size());
-  } 
+  }
 };
 
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
@@ -87,7 +87,6 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
   vertices_ = taskData->inputs_count[0];
   edges_count_ = taskData->inputs_count[1];
   source_ = taskData->inputs_count[2];
-
 
   auto* matrix = reinterpret_cast<int*>(taskData->inputs[0]);
 

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -7,9 +7,20 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::pre_processing() {
   edges_count_ = taskData->inputs_count[1];
   source_ = taskData->inputs_count[2];
 
-  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
-  int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);
-  int* weights_ = reinterpret_cast<int*>(taskData->inputs[2]);
+  int* row_offsets_data = reinterpret_cast<int*>(taskData->inputs[0]);
+  for (int i = 0; i < vertices_ + 1; ++i) {
+    row_offsets_.push_back(row_offsets_data[i]);
+  }
+
+  int* col_indices_data = reinterpret_cast<int*>(taskData->inputs[1]);
+  for (int i = 0; i < edges_count_; ++i) {
+    col_indices_.push_back(col_indices_data[i]);
+  }
+
+  int* weights_data = reinterpret_cast<int*>(taskData->inputs[2]);
+  for (int i = 0; i < edges_count_; ++i) {
+    weights_.push_back(weights_data[i]);
+  }
 
   distances_.resize(vertices_, INT_MAX);
   distances_[source_] = 0;
@@ -64,9 +75,20 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
   edges_count_ = taskData->inputs_count[1];
   source_ = taskData->inputs_count[2];
 
-  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
-  int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);
-  int* weights_ = reinterpret_cast<int*>(taskData->inputs[2]);
+  int* row_offsets_data = reinterpret_cast<int*>(taskData->inputs[0]);
+  for (int i = 0; i < vertices_ + 1; ++i) {
+    row_offsets_.push_back(row_offsets_data[i]);
+  }
+
+  int* col_indices_data = reinterpret_cast<int*>(taskData->inputs[1]);
+  for (int i = 0; i < edges_count_; ++i) {
+    col_indices_.push_back(col_indices_data[i]);
+  }
+
+  int* weights_data = reinterpret_cast<int*>(taskData->inputs[2]);
+  for (int i = 0; i < edges_count_; ++i) {
+    weights_.push_back(weights_data[i]);
+  }
 
   boost::mpi::broadcast(world, row_offsets_, 0);
   boost::mpi::broadcast(world, col_indices_, 0);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -71,6 +71,10 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
   edges_count_ = taskData->inputs_count[1];
   source_ = taskData->inputs_count[2];
 
+  row_offsets_.resize(vertices_ + 1);
+  col_indices_.resize(edges_count_);
+  weights_.resize(edges_count_);
+
   std::copy(reinterpret_cast<int*>(taskData->inputs[0]),
             reinterpret_cast<int*>(taskData->inputs[0]) + row_offsets_.size(), row_offsets_.begin());
   std::copy(reinterpret_cast<int*>(taskData->inputs[1]),

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -155,6 +155,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   return !has_negative_cycle;
 }
 
+
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::post_processing() {
   internal_order_test();
 

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -11,8 +11,8 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::pre_processing() {
   col_indices_.resize(edges_count_);
   weights_.resize(edges_count_);
   int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
-  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[1]);
-  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[2]);
+  int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);
+  int* weights_ = reinterpret_cast<int*>(taskData->inputs[2]);
 
   distances_.resize(vertices_, INT_MAX);
   distances_[source_] = 0;
@@ -72,8 +72,8 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
   weights_.resize(edges_count_);
 
   int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
-  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[1]);
-  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[2]);
+  int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);
+  int* weights_= reinterpret_cast<int*>(taskData->inputs[2]);
 
   boost::mpi::broadcast(world, row_offsets_, 0);
   boost::mpi::broadcast(world, col_indices_, 0);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -1,11 +1,11 @@
 #include "mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp"
 
 void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
-  row_ptr.push_back(0);
+  row_offsets_.push_back(0);
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {
       if (matrix[i * vertices_ + j] != 0) {
-        weights_.push_back(input_matrix[i * vertices_ + j]);
+        weights_.push_back(matrix[i * vertices_ + j]);
         col_indices_.push_back(j);
       }
     }
@@ -69,11 +69,11 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::post_processing() {
 }
 
 void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
-  row_ptr.push_back(0);
+  row_offsets_.push_back(0);
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {
       if (matrix[i * vertices_ + j] != 0) {
-        weights_.push_back(input_matrix[i * vertices_ + j]);
+        weights_.push_back(matrix[i * vertices_ + j]);
         col_indices_.push_back(j);
       }
     }

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -68,7 +68,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::post_processing() {
   return true;
 }
 
-void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
+void vavilov_v_bellman_ford_mpi::TestMPITaskParallel::CRS(const int* matrix) {
   row_offsets_.push_back(0);
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -7,9 +7,6 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::pre_processing() {
   edges_count_ = taskData->inputs_count[1];
   source_ = taskData->inputs_count[2];
 
-  row_offsets_.resize(vertices_ + 1);
-  col_indices_.resize(edges_count_);
-  weights_.resize(edges_count_);
   int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
   int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);
   int* weights_ = reinterpret_cast<int*>(taskData->inputs[2]);
@@ -66,10 +63,6 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
   vertices_ = taskData->inputs_count[0];
   edges_count_ = taskData->inputs_count[1];
   source_ = taskData->inputs_count[2];
-
-  row_offsets_.resize(vertices_ + 1);
-  col_indices_.resize(edges_count_);
-  weights_.resize(edges_count_);
 
   int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
   int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -10,13 +10,9 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::pre_processing() {
   row_offsets_.resize(vertices_ + 1);
   col_indices_.resize(edges_count_);
   weights_.resize(edges_count_);
-
-  std::copy(reinterpret_cast<int*>(taskData->inputs[0]),
-            reinterpret_cast<int*>(taskData->inputs[0]) + row_offsets_.size(), row_offsets_.begin());
-  std::copy(reinterpret_cast<int*>(taskData->inputs[1]),
-            reinterpret_cast<int*>(taskData->inputs[1]) + col_indices_.size(), col_indices_.begin());
-  std::copy(reinterpret_cast<int*>(taskData->inputs[2]), reinterpret_cast<int*>(taskData->inputs[2]) + weights_.size(),
-            weights_.begin());
+  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
+  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[1]);
+  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[2]);
 
   distances_.resize(vertices_, INT_MAX);
   distances_[source_] = 0;
@@ -75,12 +71,9 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
   col_indices_.resize(edges_count_);
   weights_.resize(edges_count_);
 
-  std::copy(reinterpret_cast<int*>(taskData->inputs[0]),
-            reinterpret_cast<int*>(taskData->inputs[0]) + row_offsets_.size(), row_offsets_.begin());
-  std::copy(reinterpret_cast<int*>(taskData->inputs[1]),
-            reinterpret_cast<int*>(taskData->inputs[1]) + col_indices_.size(), col_indices_.begin());
-  std::copy(reinterpret_cast<int*>(taskData->inputs[2]), reinterpret_cast<int*>(taskData->inputs[2]) + weights_.size(),
-            weights_.begin());
+  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
+  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[1]);
+  int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[2]);
 
   boost::mpi::broadcast(world, row_offsets_, 0);
   boost::mpi::broadcast(world, col_indices_, 0);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -1,6 +1,5 @@
 #include "mpi/vavilov_v_bellman_ford/include/ops_mpi.hpp"
 
-
 void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
   row_ptr.push_back(0);
   for (int i = 0; i < vertices_; ++i) {

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -73,7 +73,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
 
   int* row_offsets_ = reinterpret_cast<int*>(taskData->inputs[0]);
   int* col_indices_ = reinterpret_cast<int*>(taskData->inputs[1]);
-  int* weights_= reinterpret_cast<int*>(taskData->inputs[2]);
+  int* weights_ = reinterpret_cast<int*>(taskData->inputs[2]);
 
   boost::mpi::broadcast(world, row_offsets_, 0);
   boost::mpi::broadcast(world, col_indices_, 0);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -135,10 +135,12 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
     }
 
     boost::mpi::all_reduce(world, local_distances.data(), vertices_, distances_.data(), [](int a, int b) {
-      return (a == INT_MAX) ? b : (b == INT_MAX) ? a : std::min(a, b);
+      if (a == INT_MAX) return b;
+      if (b == INT_MAX) return a;
+      return std::min(a, b);
     });
 
-    bool global_changed = boost::mpi::all_reduce(world, local_changed, std::logical_or<bool>());
+    bool global_changed = boost::mpi::all_reduce(world, local_changed, std::logical_or<>());
     if (!global_changed) break;
   }
 
@@ -154,7 +156,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
     }
   }
 
-  has_negative_cycle = boost::mpi::all_reduce(world, has_negative_cycle, std::logical_or<bool>());
+  has_negative_cycle = boost::mpi::all_reduce(world, has_negative_cycle, std::logical_or<>());
   return !has_negative_cycle;
 }
 

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -94,10 +94,6 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::pre_processing() {
 
   CRS(matrix);
 
-  boost::mpi::broadcast(world, row_offsets_, 0);
-  boost::mpi::broadcast(world, col_indices_, 0);
-  boost::mpi::broadcast(world, weights_, 0);
-
   distances_.resize(vertices_, INT_MAX);
   distances_[source_] = 0;
 
@@ -115,6 +111,10 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::validation() {
 
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   internal_order_test();
+
+  boost::mpi::broadcast(world, row_offsets_, 0);
+  boost::mpi::broadcast(world, col_indices_, 0);
+  boost::mpi::broadcast(world, weights_, 0);
 
   int local_start = world.rank() * (vertices_ / world.size()) + std::min(world.rank(), vertices_ % world.size());
   int local_end = local_start + (vertices_ / world.size()) + (world.rank() < vertices_ % world.size() ? 1 : 0);

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -5,11 +5,11 @@ void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {
       if (matrix[i * vertices_ + j] != 0) {
-        weights_.push_back(input_matrix[i * V + j]);
+        weights_.push_back(input_matrix[i * vertices_ + j]);
         col_indices_.push_back(j);
       }
     }
-    row_offsets_.push_back(values.size());
+    row_offsets_.push_back(weights_.size());
   }
 };
 
@@ -68,16 +68,16 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::post_processing() {
   return true;
 }
 
-void vavilov_v_bellman_ford_mpi::TestMPITaskParallel::CRS(const int* matrix) {
+void vavilov_v_bellman_ford_mpi::TestMPITaskSequential::CRS(const int* matrix) {
   row_ptr.push_back(0);
   for (int i = 0; i < vertices_; ++i) {
     for (int j = 0; j < vertices_; ++j) {
       if (matrix[i * vertices_ + j] != 0) {
-        weights_.push_back(input_matrix[i * V + j]);
+        weights_.push_back(input_matrix[i * vertices_ + j]);
         col_indices_.push_back(j);
       }
     }
-    row_offsets_.push_back(values.size());
+    row_offsets_.push_back(weights_.size());
   }
 };
 

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -113,27 +113,28 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::validation() {
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   internal_order_test();
 
-  int local_start = world.rank() * (vertices_ / world.size());
-  int local_end = local_start + (vertices_ / world.size());
-  if (world.rank() == world.size() - 1) {
-    local_end = vertices_;  // Последний процесс обрабатывает остаток
-  }
+  int local_start = world.rank() * (vertices_ / world.size()) + std::min(world.rank(), vertices_ % world.size());
+  int local_end = local_start + (vertices_ / world.size()) + (world.rank() < vertices_ % world.size() ? 1 : 0);
 
   for (int i = 0; i < vertices_ - 1; ++i) {
+    std::vector<int> local_distances = distances_;
     bool local_changed = false;
 
     for (int u = local_start; u < local_end; ++u) {
       for (int j = row_offsets_[u]; j < row_offsets_[u + 1]; ++j) {
         int v = col_indices_[j];
         int weight = weights_[j];
-        if (distances_[u] != INT_MAX && distances_[u] + weight < distances_[v]) {
-          distances_[v] = distances_[u] + weight;
+        if (distances_[u] != INT_MAX && distances_[u] + weight < local_distances[v]) {
+          local_distances[v] = distances_[u] + weight;
           local_changed = true;
         }
       }
     }
 
-    boost::mpi::all_reduce(world, distances_.data(), vertices_, std::min<int>);
+    boost::mpi::all_reduce(world, local_distances.data(), vertices_, distances_.data(), [](int a, int b) {
+      return (a == INT_MAX) ? b : (b == INT_MAX) ? a : std::min(a, b);
+    });
+
     bool global_changed = boost::mpi::all_reduce(world, local_changed, std::logical_or<bool>());
     if (!global_changed) break;
   }

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -155,7 +155,6 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   return !has_negative_cycle;
 }
 
-
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::post_processing() {
   internal_order_test();
 

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -154,7 +154,6 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   return !has_negative_cycle;
 }
 
-
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::post_processing() {
   internal_order_test();
 

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -163,9 +163,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   }
 
   has_negative_cycle = boost::mpi::all_reduce(world, has_negative_cycle, std::logical_or<>());
-  if (has_negative_cycle) {
-    return false;
-  }
+  return !has_negative_cycle;
 }
 
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::post_processing() {

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -100,8 +100,8 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::validation() {
 bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
   internal_order_test();
 
-  int local_start = world.rank() * (vertices_ / world.size());
-  int local_end = (world.rank() == world.size() - 1) ? vertices_ : local_start + (vertices_ / world.size());
+  int local_start = world.rank() * (edges_count_ / world.size()) + std::min(world.rank(), edges_count_ % world.size());
+  int local_end = local_start + (edges_count_ / world.size()) + (world.rank() < edges_count_ % world.size() ? 1 : 0);
 
   for (int i = 0; i < vertices_ - 1; ++i) {
     std::vector<int> local_distances = distances_;

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -145,6 +145,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskParallel::run() {
         break;
       }
     }
+  }
 
   has_negative_cycle = boost::mpi::all_reduce(world, has_negative_cycle, std::logical_or<bool>());
   return !has_negative_cycle;

--- a/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
+++ b/tasks/mpi/vavilov_v_bellman_ford/src/ops_mpi.cpp
@@ -38,12 +38,15 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::validation() {
 
 bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::run() {
   internal_order_test();
-  for (int u = 0; u < vertices_; ++u) {
-    for (int j = row_offsets_[u]; j < row_offsets_[u + 1]; ++j) {
-      int v = col_indices_[j];
-      int weight = weights_[j];
-      if (distances_[u] != INT_MAX && distances_[u] + weight < distances_[v]) {
-        distances_[v] = distances_[u] + weight;
+
+  for (int i = 0; i < vertices_ - 1; ++i) {
+    for (int u = 0; u < vertices_; ++u) {
+      for (int j = row_offsets_[u]; j < row_offsets_[u + 1]; ++j) {
+        int v = col_indices_[j];
+        int weight = weights_[j];
+        if (distances_[u] != INT_MAX && distances_[u] + weight < distances_[v]) {
+          distances_[v] = distances_[u] + weight;
+        }
       }
     }
   }
@@ -53,7 +56,7 @@ bool vavilov_v_bellman_ford_mpi::TestMPITaskSequential::run() {
       int v = col_indices_[j];
       int weight = weights_[j];
       if (distances_[u] != INT_MAX && distances_[u] + weight < distances_[v]) {
-        return false;  // Negative weight cycle detected
+        return false;
       }
     }
   }

--- a/tasks/seq/vavilov_v_bellman_ford/func_tests/main.cpp
+++ b/tasks/seq/vavilov_v_bellman_ford/func_tests/main.cpp
@@ -8,7 +8,9 @@
 TEST(vavilov_v_bellman_ford_seq, ValidInputWithMultiplePaths_1) {
   std::vector<int> edges = {0, 1, 10, 0, 2, 5, 1, 2, 2, 1, 3, 1, 2, 1, 3, 2, 3, 9, 2, 4, 2, 3, 4, 4};
   std::vector<int> output(5);
-  unsigned int vertices = 5, edges_count = 8, source = 0;
+  unsigned int vertices = 5;
+  unsigned int edges_count = 8;
+  unsigned int source = 0;
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs_count.emplace_back(vertices);
@@ -31,7 +33,9 @@ TEST(vavilov_v_bellman_ford_seq, ValidInputWithMultiplePaths_1) {
 TEST(vavilov_v_bellman_ford_seq, ValidInputWithMultiplePaths_2) {
   std::vector<int> edges = {0, 1, -1, 0, 2, 4, 1, 2, 3, 1, 3, 2, 2, 3, 5, 3, 4, -3};
   std::vector<int> output(5);
-  unsigned int vertices = 5, edges_count = 6, source = 0;
+  unsigned int vertices = 5;
+  unsigned int edges_count = 6;
+  unsigned int source = 0;
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs_count.emplace_back(vertices);
@@ -54,7 +58,9 @@ TEST(vavilov_v_bellman_ford_seq, ValidInputWithMultiplePaths_2) {
 TEST(vavilov_v_bellman_ford_seq, DisconnectedGraph) {
   std::vector<int> edges = {0, 1, 4, 0, 2, 1, 1, 3, 2};
   std::vector<int> output(5);
-  int vertices = 5, edges_count = 3, source = 0;
+  unsigned int vertices = 5;
+  unsigned int edges_count = 3;
+  unsigned int source = 0;
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs_count.emplace_back(vertices);
@@ -77,7 +83,9 @@ TEST(vavilov_v_bellman_ford_seq, DisconnectedGraph) {
 TEST(vavilov_v_bellman_ford_seq, NegativeCycle) {
   std::vector<int> edges = {0, 1, 1, 1, 2, -1, 2, 0, -1};
   std::vector<int> output(3);
-  unsigned int vertices = 3, edges_count = 3, source = 0;
+  unsigned int vertices = 3;
+  unsigned int edges_count = 3;
+  unsigned int source = 0;
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs_count.emplace_back(vertices);
@@ -96,7 +104,9 @@ TEST(vavilov_v_bellman_ford_seq, NegativeCycle) {
 TEST(vavilov_v_bellman_ford_seq, SingleVertexGraph) {
   std::vector<int> edges = {};
   std::vector<int> output(1, 0);
-  unsigned int vertices = 1, edges_count = 0, source = 0;
+  unsigned int vertices = 1;
+  unsigned int edges_count = 0;
+  unsigned int source = 0;
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs_count.emplace_back(vertices);

--- a/tasks/seq/vavilov_v_bellman_ford/include/ops_seq.hpp
+++ b/tasks/seq/vavilov_v_bellman_ford/include/ops_seq.hpp
@@ -4,7 +4,6 @@
 #include <limits>
 #include <memory>
 #include <ranges>
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/vavilov_v_bellman_ford/include/ops_seq.hpp
+++ b/tasks/seq/vavilov_v_bellman_ford/include/ops_seq.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <string>
 #include <vector>
 

--- a/tasks/seq/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/seq/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -8,36 +8,40 @@
 #include "core/perf/include/perf.hpp"
 #include "seq/vavilov_v_bellman_ford/include/ops_seq.hpp"
 
-std::vector<std::tuple<int, int, int>> generate_linear_graph(int num_vertices) {
-  std::vector<std::tuple<int, int, int>> edges;
-  edges.reserve(num_vertices - 1);
+std::vector<int> generate_linear_graph(int num_vertices) {
+  std::vector<int> edges((num_vertices - 1) * 3);
   for (int i = 0; i < num_vertices - 1; ++i) {
-    edges.emplace_back(i, i + 1, i + 1);
+    edges[i * 3] = i;
+    edges[i * 3 + 1] = i + 1;
+    edges[i * 3 + 2] = 1;
   }
   return edges;
 }
 
 std::vector<int> compute_expected_distances(int num_vertices) {
-  std::vector<int> distances(num_vertices, 0);
-  for (int i = 1; i < num_vertices; ++i) {
-    distances[i] = distances[i - 1] + i;
+  std::vector<int> distances(num_vertices);
+  for (int i = 0; i < num_vertices; ++i) {
+    distances[i] = i;
   }
   return distances;
 }
 
 TEST(vavilov_v_bellman_ford_seq, test_task_run) {
   const int num_vertices = 1000;
+  const int edges_count = 999;
+  const int source = 0;
   auto edges = generate_linear_graph(num_vertices);
   auto expected_distances = compute_expected_distances(num_vertices);
 
-  std::vector<int> distances(num_vertices, INT_MAX);
-  distances[0] = 0;
+  std::vector<int> distances(num_vertices);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs_count.emplace_back(num_vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(edges.data()));
-  taskDataSeq->inputs_count.emplace_back(edges.size());
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
   taskDataSeq->outputs_count.emplace_back(distances.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
 
   auto testTaskSequential = std::make_shared<vavilov_v_bellman_ford_seq::TestTaskSequential>(taskDataSeq);
 
@@ -61,17 +65,20 @@ TEST(vavilov_v_bellman_ford_seq, test_task_run) {
 
 TEST(vavilov_v_bellman_ford_seq, test_pipeline_run) {
   const int num_vertices = 1000;
+  const int edges_count = 999;
+  const int source = 0;
   auto edges = generate_linear_graph(num_vertices);
   auto expected_distances = compute_expected_distances(num_vertices);
 
-  std::vector<int> distances(num_vertices, INT_MAX);
-  distances[0] = 0;
+  std::vector<int> distances(num_vertices);
 
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs_count.emplace_back(num_vertices);
+  taskDataSeq->inputs_count.emplace_back(edges_count);
+  taskDataSeq->inputs_count.emplace_back(source);
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(edges.data()));
-  taskDataSeq->inputs_count.emplace_back(edges.size());
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
   taskDataSeq->outputs_count.emplace_back(distances.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
 
   auto testTaskSequential = std::make_shared<vavilov_v_bellman_ford_seq::TestTaskSequential>(taskDataSeq);
 

--- a/tasks/seq/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/seq/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -10,6 +10,7 @@
 
 std::vector<std::tuple<int, int, int>> generate_linear_graph(int num_vertices) {
   std::vector<std::tuple<int, int, int>> edges;
+  edges.reserve(num_vertices - 1);  // Резервируем память для всех элементов заранее
   for (int i = 0; i < num_vertices - 1; ++i) {
     edges.emplace_back(i, i + 1, i + 1);
   }

--- a/tasks/seq/vavilov_v_bellman_ford/perf_tests/main.cpp
+++ b/tasks/seq/vavilov_v_bellman_ford/perf_tests/main.cpp
@@ -10,7 +10,7 @@
 
 std::vector<std::tuple<int, int, int>> generate_linear_graph(int num_vertices) {
   std::vector<std::tuple<int, int, int>> edges;
-  edges.reserve(num_vertices - 1);  // Резервируем память для всех элементов заранее
+  edges.reserve(num_vertices - 1);
   for (int i = 0; i < num_vertices - 1; ++i) {
     edges.emplace_back(i, i + 1, i + 1);
   }

--- a/tasks/seq/vavilov_v_bellman_ford/src/ops_seq.cpp
+++ b/tasks/seq/vavilov_v_bellman_ford/src/ops_seq.cpp
@@ -28,20 +28,18 @@ bool vavilov_v_bellman_ford_seq::TestTaskSequential::run() {
   internal_order_test();
 
   for (int i = 1; i < vertices_; ++i) {
-    for (const auto& edge : edges_) {
+    std::for_each(edges_.begin(), edges_.end(), [this](const Edge& edge) {
       if (distances_[edge.src] != INT_MAX && distances_[edge.src] + edge.weight < distances_[edge.dest]) {
         distances_[edge.dest] = distances_[edge.src] + edge.weight;
       }
-    }
+    });
   }
 
-  for (const auto& edge : edges_) {
-    if (distances_[edge.src] != INT_MAX && distances_[edge.src] + edge.weight < distances_[edge.dest]) {
-      return false;  // Negative weight cycle detected
-    }
-  }
+  const bool has_negative_cycle = std::ranges::any_of(edges_, [this](const Edge& edge) {
+    return distances_[edge.src] != INT_MAX && distances_[edge.src] + edge.weight < distances_[edge.dest];
+  });
 
-  return true;
+  return !has_negative_cycle;
 }
 
 bool vavilov_v_bellman_ford_seq::TestTaskSequential::post_processing() {


### PR DESCRIPTION
Алгоритм Беллмана-Форда широко используется для поиска кратчайших путей от одной вершины до всех остальных в графе с заданными весами рёбер. Основное преимущество алгоритма заключается в его способности корректно обрабатывать графы с отрицательными весами рёбер. 

Дан направленный граф $G = (V, E)$, где $V$ - множество вершин, $E$ - множество рёбер с весами $w(u, v)$. Требуется найти кратчайшие пути от заданной вершины $s \in V$ до всех остальных вершин графа.
Было реализовано 2 последовательной версии. Первая хранит в массиве исходящую вершину, входящую вершину и вес. Вторая версия заключается в реализации CRS графа. Поскольку использование CRS графа эффективнее, то параллельная версия была реализована с CRS хранением.

Схема последовательного алгоритма:
1) Инициализировать расстояния: $dist[s] = 0$, $dist[v] = \infty$ для всех $v \neq s$.
2) Выполнить $|V| - 1$ итерацию:
    Для каждого ребра $(u, v)$: $dist[v] = \min(dist[v], dist[u] + w(u, v))$.
3) Проверить наличие отрицательных циклов.

Схема параллельного алгоритма:
1) Инициализировать расстояния на каждом процессоре.
2) Выполнить $|V| - 1$ итерацию:
    Локально обновить расстояния для вершин, закреплённых за процессором.
    Обменяться обновлёнными данными с другими процессорами.
3) Проверить наличие отрицательных циклов.

