### PR TITLE
Созонов Илья. Задача 3. Вариант 27. Линейная фильтрация изображений (вертикальное разбиение). Ядро Гаусса 3x3.

### DIFF
--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -1,0 +1,409 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <random>
+#include <vector>
+
+#include "mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_mpi.hpp"
+
+namespace sozonov_i_image_filtering_vertical_gaussian_3x3_mpi {
+
+std::vector<double> getRandomImage(int sz) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_real_distribution<double> dis(0, 255);
+  std::vector<double> img(sz);
+  for (int i = 0; i < sz; ++i) {
+    img[i] = dis(gen);
+  }
+  return img;
+}
+
+}  // namespace sozonov_i_image_filtering_vertical_gaussian_3x3_mpi
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_7x5) {
+  boost::mpi::communicator world;
+
+  const int width = 7;
+  const int height = 5;
+
+  std::vector<double> global_img = {34, 24, 27, 1,   67, 42, 48, 93, 26, 47, 2,  16, 34, 13, 81, 5, 24, 32,
+                                    12, 2,  37, 123, 12, 78, 64, 1,  76, 7,  46, 9,  4,  10, 17, 4, 112};
+  std::vector<double> global_ans(width * height, 0);
+  std::vector<double> ans = {0,      0,       0,       0,      0,       0,     0,       42.6875, 38,
+                             25.5,   20.625,  23.1875, 27.875, 20.875,  50.25, 40.4375, 32.75,   29.625,
+                             20.375, 22.6875, 18.875,  49,     39.5625, 36,    34.6875, 24.375,  31.875,
+                             30.25,  0,       0,       0,      0,       0,     0,       0};
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(reference_ans, ans);
+    ASSERT_EQ(global_ans, ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_10x3) {
+  boost::mpi::communicator world;
+
+  const int width = 10;
+  const int height = 3;
+
+  std::vector<double> global_img = {34, 24, 27, 67,  42, 48, 93, 26, 47, 2,  34, 13, 81, 24, 32,
+                                    12, 2,  37, 123, 12, 78, 64, 1,  7,  46, 9,  10, 17, 4,  112};
+  std::vector<double> global_ans(width * height, 0);
+  std::vector<double> ans = {0,      0,      0,    0,      0,       0,       0,     0,      0,       0,
+                             29.625, 37.375, 38.5, 36.625, 31.6875, 26.3125, 25.75, 39.875, 53.0625, 35.8125,
+                             0,      0,      0,    0,      0,       0,       0,     0,      0,       0};
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(reference_ans, ans);
+    ASSERT_EQ(global_ans, ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_100x100) {
+  boost::mpi::communicator world;
+
+  const int width = 100;
+  const int height = 100;
+
+  std::vector<double> global_img(width * height, 1);
+  std::vector<double> global_ans(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(global_ans, reference_ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_150x200) {
+  boost::mpi::communicator world;
+
+  const int width = 150;
+  const int height = 200;
+
+  std::vector<double> global_img(width * height, 1);
+  std::vector<double> global_ans(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(global_ans, reference_ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_random_100x100) {
+  boost::mpi::communicator world;
+
+  const int width = 100;
+  const int height = 100;
+
+  std::vector<double> global_img(width * height);
+  std::vector<double> global_ans(width * height, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_img = sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::getRandomImage(width * height);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(global_ans, reference_ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_random_150x100) {
+  boost::mpi::communicator world;
+
+  const int width = 150;
+  const int height = 100;
+
+  std::vector<double> global_img(width * height);
+  std::vector<double> global_ans(width * height, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_img = sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::getRandomImage(width * height);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(global_ans, reference_ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_random_120x200) {
+  boost::mpi::communicator world;
+
+  const int width = 120;
+  const int height = 200;
+
+  std::vector<double> global_img(width * height);
+  std::vector<double> global_ans(width * height, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    global_img = sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::getRandomImage(width * height);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    // Create data
+    std::vector<double> reference_ans(width * height, 0);
+
+    // Create TaskData
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataSeq->inputs_count.emplace_back(global_img.size());
+    taskDataSeq->inputs_count.emplace_back(width);
+    taskDataSeq->inputs_count.emplace_back(height);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_ans.data()));
+    taskDataSeq->outputs_count.emplace_back(reference_ans.size());
+
+    // Create Task
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+    testMpiTaskSequential.pre_processing();
+    testMpiTaskSequential.run();
+    testMpiTaskSequential.post_processing();
+
+    ASSERT_EQ(global_ans, reference_ans);
+  }
+}

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -68,29 +68,6 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_wrong_pixels) {
   }
 }
 
-TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_wrong_input_count) {
-  boost::mpi::communicator world;
-
-  const int width = 100;
-  const int height = 50;
-
-  std::vector<double> global_img(30, 1);
-  std::vector<double> global_ans(width * height, 0);
-  // Create TaskData
-  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-
-  if (world.rank() == 0) {
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
-    taskDataPar->inputs_count.emplace_back(global_img.size());
-    taskDataPar->inputs_count.emplace_back(width);
-    taskDataPar->inputs_count.emplace_back(height);
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
-    taskDataPar->outputs_count.emplace_back(global_ans.size());
-    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-    ASSERT_FALSE(testMpiTaskParallel.validation());
-  }
-}
-
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_7x5) {
   boost::mpi::communicator world;
 

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -74,7 +74,7 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_wrong_input_count
   const int width = 100;
   const int height = 50;
 
-  std::vector<double> global_img(150, 1);
+  std::vector<double> global_img(30, 1);
   std::vector<double> global_ans(width * height, 0);
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -51,7 +51,7 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_wrong_pixels) {
   const int width = 5;
   const int height = 3;
 
-  std::vector<double> global_img = {143, 6, 853, 24, 31, 25, 1, 5, 7, 361, 28, 98, 45, 982, 461};
+  std::vector<double> global_img = {143, 6, 853, -24, 31, 25, 1, -5, 7, 361, -28, 98, -45, 982, 461};
   std::vector<double> global_ans(width * height, 0);
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -22,6 +22,75 @@ std::vector<double> getRandomImage(int sz) {
 
 }  // namespace sozonov_i_image_filtering_vertical_gaussian_3x3_mpi
 
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_image_less_than_3x3) {
+  boost::mpi::communicator world;
+
+  const int width = 2;
+  const int height = 2;
+
+  std::vector<double> global_img = {4, 6, 8, 24};
+  std::vector<double> global_ans(width * height, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_wrong_pixels) {
+  boost::mpi::communicator world;
+
+  const int width = 5;
+  const int height = 3;
+
+  std::vector<double> global_img = {143, 6, 853, 24, 31, 25, 1, 5, 7, 361, 28, 98, 45, 982, 461};
+  std::vector<double> global_ans(width * height, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_wrong_input_count) {
+  boost::mpi::communicator world;
+
+  const int width = 100;
+  const int height = 50;
+
+  std::vector<double> global_img(150, 1);
+  std::vector<double> global_ans(width * height, 0);
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+    sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_7x5) {
   boost::mpi::communicator world;
 

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_mpi.hpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_mpi.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace sozonov_i_image_filtering_vertical_gaussian_3x3_mpi {
+
+class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> image, filtered_image;
+  int width{}, height{};
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> image, filtered_image;
+  int width{}, height{};
+  boost::mpi::communicator world;
+};
+
+}  // namespace sozonov_i_image_filtering_vertical_gaussian_3x3_mpi

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_mpi.hpp"
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+
+  const int width = 1000;
+  const int height = 1000;
+
+  std::vector<double> global_img(width * height, 1);
+  std::vector<double> global_ans(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  auto testMpiTaskParallel =
+      std::make_shared<sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(global_ans, ans);
+  }
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_task_run) {
+  boost::mpi::communicator world;
+
+  const int width = 1000;
+  const int height = 1000;
+
+  std::vector<double> global_img(width * height, 1);
+  std::vector<double> global_ans(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_img.data()));
+    taskDataPar->inputs_count.emplace_back(global_img.size());
+    taskDataPar->inputs_count.emplace_back(width);
+    taskDataPar->inputs_count.emplace_back(height);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(global_ans.data()));
+    taskDataPar->outputs_count.emplace_back(global_ans.size());
+  }
+
+  auto testMpiTaskParallel =
+      std::make_shared<sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_EQ(global_ans, ans);
+  }
+}

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
@@ -10,8 +10,8 @@
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
 
-  const int width = 1000;
-  const int height = 1000;
+  const int width = 3000;
+  const int height = 3000;
 
   std::vector<double> global_img(width * height, 1);
   std::vector<double> global_ans(width * height, 0);
@@ -66,8 +66,8 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_pipeline_run) {
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_mpi, test_task_run) {
   boost::mpi::communicator world;
 
-  const int width = 1000;
-  const int height = 1000;
+  const int width = 3000;
+  const int height = 3000;
 
   std::vector<double> global_img(width * height, 1);
   std::vector<double> global_ans(width * height, 0);

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_mpi.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_mpi.cpp
@@ -24,7 +24,7 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential:
 bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential::validation() {
   internal_order_test();
   // Check input and output count
-  return taskData->inputs_count[0] = taskData->outputs_count[0] = taskData->inputs_count[1] * taskData->inputs_count[2];
+  return taskData->inputs_count[0] > 0;
 }
 
 bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential::run() {
@@ -82,8 +82,7 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel::v
   internal_order_test();
   if (world.rank() == 0) {
     // Check input and output count
-    return taskData->inputs_count[0] = taskData->outputs_count[0] =
-               taskData->inputs_count[1] * taskData->inputs_count[2];
+    return taskData->inputs_count[0] > 0;
   }
   return true;
 }

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_mpi.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_mpi.cpp
@@ -28,12 +28,17 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential:
   auto *tmp_ptr = reinterpret_cast<double *>(taskData->inputs[0]);
   std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
 
-  size_t size = taskData->inputs_count[1] * taskData->inputs_count[2];
+  size_t img_size = taskData->inputs_count[1] * taskData->inputs_count[2];
 
-  bool check_pixels = std::all_of(image.begin(), image.end(), [](double pixel) { return pixel >= 0 && pixel <= 255; });
+  // Check pixels range from 0 to 255
+  for (size_t i = 0; i < img_size; ++i) {
+    if (image[i] < 0 || image[i] > 255) {
+      return false;
+    }
+  }
 
-  // Check input and output count and pixels range from 0 to 255
-  return taskData->inputs_count[0] == size && taskData->outputs_count[0] == size && check_pixels &&
+  // Check size of image
+  return taskData->inputs_count[0] == img_size && taskData->outputs_count[0] == img_size &&
          taskData->inputs_count[1] >= 3 && taskData->inputs_count[2] >= 3;
 }
 
@@ -96,13 +101,17 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel::v
     auto *tmp_ptr = reinterpret_cast<double *>(taskData->inputs[0]);
     std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
 
-    size_t size = taskData->inputs_count[1] * taskData->inputs_count[2];
+    size_t img_size = taskData->inputs_count[1] * taskData->inputs_count[2];
 
-    bool check_pixels =
-        std::all_of(image.begin(), image.end(), [](double pixel) { return pixel >= 0 && pixel <= 255; });
+    // Check pixels range from 0 to 255
+    for (size_t i = 0; i < img_size; ++i) {
+      if (image[i] < 0 || image[i] > 255) {
+        return false;
+      }
+    }
 
-    // Check input and output count and pixels range from 0 to 255
-    return taskData->inputs_count[0] == size && taskData->outputs_count[0] == size && check_pixels &&
+    // Check size of image
+    return taskData->inputs_count[0] == img_size && taskData->outputs_count[0] == img_size &&
            taskData->inputs_count[1] >= 3 && taskData->inputs_count[2] >= 3;
   }
   return true;

--- a/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_mpi.cpp
+++ b/tasks/mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_mpi.cpp
@@ -1,0 +1,200 @@
+#include "mpi/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <numbers>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+  // Init image
+  image = std::vector<double>(taskData->inputs_count[0]);
+  auto *tmp_ptr = reinterpret_cast<double *>(taskData->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
+  width = taskData->inputs_count[1];
+  height = taskData->inputs_count[2];
+  // Init filtered image
+  filtered_image = std::vector<double>(width * height, 0);
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  // Check input and output count
+  return taskData->inputs_count[0] = taskData->outputs_count[0] = taskData->inputs_count[1] * taskData->inputs_count[2];
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+  std::vector<double> kernel = {0.0625, 0.125, 0.0625, 0.125, 0.25, 0.125, 0.0625, 0.125, 0.0625};
+  std::vector<double> tmp_image((width + 2) * height, 0);
+  for (int i = 0; i < height; ++i) {
+    for (int j = 1; j < width + 1; ++j) {
+      tmp_image[i * (width + 2) + j] = image[i * width + j - 1];
+    }
+  }
+  std::vector<double> tmp_filtered_image((width + 2) * height, 0);
+  for (int i = 1; i < height - 1; ++i) {
+    for (int j = 1; j < width + 1; ++j) {
+      double sum = 0;
+      for (int l = -1; l <= 1; ++l) {
+        for (int k = -1; k <= 1; ++k) {
+          sum += tmp_image[(i - l) * (width + 2) + j - k] * kernel[(l + 1) * 3 + k + 1];
+        }
+      }
+      tmp_filtered_image[i * (width + 2) + j] = sum;
+    }
+  }
+  for (int i = 0; i < height; ++i) {
+    for (int j = 1; j < width + 1; ++j) {
+      filtered_image[i * width + j - 1] = tmp_filtered_image[i * (width + 2) + j];
+    }
+  }
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  auto *out = reinterpret_cast<double *>(taskData->outputs[0]);
+  std::copy(filtered_image.begin(), filtered_image.end(), out);
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    // Init image
+    image = std::vector<double>(taskData->inputs_count[0]);
+    auto *tmp_ptr = reinterpret_cast<double *>(taskData->inputs[0]);
+    std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
+    width = taskData->inputs_count[1];
+    height = taskData->inputs_count[2];
+    // Init filtered image
+    filtered_image = std::vector<double>(width * height, 0);
+  }
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    // Check input and output count
+    return taskData->inputs_count[0] = taskData->outputs_count[0] =
+               taskData->inputs_count[1] * taskData->inputs_count[2];
+  }
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel::run() {
+  internal_order_test();
+
+  broadcast(world, width, 0);
+  broadcast(world, height, 0);
+
+  std::vector<int> col_num(world.size());
+
+  int delta = width / world.size();
+  if (width % world.size() != 0) {
+    delta++;
+  }
+  if (world.rank() >= world.size() - world.size() * delta + width) {
+    delta--;
+  }
+
+  delta = delta + 2;
+
+  boost::mpi::gather(world, delta, col_num.data(), 0);
+
+  std::vector<double> local_image(delta * height, 0);
+  std::vector<double> send_image(delta * height);
+
+  if (world.rank() == 0) {
+    for (int i = 0; i < height; ++i) {
+      for (int j = 0; j < delta - 1; ++j) {
+        local_image[i * delta + j + 1] = image[i * width + j];
+      }
+    }
+    int idx = delta - 2;
+    for (int proc = 1; proc < world.size(); ++proc) {
+      send_image = std::vector<double>(delta * height, 0);
+      if (proc == world.size() - 1) {
+        for (int i = 0; i < height; ++i) {
+          for (int j = -1; j < col_num[proc] - 2; ++j) {
+            send_image[i * col_num[proc] + j + 1] = image[i * width + j + idx];
+          }
+        }
+      } else {
+        for (int i = 0; i < height; ++i) {
+          for (int j = -1; j < col_num[proc] - 1; ++j) {
+            send_image[i * col_num[proc] + j + 1] = image[i * width + j + idx];
+          }
+        }
+        idx += col_num[proc] - 2;
+      }
+      world.send(proc, 0, send_image.data(), col_num[proc] * height);
+    }
+  } else {
+    world.recv(0, 0, local_image.data(), delta * height);
+  }
+
+  std::vector<double> kernel = {0.0625, 0.125, 0.0625, 0.125, 0.25, 0.125, 0.0625, 0.125, 0.0625};
+
+  std::vector<double> local_filtered_image(delta * height, 0);
+
+  for (int i = 1; i < height - 1; ++i) {
+    for (int j = 1; j < delta - 1; ++j) {
+      double sum = 0;
+      for (int l = -1; l <= 1; ++l) {
+        for (int k = -1; k <= 1; ++k) {
+          sum += local_image[(i - l) * delta + j - k] * kernel[(l + 1) * 3 + k + 1];
+        }
+      }
+      local_filtered_image[i * delta + j] = sum;
+    }
+  }
+
+  std::vector<double> back_image((delta - 2) * height);
+
+  for (int i = 0; i < height; ++i) {
+    for (int j = 1; j < delta - 1; ++j) {
+      back_image[i * (delta - 2) + j - 1] = local_filtered_image[i * delta + j];
+    }
+  }
+
+  std::vector<int> recv_counts(world.size());
+
+  if (world.rank() == 0) {
+    for (int i = 0; i < world.size(); ++i) {
+      recv_counts[i] = (col_num[i] - 2) * height;
+    }
+  }
+
+  std::vector<double> gathered_image(width * height);
+  boost::mpi::gatherv(world, back_image, gathered_image.data(), recv_counts, 0);
+
+  if (world.rank() == 0) {
+    int idx = 0;
+    for (int proc = 0; proc < world.size(); ++proc) {
+      for (int i = 0; i < height; ++i) {
+        for (int j = 0; j < col_num[proc] - 2; ++j) {
+          filtered_image[i * width + j + idx] = gathered_image[i * (col_num[proc] - 2) + j + idx * height];
+        }
+      }
+      idx += col_num[proc] - 2;
+    }
+  }
+
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_mpi::TestMPITaskParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    auto *out = reinterpret_cast<double *>(taskData->outputs[0]);
+    std::copy(filtered_image.begin(), filtered_image.end(), out);
+  }
+  return true;
+}

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -49,28 +49,6 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_wrong_pixels) {
   ASSERT_FALSE(testTaskSequential.validation());
 }
 
-TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_wrong_input_count) {
-  const int width = 100;
-  const int height = 50;
-
-  // Create data
-  std::vector<double> in(30, 1);
-  std::vector<double> out(width * height, 0);
-
-  // Create TaskData
-  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskDataSeq->inputs_count.emplace_back(in.size());
-  taskDataSeq->inputs_count.emplace_back(width);
-  taskDataSeq->inputs_count.emplace_back(height);
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskDataSeq->outputs_count.emplace_back(out.size());
-
-  // Create Task
-  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
-  ASSERT_FALSE(testTaskSequential.validation());
-}
-
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_3x3) {
   const int width = 3;
   const int height = 3;

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -5,6 +5,72 @@
 
 #include "seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp"
 
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_image_less_than_3x3) {
+  const int width = 2;
+  const int height = 2;
+
+  // Create data
+  std::vector<double> in = {4, 6, 8, 24};
+  std::vector<double> out(width * height, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_FALSE(testTaskSequential.validation());
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_wrong_pixels) {
+  const int width = 5;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {143, 6, 853, 24, 31, 25, 1, 5, 7, 361, 28, 98, 45, 982, 461};
+  std::vector<double> out(width * height, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_FALSE(testTaskSequential.validation());
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_wrong_input_count) {
+  const int width = 100;
+  const int height = 50;
+
+  // Create data
+  std::vector<double> in(150, 1);
+  std::vector<double> out(width * height, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_FALSE(testTaskSequential.validation());
+}
+
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_3x3) {
   const int width = 3;
   const int height = 3;

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -32,7 +32,7 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_wrong_pixels) {
   const int height = 3;
 
   // Create data
-  std::vector<double> in = {143, 6, 853, 24, 31, 25, 1, 5, 7, 361, 28, 98, 45, 982, 461};
+  std::vector<double> in = {143, 6, 853, -24, 31, -25, 1, 5, -7, 361, 28, 98, -45, 982, 461};
   std::vector<double> out(width * height, 0);
 
   // Create TaskData

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -1,0 +1,255 @@
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <vector>
+
+#include "seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp"
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_3x3) {
+  const int width = 3;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {4, 6, 8, 24, 31, 25, 1, 5, 7};
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 11.1875, 16.5, 12.6875, 0, 0, 0};
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_5x3) {
+  const int width = 5;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {34, 24, 27, 67, 42, 48, 93, 26, 47, 2, 34, 13, 81, 24, 32};
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 0, 34.4375, 48.125, 45.5, 38, 21.3125, 0, 0, 0, 0, 0};
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_5x5) {
+  const int width = 5;
+  const int height = 5;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0,  0,     0,    0,  0,  4,  6,  7, 8, 6.5, 7.75, 11, 12,
+                             13, 10.25, 11.5, 16, 17, 18, 14, 0, 0, 0,   0,    0};
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_5x7) {
+  const int width = 5;
+  const int height = 7;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0,  0,  0,     0,  0,  4,  6,     7,  8,  6.5, 7.75, 11,   12, 13, 10.25, 11.5, 16, 17,
+                             18, 14, 15.25, 21, 22, 23, 17.75, 19, 26, 27,  28,   21.5, 0,  0,  0,     0,    0};
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_10x4) {
+  const int width = 10;
+  const int height = 4;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0,     0,  0,  0,  0,  0,  0,  0,  0,  0,    7.75, 11, 12, 13, 14, 15, 16, 17, 18, 14,
+                             15.25, 21, 22, 23, 24, 25, 26, 27, 28, 21.5, 0,    0,  0,  0,  0,  0,  0,  0,  0,  0};
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_100x100) {
+  const int width = 100;
+  const int height = 100;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_150x100) {
+  const int width = 150;
+  const int height = 100;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_120x200) {
+  const int width = 120;
+  const int height = 200;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+  ASSERT_EQ(ans, out);
+}

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/func_tests/main.cpp
@@ -54,7 +54,7 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_wrong_input_count
   const int height = 50;
 
   // Create data
-  std::vector<double> in(150, 1);
+  std::vector<double> in(30, 1);
   std::vector<double> out(width * height, 0);
 
   // Create TaskData

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace sozonov_i_image_filtering_vertical_gaussian_3x3_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> image, filtered_image;
+  int width{}, height{};
+};
+
+}  // namespace sozonov_i_image_filtering_vertical_gaussian_3x3_seq

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
@@ -8,8 +8,8 @@
 #include "seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp"
 
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_pipeline_run) {
-  const int width = 1000;
-  const int height = 1000;
+  const int width = 3000;
+  const int height = 3000;
 
   // Create data
   std::vector<double> in(width * height, 1);
@@ -60,8 +60,8 @@ TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_pipeline_run) {
 }
 
 TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_task_run) {
-  const int width = 1000;
-  const int height = 1000;
+  const int width = 3000;
+  const int height = 3000;
 
   // Create data
   std::vector<double> in(width * height, 1);

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/perf_tests/main.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp"
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_pipeline_run) {
+  const int width = 1000;
+  const int height = 1000;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto testTaskSequential =
+      std::make_shared<sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  ASSERT_EQ(ans, out);
+}
+
+TEST(sozonov_i_image_filtering_vertical_gaussian_3x3_seq, test_task_run) {
+  const int width = 1000;
+  const int height = 1000;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[(height - 1) * width + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0.75;
+    ans[i * width + width - 1] = 0.75;
+  }
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->inputs_count.emplace_back(width);
+  taskDataSeq->inputs_count.emplace_back(height);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto testTaskSequential =
+      std::make_shared<sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  ASSERT_EQ(ans, out);
+}

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
@@ -1,0 +1,61 @@
+#include "seq/sozonov_i_image_filtering_vertical_gaussian_3x3/include/ops_seq.hpp"
+
+#include <numbers>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::pre_processing() {
+  internal_order_test();
+  // Init image
+  image = std::vector<double>(taskData->inputs_count[0]);
+  auto* tmp_ptr = reinterpret_cast<double*>(taskData->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
+  width = taskData->inputs_count[1];
+  height = taskData->inputs_count[2];
+  // Init filtered image
+  filtered_image = std::vector<double>(width * height, 0);
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::validation() {
+  internal_order_test();
+  // Check input and output count
+  return taskData->inputs_count[0] = taskData->outputs_count[0] = taskData->inputs_count[1] * taskData->inputs_count[2];
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::run() {
+  internal_order_test();
+  std::vector<double> kernel = {0.0625, 0.125, 0.0625, 0.125, 0.25, 0.125, 0.0625, 0.125, 0.0625};
+  std::vector<double> tmp_image((width + 2) * height, 0);
+  for (int i = 0; i < height; ++i) {
+    for (int j = 1; j < width + 1; ++j) {
+      tmp_image[i * (width + 2) + j] = image[i * width + j - 1];
+    }
+  }
+  std::vector<double> tmp_filtered_image((width + 2) * height, 0);
+  for (int i = 1; i < height - 1; ++i) {
+    for (int j = 1; j < width + 1; ++j) {
+      double sum = 0;
+      for (int l = -1; l <= 1; ++l) {
+        for (int k = -1; k <= 1; ++k) {
+          sum += tmp_image[(i - l) * (width + 2) + j - k] * kernel[(l + 1) * 3 + k + 1];
+        }
+      }
+      tmp_filtered_image[i * (width + 2) + j] = sum;
+    }
+  }
+  for (int i = 0; i < height; ++i) {
+    for (int j = 1; j < width + 1; ++j) {
+      filtered_image[i * width + j - 1] = tmp_filtered_image[i * (width + 2) + j];
+    }
+  }
+  return true;
+}
+
+bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::post_processing() {
+  internal_order_test();
+  auto* out = reinterpret_cast<double*>(taskData->outputs[0]);
+  std::copy(filtered_image.begin(), filtered_image.end(), out);
+  return true;
+}

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
@@ -21,7 +21,7 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::pr
 bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::validation() {
   internal_order_test();
   // Check input and output count
-  return taskData->inputs_count[0] = taskData->outputs_count[0] = taskData->inputs_count[1] * taskData->inputs_count[2];
+  return taskData->inputs_count[0] > 0;
 }
 
 bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::run() {

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
@@ -25,12 +25,17 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::va
   auto* tmp_ptr = reinterpret_cast<double*>(taskData->inputs[0]);
   std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
 
-  size_t size = taskData->inputs_count[1] * taskData->inputs_count[2];
+  size_t img_size = taskData->inputs_count[1] * taskData->inputs_count[2];
 
-  bool check_pixels = std::all_of(image.begin(), image.end(), [](double pixel) { return pixel >= 0 && pixel <= 255; });
+  // Check pixels range from 0 to 255
+  for (size_t i = 0; i < img_size; ++i) {
+    if (image[i] < 0 || image[i] > 255) {
+      return false;
+    }
+  }
 
-  // Check input and output count and pixels range from 0 to 255
-  return taskData->inputs_count[0] == size && taskData->outputs_count[0] == size && check_pixels &&
+  // Check size of image
+  return taskData->inputs_count[0] == img_size && taskData->outputs_count[0] == img_size &&
          taskData->inputs_count[1] >= 3 && taskData->inputs_count[2] >= 3;
 }
 

--- a/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
+++ b/tasks/seq/sozonov_i_image_filtering_vertical_gaussian_3x3/src/ops_seq.cpp
@@ -20,8 +20,18 @@ bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::pr
 
 bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::validation() {
   internal_order_test();
-  // Check input and output count
-  return taskData->inputs_count[0] > 0;
+  // Init image
+  image = std::vector<double>(taskData->inputs_count[0]);
+  auto* tmp_ptr = reinterpret_cast<double*>(taskData->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + taskData->inputs_count[0], image.begin());
+
+  size_t size = taskData->inputs_count[1] * taskData->inputs_count[2];
+
+  bool check_pixels = std::all_of(image.begin(), image.end(), [](double pixel) { return pixel >= 0 && pixel <= 255; });
+
+  // Check input and output count and pixels range from 0 to 255
+  return taskData->inputs_count[0] == size && taskData->outputs_count[0] == size && check_pixels &&
+         taskData->inputs_count[1] >= 3 && taskData->inputs_count[2] >= 3;
 }
 
 bool sozonov_i_image_filtering_vertical_gaussian_3x3_seq::TestTaskSequential::run() {


### PR DESCRIPTION
**Описание последовательной задачи**
Ядро Гаусса 3x3: 
![image](https://github.com/user-attachments/assets/ccc04edf-5c03-4b79-8011-e3db53957f27)

К изображению добавляем нулевые края со всех сторон. Для каждого пикселя (кроме граничных) берется окно размером 3×3. Значения пикселей из этого окна умножаются на соответствующие коэффициенты ядра, и их сумма записывается в новый массив как фильтрованное значение пикселя. Это позволяет убрать шум, сохраняя детали изображения.

**Описание MPI задачи**
Столбцы изображения равномерно распределяются между процессами, включая дополнительные столбцы для учета соседей. Главный процесс отправляет каждому процессу его часть изображения. Каждый процесс выполняет свертку ядра Гаусса на своей части изображения. Все процессы отправляют обработанные данные главному процессу, который собирает итоговое изображение.