### PR TITLE
Дурыничев Дмитрий. Задача 3. Вариант 21. "Поразрядная сортировка для вещественных чисел (тип double)  с четно-нечетным слиянием Бэтчера."

### DIFF
--- a/tasks/mpi/durynichev_d_radix_batcher/func_tests/main.cpp
+++ b/tasks/mpi/durynichev_d_radix_batcher/func_tests/main.cpp
@@ -64,6 +64,21 @@ void testTemplate(const std::vector<double>& input_array) {
 
 }  // namespace durynichev_d_radix_batcher_mpi
 
+TEST(durynichev_d_radix_batcher_mpi, sort_test_empty) {
+  std::vector<double> empty_vector;
+
+  EXPECT_NO_THROW(durynichev_d_radix_batcher_mpi::radixSortDouble(empty_vector.begin(), empty_vector.end()));
+  EXPECT_TRUE(empty_vector.empty());
+}
+
+TEST(durynichev_d_radix_batcher_mpi, sort_test_right_work) {
+  std::vector<double> data = {3.1, 2.4, 5.6, 1.2, 8.9, 7.3, 4.5, 6.7};
+  std::vector<double> expected = {1.2, 2.4, 3.1, 4.5, 5.6, 6.7, 7.3, 8.9};
+
+  durynichev_d_radix_batcher_mpi::radixSortDouble(data.begin(), data.end());
+  EXPECT_EQ(data, expected);
+}
+
 TEST(durynichev_d_radix_batcher_mpi, positive_numbers_size_8) {
   durynichev_d_radix_batcher_mpi::testTemplate({2.0, 4.2, 1.3, 5.7, 0.1, 8.9, 7.4, 6.1});
 }

--- a/tasks/mpi/durynichev_d_radix_batcher/func_tests/main.cpp
+++ b/tasks/mpi/durynichev_d_radix_batcher/func_tests/main.cpp
@@ -1,0 +1,135 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <random>
+#include <vector>
+
+#include "mpi/durynichev_d_radix_batcher/include/ops_mpi.hpp"
+
+namespace durynichev_d_radix_batcher_mpi {
+
+std::vector<double> generateRandomData(int array_size) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_real_distribution<double> dist(-1000, 1000);
+
+  std::vector<double> arr(array_size);
+  for (size_t i = 0; i < arr.size(); i++) {
+    arr[i] = dist(gen);
+  }
+  return arr;
+}
+
+void testTemplate(const std::vector<double>& input_array) {
+  boost::mpi::communicator world;
+  int array_size = input_array.size();
+  std::vector<double> array;
+  std::vector<double> result;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&array_size));
+  taskDataPar->inputs_count.emplace_back(1);
+
+  if (world.rank() == 0) {
+    array = input_array;
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(array.data()));
+    taskDataPar->inputs_count.emplace_back(array.size());
+
+    result.resize(array_size);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+    taskDataPar->outputs_count.emplace_back(result.size());
+  }
+
+  auto taskParallel = std::make_shared<RadixBatcher>(taskDataPar);
+
+  if (array_size < 1) {
+    if (world.rank() == 0) {
+      ASSERT_FALSE(taskParallel->validation());
+    }
+  } else {
+    ASSERT_TRUE(taskParallel->validation());
+    taskParallel->pre_processing();
+    taskParallel->run();
+    taskParallel->post_processing();
+
+    if (world.rank() == 0) {
+      std::sort(array.begin(), array.end());
+      EXPECT_EQ(array, result);
+    }
+  }
+}
+
+}  // namespace durynichev_d_radix_batcher_mpi
+
+TEST(durynichev_d_radix_batcher_mpi, positive_numbers_size_8) {
+  durynichev_d_radix_batcher_mpi::testTemplate({2.0, 4.2, 1.3, 5.7, 0.1, 8.9, 7.4, 6.1});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, negative_numbers_size_8) {
+  durynichev_d_radix_batcher_mpi::testTemplate({-2.0, -4.2, -1.3, -5.7, -0.1, -8.9, -7.4, -6.1});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, mixed_numbers_size_8) {
+  durynichev_d_radix_batcher_mpi::testTemplate({-2.0, 4.2, -1.3, 5.7, 0.1, -8.9, 7.4, -6.1});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, fractional_numbers_size_4) {
+  durynichev_d_radix_batcher_mpi::testTemplate({0.2, 0.002, 0.0002, 0.02});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, large_numbers_size_8) {
+  durynichev_d_radix_batcher_mpi::testTemplate({2e11, 4e16, 1e13, 5e19, 2e10, 8e21, 7e12, 6e15});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, small_numbers_size_8) {
+  durynichev_d_radix_batcher_mpi::testTemplate({2e-11, 4e-16, 1e-13, 5e-19, 2e-10, 8e-21, 7e-12, 6e-15});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, numbers_with_infinity_size_4) {
+  durynichev_d_radix_batcher_mpi::testTemplate(
+      {2.0, -2.0, std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, identical_numbers_size_4) {
+  durynichev_d_radix_batcher_mpi::testTemplate({3.3, 3.3, 3.3, 3.3});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, empty_vector) { durynichev_d_radix_batcher_mpi::testTemplate({}); }
+
+TEST(durynichev_d_radix_batcher_mpi, single_element) { durynichev_d_radix_batcher_mpi::testTemplate({24.0}); }
+
+TEST(durynichev_d_radix_batcher_mpi, numbers_close_to_zero_size_4) {
+  durynichev_d_radix_batcher_mpi::testTemplate({-0.000002, 0.0, 0.000002, 0.000003});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, very_large_and_very_small_numbers_size_4) {
+  durynichev_d_radix_batcher_mpi::testTemplate({2e19, 2e-19, -2e19, -2e-19});
+}
+
+TEST(durynichev_d_radix_batcher_mpi, random_vector_size_1) {
+  auto vec = durynichev_d_radix_batcher_mpi::generateRandomData(1);
+  durynichev_d_radix_batcher_mpi::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_mpi, random_vector_size_2) {
+  auto vec = durynichev_d_radix_batcher_mpi::generateRandomData(2);
+  durynichev_d_radix_batcher_mpi::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_mpi, random_vector_size_8) {
+  auto vec = durynichev_d_radix_batcher_mpi::generateRandomData(8);
+  durynichev_d_radix_batcher_mpi::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_mpi, random_vector_size_64) {
+  auto vec = durynichev_d_radix_batcher_mpi::generateRandomData(64);
+  durynichev_d_radix_batcher_mpi::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_mpi, random_vector_size_512) {
+  auto vec = durynichev_d_radix_batcher_mpi::generateRandomData(512);
+  durynichev_d_radix_batcher_mpi::testTemplate(vec);
+}

--- a/tasks/mpi/durynichev_d_radix_batcher/include/ops_mpi.hpp
+++ b/tasks/mpi/durynichev_d_radix_batcher/include/ops_mpi.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <unordered_set>
+
+#include "core/task/include/task.hpp"
+
+namespace durynichev_d_radix_batcher_mpi {
+void exchange_data(boost::mpi::communicator& comm, int shift, std::vector<double>& data, bool is_sending);
+std::unordered_set<int> populate_send_workers(int comm_size, int shift);
+void batcher(boost::mpi::communicator& comm, std::vector<double>& data);
+
+template <typename RandomIt, typename Compare = std::less<typename std::iterator_traits<RandomIt>::value_type>>
+void radixSortDouble(RandomIt begin, RandomIt end, Compare comp = Compare{}) {
+  using ValueType = typename std::iterator_traits<RandomIt>::value_type;
+
+  if (begin == end) {
+    return;
+  }
+
+  constexpr size_t elemSize = sizeof(ValueType);
+  constexpr size_t bitCount = elemSize * 8;
+  constexpr size_t bucketCount = 256;
+
+  union DoubleInt64 {
+    ValueType d;
+    uint64_t u;
+  };
+
+  auto toUint64Key = [](ValueType val) -> uint64_t {
+    DoubleInt64 di{val};
+    uint64_t u = di.u;
+
+    if (u & (1ULL << (bitCount - 1))) {
+      u = ~u;
+    } else {
+      u |= (1ULL << (bitCount - 1));
+    }
+    return u;
+  };
+
+  auto getByte = [](uint64_t key, size_t byteIndex) -> uint8_t {
+    return static_cast<uint8_t>((key >> (byteIndex * 8)) & 0xFF);
+  };
+
+  auto length = static_cast<size_t>(std::distance(begin, end));
+  std::vector<ValueType> buffer(length);
+  RandomIt src = begin;
+  RandomIt dst = buffer.begin();
+
+  bool reverse = comp(ValueType(1), ValueType(0));
+
+  for (size_t bytePos = 0; bytePos < elemSize; ++bytePos) {
+    std::vector<size_t> count(bucketCount, 0);
+
+    for (auto it = src; it != src + length; ++it) {
+      uint64_t key = toUint64Key(*it);
+      ++count[getByte(key, bytePos)];
+    }
+
+    if (reverse) {
+      for (size_t i = bucketCount - 1; i > 0; --i) {
+        count[i - 1] += count[i];
+      }
+    } else {
+      for (size_t i = 1; i < bucketCount; ++i) {
+        count[i] += count[i - 1];
+      }
+    }
+
+    for (auto it = src + length; it != src;) {
+      --it;
+      uint64_t key = toUint64Key(*it);
+      size_t pos = --count[getByte(key, bytePos)];
+      dst[pos] = *it;
+    }
+
+    std::swap(src, dst);
+  }
+
+  if (src != begin) {
+    std::copy(src, src + length, begin);
+  }
+}
+
+class RadixBatcher : public ppc::core::Task {
+ public:
+  explicit RadixBatcher(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  int arr_size;
+  int workers_count;
+  std::vector<double> input_data;
+  std::vector<double> output_data;
+  boost::mpi::communicator world;
+};
+
+}  // namespace durynichev_d_radix_batcher_mpi

--- a/tasks/mpi/durynichev_d_radix_batcher/perf_tests/main.cpp
+++ b/tasks/mpi/durynichev_d_radix_batcher/perf_tests/main.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/timer.hpp>
+#include <cmath>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/durynichev_d_radix_batcher/include/ops_mpi.hpp"
+
+TEST(durynichev_d_radix_batcher_mpi, pipeline_run) {
+  boost::mpi::communicator world;
+  size_t array_size = 262144;
+  std::vector<double> array;
+  std::vector<double> result;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&array_size));
+  taskDataPar->inputs_count.emplace_back(1);
+
+  if (world.rank() == 0) {
+    array.resize(array_size);
+    double current = array_size;
+    std::generate(array.begin(), array.end(), [&current]() { return current--; });
+
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(array.data()));
+    taskDataPar->inputs_count.emplace_back(array.size());
+
+    result.resize(array_size);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+    taskDataPar->outputs_count.emplace_back(result.size());
+  }
+
+  auto taskParallel = std::make_shared<durynichev_d_radix_batcher_mpi::RadixBatcher>(taskDataPar);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    std::sort(array.begin(), array.end());
+    EXPECT_EQ(array, result);
+  }
+}
+
+TEST(durynichev_d_radix_batcher_mpi, task_run) {
+  boost::mpi::communicator world;
+  size_t array_size = 262144;
+  std::vector<double> array;
+  std::vector<double> result;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&array_size));
+  taskDataPar->inputs_count.emplace_back(1);
+
+  if (world.rank() == 0) {
+    array.resize(array_size);
+    double current = array_size;
+    std::generate(array.begin(), array.end(), [&current]() { return current--; });
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(array.data()));
+    taskDataPar->inputs_count.emplace_back(array.size());
+
+    result.resize(array_size);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+    taskDataPar->outputs_count.emplace_back(result.size());
+  }
+
+  auto taskParallel = std::make_shared<durynichev_d_radix_batcher_mpi::RadixBatcher>(taskDataPar);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    std::sort(array.begin(), array.end());
+    EXPECT_EQ(array, result);
+  }
+}

--- a/tasks/mpi/durynichev_d_radix_batcher/src/ops_mpi.cpp
+++ b/tasks/mpi/durynichev_d_radix_batcher/src/ops_mpi.cpp
@@ -1,0 +1,114 @@
+#include "mpi/durynichev_d_radix_batcher/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/vector.hpp>
+#include <vector>
+
+namespace durynichev_d_radix_batcher_mpi {
+
+void exchange_data(boost::mpi::communicator& comm, int shift, std::vector<double>& data, bool is_sending) {
+  int partner_rank = is_sending ? comm.rank() + shift : comm.rank() - shift;
+  if (is_sending) {
+    comm.send(partner_rank, 0, data);
+    comm.recv(partner_rank, 1, data);
+  } else {
+    std::vector<double> recv_data(data.size());
+    comm.recv(partner_rank, 0, recv_data);
+    for (size_t iter = 0; iter < data.size(); iter++) {
+      if (recv_data[iter] > data[iter]) {
+        auto temp = recv_data[iter];
+        recv_data[iter] = data[iter];
+        data[iter] = temp;
+      }
+    }
+    comm.send(partner_rank, 1, recv_data);
+  }
+}
+
+std::unordered_set<int> populate_send_workers(int comm_size, int shift) {
+  std::unordered_set<int> send_workers;
+  for (int worker = 0; worker < comm_size; worker++) {
+    if (worker + shift < comm_size && send_workers.find(worker - shift) == send_workers.end()) {
+      send_workers.insert(worker);
+    }
+  }
+  return send_workers;
+}
+
+void batcher(boost::mpi::communicator& comm, std::vector<double>& data) {
+  for (int shift = comm.size() / 2; shift > 0; shift /= 2) {
+    std::unordered_set<int> send_workers = populate_send_workers(comm.size(), shift);
+    bool should_send = (send_workers.find(comm.rank()) != send_workers.end());
+    exchange_data(comm, shift, data, should_send);
+  }
+}
+
+bool RadixBatcher::validation() {
+  internal_order_test();
+
+  if (world.rank() != 0) {
+    return true;
+  }
+
+  int val_in_size = taskData->inputs_count[1];
+  int val_out_size = taskData->outputs_count[0];
+
+  return val_in_size == val_out_size && val_in_size > 0;
+}
+
+bool RadixBatcher::pre_processing() {
+  internal_order_test();
+
+  arr_size = *reinterpret_cast<int*>(taskData->inputs[0]);
+  if (world.rank() == 0) {
+    auto* data_ptr_ = reinterpret_cast<double*>(taskData->inputs[1]);
+    int data_size = taskData->inputs_count[1];
+    input_data.assign(data_ptr_, data_ptr_ + data_size);
+
+    int output_data_size = taskData->outputs_count[0];
+    output_data.resize(output_data_size);
+
+    radixSortDouble(input_data.begin(), input_data.begin() + input_data.size() / 2);
+    radixSortDouble(input_data.begin() + input_data.size() / 2, input_data.end(), std::greater<>());
+  }
+
+  return true;
+}
+
+bool RadixBatcher::run() {
+  internal_order_test();
+
+  for (workers_count = 1; workers_count * 2 <= world.size(); workers_count *= 2);
+
+  int isWorker = static_cast<int>(world.rank() < arr_size && world.rank() < workers_count);
+  boost::mpi::communicator workers = world.split(isWorker);
+
+  if (isWorker == 0) {
+    return true;
+  }
+
+  int recv_size = arr_size / workers.size();
+  std::vector<double> local_data(recv_size);
+  boost::mpi::scatter(workers, input_data.data(), local_data.data(), recv_size, 0);
+
+  batcher(workers, local_data);
+  radixSortDouble(local_data.begin(), local_data.end());
+
+  boost::mpi::gather(workers, local_data.data(), recv_size, output_data.data(), 0);
+
+  return true;
+}
+
+bool RadixBatcher::post_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    auto* output_data_ptr_ = reinterpret_cast<double*>(taskData->outputs[0]);
+    std::copy(output_data.begin(), output_data.end(), output_data_ptr_);
+  }
+
+  return true;
+}
+
+}  // namespace durynichev_d_radix_batcher_mpi

--- a/tasks/seq/durynichev_d_radix_batcher/func_tests/main.cpp
+++ b/tasks/seq/durynichev_d_radix_batcher/func_tests/main.cpp
@@ -45,6 +45,21 @@ void testTemplate(const std::vector<double>& vec) {
 
 }  // namespace durynichev_d_radix_batcher_seq
 
+TEST(durynichev_d_radix_batcher_seq, sort_test_empty) {
+  std::vector<double> empty_vector;
+
+  EXPECT_NO_THROW(durynichev_d_radix_batcher_seq::radixSortDouble(empty_vector.begin(), empty_vector.end()));
+  EXPECT_TRUE(empty_vector.empty());
+}
+
+TEST(durynichev_d_radix_batcher_seq, sort_test_right_work) {
+  std::vector<double> data = {3.1, 2.4, 5.6, 1.2, 8.9, 7.3, 4.5, 6.7};
+  std::vector<double> expected = {1.2, 2.4, 3.1, 4.5, 5.6, 6.7, 7.3, 8.9};
+
+  durynichev_d_radix_batcher_seq::radixSortDouble(data.begin(), data.end());
+  EXPECT_EQ(data, expected);
+}
+
 TEST(durynichev_d_radix_batcher_seq, positive_numbers_size_8) {
   durynichev_d_radix_batcher_seq::testTemplate({2.0, 4.2, 1.3, 5.7, 0.1, 8.9, 7.4, 6.1});
 }

--- a/tasks/seq/durynichev_d_radix_batcher/func_tests/main.cpp
+++ b/tasks/seq/durynichev_d_radix_batcher/func_tests/main.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+#include "seq/durynichev_d_radix_batcher/include/ops_seq.hpp"
+
+namespace durynichev_d_radix_batcher_seq {
+
+std::vector<double> generateRandomData(int array_size) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_real_distribution<double> dist(-1000, 1000);
+
+  std::vector<double> arr(array_size);
+  for (size_t i = 0; i < arr.size(); i++) {
+    arr[i] = dist(gen);
+  }
+  return arr;
+}
+
+void testTemplate(const std::vector<double>& vec) {
+  std::vector<double> arr = vec;
+  std::vector<double> result_data(arr.size());
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result_data.data()));
+
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+
+  auto taskSequential = std::make_shared<RadixBatcher>(taskDataSeq);
+
+  if (taskSequential->validation()) {
+    taskSequential->pre_processing();
+    taskSequential->run();
+    taskSequential->post_processing();
+
+    std::sort(arr.begin(), arr.end());
+    EXPECT_EQ(arr, result_data);
+  }
+}
+
+}  // namespace durynichev_d_radix_batcher_seq
+
+TEST(durynichev_d_radix_batcher_seq, positive_numbers_size_8) {
+  durynichev_d_radix_batcher_seq::testTemplate({2.0, 4.2, 1.3, 5.7, 0.1, 8.9, 7.4, 6.1});
+}
+
+TEST(durynichev_d_radix_batcher_seq, negative_numbers_size_8) {
+  durynichev_d_radix_batcher_seq::testTemplate({-2.0, -4.2, -1.3, -5.7, -0.1, -8.9, -7.4, -6.1});
+}
+
+TEST(durynichev_d_radix_batcher_seq, mixed_numbers_size_8) {
+  durynichev_d_radix_batcher_seq::testTemplate({-2.0, 4.2, -1.3, 5.7, 0.1, -8.9, 7.4, -6.1});
+}
+
+TEST(durynichev_d_radix_batcher_seq, fractional_numbers_size_4) {
+  durynichev_d_radix_batcher_seq::testTemplate({0.2, 0.002, 0.0002, 0.02});
+}
+
+TEST(durynichev_d_radix_batcher_seq, large_numbers_size_8) {
+  durynichev_d_radix_batcher_seq::testTemplate({2e11, 4e16, 1e13, 5e19, 2e10, 8e21, 7e12, 6e15});
+}
+
+TEST(durynichev_d_radix_batcher_seq, small_numbers_size_8) {
+  durynichev_d_radix_batcher_seq::testTemplate({2e-11, 4e-16, 1e-13, 5e-19, 2e-10, 8e-21, 7e-12, 6e-15});
+}
+
+TEST(durynichev_d_radix_batcher_seq, numbers_with_infinity_size_4) {
+  durynichev_d_radix_batcher_seq::testTemplate(
+      {2.0, -2.0, std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()});
+}
+
+TEST(durynichev_d_radix_batcher_seq, identical_numbers_size_4) {
+  durynichev_d_radix_batcher_seq::testTemplate({3.3, 3.3, 3.3, 3.3});
+}
+
+TEST(durynichev_d_radix_batcher_seq, empty_vector) { durynichev_d_radix_batcher_seq::testTemplate({}); }
+
+TEST(durynichev_d_radix_batcher_seq, single_element) { durynichev_d_radix_batcher_seq::testTemplate({24.0}); }
+
+TEST(durynichev_d_radix_batcher_seq, numbers_close_to_zero_size_4) {
+  durynichev_d_radix_batcher_seq::testTemplate({-0.000002, 0.0, 0.000002, 0.000003});
+}
+
+TEST(durynichev_d_radix_batcher_seq, very_large_and_very_small_numbers_size_4) {
+  durynichev_d_radix_batcher_seq::testTemplate({2e19, 2e-19, -2e19, -2e-19});
+}
+
+TEST(durynichev_d_radix_batcher_seq, random_vector_size_1) {
+  auto vec = durynichev_d_radix_batcher_seq::generateRandomData(1);
+  durynichev_d_radix_batcher_seq::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_seq, random_vector_size_2) {
+  auto vec = durynichev_d_radix_batcher_seq::generateRandomData(2);
+  durynichev_d_radix_batcher_seq::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_seq, random_vector_size_8) {
+  auto vec = durynichev_d_radix_batcher_seq::generateRandomData(8);
+  durynichev_d_radix_batcher_seq::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_seq, random_vector_size_64) {
+  auto vec = durynichev_d_radix_batcher_seq::generateRandomData(64);
+  durynichev_d_radix_batcher_seq::testTemplate(vec);
+}
+
+TEST(durynichev_d_radix_batcher_seq, random_vector_size_512) {
+  auto vec = durynichev_d_radix_batcher_seq::generateRandomData(512);
+  durynichev_d_radix_batcher_seq::testTemplate(vec);
+}

--- a/tasks/seq/durynichev_d_radix_batcher/include/ops_seq.hpp
+++ b/tasks/seq/durynichev_d_radix_batcher/include/ops_seq.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace durynichev_d_radix_batcher_seq {
+
+template <typename RandomIt, typename Compare = std::less<typename std::iterator_traits<RandomIt>::value_type>>
+void radixSortDouble(RandomIt begin, RandomIt end, Compare comp = Compare{}) {
+  using ValueType = typename std::iterator_traits<RandomIt>::value_type;
+  static_assert(std::is_floating_point_v<ValueType>, "radixSortDouble requires floating-point values.");
+
+  if (begin == end) {
+    return;
+  }
+
+  constexpr size_t elemSize = sizeof(ValueType);
+  constexpr size_t bitCount = elemSize * 8;
+  constexpr size_t bucketCount = 256;
+
+  auto toUint64Key = [](ValueType val) {
+    static_assert(sizeof(ValueType) == sizeof(uint64_t), "Expected 64-bit floating-point type.");
+    uint64_t u;
+    memcpy(&u, &val, sizeof(uint64_t));
+
+    if (u & (1ULL << (bitCount - 1))) {
+      u = ~u;
+    } else {
+      u |= (1ULL << (bitCount - 1));
+    }
+    return u;
+  };
+
+  auto getByte = [](uint64_t key, size_t byteIndex) -> uint8_t {
+    return static_cast<uint8_t>((key >> (byteIndex * 8)) & 0xFF);
+  };
+
+  auto length = static_cast<size_t>(std::distance(begin, end));
+  std::vector<ValueType> temp(length);
+  std::vector<size_t> count(bucketCount, 0);
+
+  for (size_t bytePos = 0; bytePos < elemSize; ++bytePos) {
+    std::fill(count.begin(), count.end(), 0);
+
+    for (auto it = begin; it != end; ++it) {
+      uint64_t key = toUint64Key(*it);
+      ++count[getByte(key, bytePos)];
+    }
+
+    if (comp(ValueType(1), ValueType(0))) {
+      for (size_t i = bucketCount - 1; i > 0; --i) {
+        count[i - 1] += count[i];
+      }
+    } else {
+      for (size_t i = 1; i < bucketCount; ++i) {
+        count[i] += count[i - 1];
+      }
+    }
+
+    for (auto it = end; it != begin;) {
+      --it;
+      uint64_t key = toUint64Key(*it);
+      size_t pos = --count[getByte(key, bytePos)];
+      temp[pos] = *it;
+    }
+
+    std::copy(temp.begin(), temp.end(), begin);
+  }
+}
+
+class RadixBatcher : public ppc::core::Task {
+ public:
+  explicit RadixBatcher(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> arr;
+};
+
+}  // namespace durynichev_d_radix_batcher_seq

--- a/tasks/seq/durynichev_d_radix_batcher/perf_tests/main.cpp
+++ b/tasks/seq/durynichev_d_radix_batcher/perf_tests/main.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/durynichev_d_radix_batcher/include/ops_seq.hpp"
+
+TEST(durynichev_d_radix_batcher_seq, pipeline_run) {
+  int vector_size = std::pow(2, 18);
+  std::vector<double> data;
+  std::vector<double> result_data;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  data.resize(vector_size);
+  result_data.resize(vector_size);
+
+  double current = vector_size;
+  std::generate(data.begin(), data.end(), [&current]() { return current--; });
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(data.data()));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result_data.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vector_size);
+
+  auto taskSequential = std::make_shared<durynichev_d_radix_batcher_seq::RadixBatcher>(taskDataSeq);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  auto start_time = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&start_time] {
+    auto now = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = now - start_time;
+    return elapsed.count();
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  std::sort(data.begin(), data.end());
+  EXPECT_EQ(data, result_data);
+}
+
+TEST(durynichev_d_radix_batcher_seq, task_run) {
+  int vector_size = std::pow(2, 18);
+  std::vector<double> data;
+  std::vector<double> result_data;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  data.resize(vector_size);
+  result_data.resize(vector_size);
+
+  double current = vector_size;
+  std::generate(data.begin(), data.end(), [&current]() { return current--; });
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(data.data()));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result_data.data()));
+
+  taskDataSeq->inputs_count.emplace_back(vector_size);
+
+  auto taskSequential = std::make_shared<durynichev_d_radix_batcher_seq::RadixBatcher>(taskDataSeq);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  auto start_time = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&start_time] {
+    auto now = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = now - start_time;
+    return elapsed.count();
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(taskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  std::sort(data.begin(), data.end());
+  EXPECT_EQ(data, result_data);
+}

--- a/tasks/seq/durynichev_d_radix_batcher/src/ops_seq.cpp
+++ b/tasks/seq/durynichev_d_radix_batcher/src/ops_seq.cpp
@@ -1,0 +1,41 @@
+#include "seq/durynichev_d_radix_batcher/include/ops_seq.hpp"
+
+#include <algorithm>
+
+namespace durynichev_d_radix_batcher_seq {
+
+bool RadixBatcher::validation() {
+  internal_order_test();
+
+  return taskData->inputs_count[0] > 1;
+}
+
+bool RadixBatcher::pre_processing() {
+  internal_order_test();
+
+  auto* vec_data = reinterpret_cast<double*>(taskData->inputs[0]);
+  int vec_size = taskData->inputs_count[0];
+
+  arr.assign(vec_data, vec_data + vec_size);
+
+  return true;
+}
+
+bool RadixBatcher::run() {
+  internal_order_test();
+
+  radixSortDouble(arr.begin(), arr.end());
+
+  return true;
+}
+
+bool RadixBatcher::post_processing() {
+  internal_order_test();
+
+  auto* out_vector_ = reinterpret_cast<double*>(taskData->outputs[0]);
+  std::copy(arr.begin(), arr.end(), out_vector_);
+
+  return true;
+}
+
+}  // namespace durynichev_d_radix_batcher_seq


### PR DESCRIPTION
Алгоритм поразрядной сортировки для вещественных чисел типа double с использованием четно-нечетного слияния Бэтчера работает следующим образом: данные равномерно распределяются между процессами с помощью boost::mpi::scatter, затем происходит обмен элементами и их локальная сортировка согласно алгоритму Бэтчера. После этого отсортированные части объединяются в итоговый отсортированный массив с помощью boost::mpi::gather.