### PR TITLE
Суворов Дмитрий. Задача 3. Вариант 16. Сортировка Шелла с простым слиянием.

### DIFF
--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -1,0 +1,54 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+
+#include "mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp"
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_unique_elements) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+  
+  if (world.rank() == 0) {
+    data_to_sort = {5, 2, 7, 4, 1, 3, 9};
+    count_of_elems = data_to_sort.size();
+    sorted_result_mpi.assign(count_of_elems, 0);
+  
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
+  }
+
+  suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
+  ASSERT_EQ(ShellSortMpi.validation(), true);
+  ShellSortMpi.pre_processing();
+  ShellSortMpi.run();
+  ShellSortMpi.post_processing();
+
+  if (world.rank() == 0) {
+    std::vector<int32_t> sorted_result_seq(count_of_elems, 0);
+
+    std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
+    taskDataSeq->inputs_count.emplace_back(data_to_sort.size());
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(sorted_result_seq.data()));
+    taskDataSeq->outputs_count.emplace_back(sorted_result_seq.size());
+
+    suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
+    ASSERT_EQ(ShellSortSeq.validation(), true);
+    ShellSortSeq.pre_processing();
+    ShellSortSeq.run();
+    ShellSortSeq.post_processing();
+
+    bool test_result = sorted_result_seq == sorted_result_mpi &&
+      std::is_sorted(sorted_result.begin(), sorted_result.end()) &&
+      std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end())
+    EXPECT_TRUE(test_result);
+  }
+}

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -90,5 +90,7 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_an_empty_vector) {
   }
 
   suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
-  if (world.rank() == 0) EXPECT_FALSE(ShellSortMpi.validation());
+  if (world.rank() == 0) {
+    EXPECT_FALSE(ShellSortMpi.validation());
+  }
 }

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -7,18 +7,19 @@
 
 #include "mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp"
 
-TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_unique_elements) {
+namespace suvorov_d_shell_with_ord_merge_mpi {
+void check_correctness_cases(const std::vector<int> &correct_test_data) {
   boost::mpi::communicator world;
   std::vector<int> data_to_sort;
   size_t count_of_elems;
   std::vector<int> sorted_result_mpi;
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
-  
+
   if (world.rank() == 0) {
-    data_to_sort = {5, 2, 7, 4, 1, 3, 9};
+    data_to_sort = correct_test_data;
     count_of_elems = data_to_sort.size();
     sorted_result_mpi.assign(count_of_elems, 0);
-  
+
     taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
     taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
     taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
@@ -35,9 +36,9 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_unique_elements) 
     std::vector<int32_t> sorted_result_seq(count_of_elems, 0);
 
     std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
-    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
     taskDataSeq->inputs_count.emplace_back(data_to_sort.size());
-    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(sorted_result_seq.data()));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_seq.data()));
     taskDataSeq->outputs_count.emplace_back(sorted_result_seq.size());
 
     suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
@@ -47,8 +48,46 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_unique_elements) 
     ShellSortSeq.post_processing();
 
     bool test_result = sorted_result_seq == sorted_result_mpi &&
-      std::is_sorted(sorted_result.begin(), sorted_result.end()) &&
-      std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end())
-    EXPECT_TRUE(test_result);
+                       std::is_sorted(sorted_result.begin(), sorted_result.end()) &&
+                       std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end()) EXPECT_TRUE(test_result);
   }
+}
+}  // namespace suvorov_d_shell_with_ord_merge_mpi
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_unique_elements) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({5, 2, 7, 4, 1, 3, 9});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_repeating_elements) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({5, 2, 4, 8, 5, 1, 2, 2, 5, 9, 8});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_a_single_element) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({31});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_negative_elements) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({5, -2, 4, 7, -12, 10, 3, -5});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_an_empty_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    data_to_sort = {};
+    count_of_elems = data_to_sort.size();
+    sorted_result_mpi.assign(count_of_elems, 0);
+
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
+  }
+
+  suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
+  EXPECT_FALSE(ShellSortMpi.validation());
 }

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -71,6 +71,18 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_negative_elements
   suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({5, -2, 4, 7, -12, 10, 3, -5});
 }
 
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_an_already_sorted_vector) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({2, 4, 7, 9, 12, 31, 42, 63, 85});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_sorted_in_reverse_order) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({93, 78, 61, 45, 33, 20, 13, 9, 5, 2});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_a_vector_with_identical_elements) {
+  suvorov_d_shell_with_ord_merge_mpi::check_correctness_cases({25, 25, 25, 25, 25, 25, 25, 25, 25});
+}
+
 TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_an_empty_vector) {
   boost::mpi::communicator world;
   std::vector<int> data_to_sort;
@@ -87,6 +99,79 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_an_empty_vector) {
     taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
     taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
     taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
+  }
+
+  suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
+  if (world.rank() == 0) {
+    EXPECT_FALSE(ShellSortMpi.validation());
+  }
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Checking_an_attempt_to_transfer_a_zero_input_size_inside_the_task) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    data_to_sort = {5, -2, 4, 7, -12, 10, 3, -5};
+    count_of_elems = data_to_sort.size();
+    sorted_result_mpi.assign(count_of_elems, 0);
+
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(0);
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
+  }
+
+  suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
+  if (world.rank() == 0) {
+    EXPECT_FALSE(ShellSortMpi.validation());
+  }
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi, Checking_an_attempt_to_transfer_a_zero_output_size_inside_the_task) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    data_to_sort = {5, -2, 4, 7, -12, 10, 3, -5};
+    count_of_elems = data_to_sort.size();
+    sorted_result_mpi.assign(count_of_elems, 0);
+
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(0);
+  }
+
+  suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
+  if (world.rank() == 0) {
+    EXPECT_FALSE(ShellSortMpi.validation());
+  }
+}
+
+TEST(suvorov_d_shell_with_ord_merge_mpi,
+     Checking_an_attempt_to_transfer_unequal_input_and_output_sizes_inside_the_task) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    data_to_sort = {5, -2, 4, 7, -12, 10, 3, -5};
+    count_of_elems = data_to_sort.size();
+    sorted_result_mpi.assign(count_of_elems, 0);
+
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(data_to_sort.size() + 1);
   }
 
   suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -11,7 +11,7 @@ namespace suvorov_d_shell_with_ord_merge_mpi {
 void check_correctness_cases(const std::vector<int> &correct_test_data) {
   boost::mpi::communicator world;
   std::vector<int> data_to_sort;
-  size_t count_of_elems;
+  size_t count_of_elems = 0;
   std::vector<int> sorted_result_mpi;
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
 
@@ -36,10 +36,10 @@ void check_correctness_cases(const std::vector<int> &correct_test_data) {
     std::vector<int32_t> sorted_result_seq(count_of_elems, 0);
 
     std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
-    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
-    taskDataSeq->inputs_count.emplace_back(data_to_sort.size());
-    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_seq.data()));
-    taskDataSeq->outputs_count.emplace_back(sorted_result_seq.size());
+    taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+    taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result_seq.data()));
+    taskDataForSortingSeq->outputs_count.emplace_back(sorted_result_seq.size());
 
     suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
     ASSERT_EQ(ShellSortSeq.validation(), true);
@@ -48,8 +48,9 @@ void check_correctness_cases(const std::vector<int> &correct_test_data) {
     ShellSortSeq.post_processing();
 
     bool test_result = sorted_result_seq == sorted_result_mpi &&
-                       std::is_sorted(sorted_result.begin(), sorted_result.end()) &&
-                       std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end()) EXPECT_TRUE(test_result);
+                       std::is_sorted(sorted_result_seq.begin(), sorted_result_seq.end()) &&
+                       std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end());
+    EXPECT_TRUE(test_result);
   }
 }
 }  // namespace suvorov_d_shell_with_ord_merge_mpi

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -90,5 +90,5 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, Sorting_an_empty_vector) {
   }
 
   suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel ShellSortMpi(taskDataForSortingMpi);
-  EXPECT_FALSE(ShellSortMpi.validation());
+  if (world.rank() == 0) EXPECT_FALSE(ShellSortMpi.validation());
 }

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -33,7 +33,7 @@ void check_correctness_cases(const std::vector<int> &correct_test_data) {
   ShellSortMpi.post_processing();
 
   if (world.rank() == 0) {
-    std::vector<int32_t> sorted_result_seq(count_of_elems, 0);
+    std::vector<int> sorted_result_seq(count_of_elems, 0);
 
     std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
     taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
@@ -5,10 +5,6 @@
 
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <memory>
-#include <numeric>
-#include <string>
-#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
@@ -1,0 +1,47 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace suvorov_d_shell_with_ord_merge_mpi {
+
+std::vector<int> shell_sort(const std::vector<int>&);
+
+class TaskShellSortSeq : public ppc::core::Task {
+ public:
+  explicit TaskShellSortSeq(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> data_to_sort;
+  std::vector<int> sorted_data;
+};
+
+class TaskShellSortParallel : public ppc::core::Task {
+ public:
+  explicit TaskShellSortParallel(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
+      : Task(std::move(taskData_)), ops(std::move(ops_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> data_to_sort, sorted_data, partial_data;
+  boost::mpi::communicator world;
+};
+
+}  // namespace suvorov_d_shell_with_ord_merge_seq

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
@@ -44,4 +44,4 @@ class TaskShellSortParallel : public ppc::core::Task {
   boost::mpi::communicator world;
 };
 
-}  // namespace suvorov_d_shell_with_ord_merge_seq
+}  // namespace suvorov_d_shell_with_ord_merge_mpi

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp
@@ -16,6 +16,7 @@
 namespace suvorov_d_shell_with_ord_merge_mpi {
 
 std::vector<int> shell_sort(const std::vector<int>&);
+void merge_vectors(const std::vector<int>& left, const std::vector<int>& right, std::vector<int>& result);
 
 class TaskShellSortSeq : public ppc::core::Task {
  public:
@@ -32,8 +33,7 @@ class TaskShellSortSeq : public ppc::core::Task {
 
 class TaskShellSortParallel : public ppc::core::Task {
  public:
-  explicit TaskShellSortParallel(std::shared_ptr<ppc::core::TaskData> taskData_, std::string ops_)
-      : Task(std::move(taskData_)), ops(std::move(ops_)) {}
+  explicit TaskShellSortParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
   bool pre_processing() override;
   bool validation() override;
   bool run() override;

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -21,7 +21,7 @@ std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -100
 }
 }  // namespace suvorov_d_shell_with_ord_merge_mpi
 
-TEST(mpi_example_perf_test, test_pipeline_run) {
+TEST(suvorov_d_shell_with_ord_merge_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
   std::vector<int> data_to_sort;
   size_t count_of_elems;
@@ -30,8 +30,8 @@ TEST(mpi_example_perf_test, test_pipeline_run) {
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
-    count_of_elems = 100000;
-    data_to_sort = get_rand_vector(count_of_elems);
+    count_of_elems = 1000000;
+    data_to_sort = suvorov_d_shell_with_ord_merge_mpi::get_rand_vector(count_of_elems);
     sorted_result_mpi.assign(count_of_elems, 0);
     taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
     taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
@@ -57,21 +57,20 @@ TEST(mpi_example_perf_test, test_pipeline_run) {
   perfAnalyzer->pipeline_run(perfAttr, perfResults);
   if (world.rank() == 0) {
     ppc::core::Perf::print_perf_statistic(perfResults);
-    EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+    EXPECT_TRUE(std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end()));
   }
 }
 
-TEST(mpi_example_perf_test, test_task_run) {
+TEST(suvorov_d_shell_with_ord_merge_mpi, test_task_run) {
   boost::mpi::communicator world;
   std::vector<int> data_to_sort;
   size_t count_of_elems;
   std::vector<int> sorted_result_mpi;
 
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
-  int count_of_elems;
   if (world.rank() == 0) {
-    count_of_elems = 100000;
-    data_to_sort = get_rand_vector(count_of_elems);
+    count_of_elems = 1000000;
+    data_to_sort = suvorov_d_shell_with_ord_merge_mpi::get_rand_vector(count_of_elems);
     sorted_result_mpi.assign(count_of_elems, 0);
     taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
     taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
@@ -80,7 +79,7 @@ TEST(mpi_example_perf_test, test_task_run) {
   }
 
   auto ShellSortMpi =
-      std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi, "+");
+      std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi);
   ASSERT_EQ(ShellSortMpi->validation(), true);
   ShellSortMpi->pre_processing();
   ShellSortMpi->run();
@@ -97,6 +96,6 @@ TEST(mpi_example_perf_test, test_task_run) {
   perfAnalyzer->task_run(perfAttr, perfResults);
   if (world.rank() == 0) {
     ppc::core::Perf::print_perf_statistic(perfResults);
-    EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+    EXPECT_TRUE(std::is_sorted(sorted_result_mpi.begin(), sorted_result_mpi.end()));
   }
 }

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -1,0 +1,100 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <vector>
+#include <algorithm>
+#include <random>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp"
+
+namespace suvorov_d_shell_with_ord_merge_mpi {
+std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -10000, const int max_int = 10000) {
+  std::random_device r_dev;
+  std::mt19937 gen(r_dev());
+  std::uniform_int_distribution<> distr(min_int, max_int);
+
+  std::vector<int> new_vec(vec_size);
+  std::generate(new_vec.begin(), new_vec.end(), [&] () {return distr(gen);});
+  return new_vec;
+}
+}  
+
+TEST(mpi_example_perf_test, test_pipeline_run) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    count_of_elems = 100000;
+    data_to_sort = get_rand_vector(count_of_elems);
+    sorted_result_mpi.assign(count_of_elems, 0);
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t*>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
+  }
+
+  auto ShellSortMpi = std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi);
+  ASSERT_EQ(ShellSortMpi->validation(), true);
+  ShellSortMpi->pre_processing();
+  ShellSortMpi->run();
+  ShellSortMpi->post_processing();
+  
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(ShellSortMpi);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+  }
+}
+
+TEST(mpi_example_perf_test, test_task_run) {
+  boost::mpi::communicator world;
+  std::vector<int> data_to_sort;
+  size_t count_of_elems;
+  std::vector<int> sorted_result_mpi;
+  
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
+  int count_of_elems;
+  if (world.rank() == 0) {
+    count_of_elems = 100000;
+    data_to_sort = get_rand_vector(count_of_elems);
+    sorted_result_mpi.assign(count_of_elems, 0);
+    taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
+    taskDataForSortingMpi->inputs_count.emplace_back(data_to_sort.size());
+    taskDataForSortingMpi->outputs.emplace_back(reinterpret_cast<uint8_t*>(sorted_result_mpi.data()));
+    taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
+  }
+
+  auto ShellSortMpi = std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi, "+");
+  ASSERT_EQ(ShellSortMpi->validation(), true);
+  ShellSortMpi->pre_processing();
+  ShellSortMpi->run();
+  ShellSortMpi->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(ShellSortMpi);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+  }
+}

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -17,6 +17,7 @@ std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -100
 
   std::vector<int> new_vec(vec_size);
   std::generate(new_vec.begin(), new_vec.end(), [&]() { return distr(gen); });
+  std::sort(new_vec.begin(), new_vec.end(), std::greater<>());
   return new_vec;
 }
 }  // namespace suvorov_d_shell_with_ord_merge_mpi
@@ -30,7 +31,7 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, test_pipeline_run) {
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
-    count_of_elems = 1000000;
+    count_of_elems = 10000000;
     data_to_sort = suvorov_d_shell_with_ord_merge_mpi::get_rand_vector(count_of_elems);
     sorted_result_mpi.assign(count_of_elems, 0);
     taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));
@@ -69,7 +70,7 @@ TEST(suvorov_d_shell_with_ord_merge_mpi, test_task_run) {
 
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    count_of_elems = 1000000;
+    count_of_elems = 10000000;
     data_to_sort = suvorov_d_shell_with_ord_merge_mpi::get_rand_vector(count_of_elems);
     sorted_result_mpi.assign(count_of_elems, 0);
     taskDataForSortingMpi->inputs.emplace_back(reinterpret_cast<uint8_t*>(data_to_sort.data()));

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -1,10 +1,10 @@
 // Copyright 2023 Nesterov Alexander
 #include <gtest/gtest.h>
 
-#include <boost/mpi/timer.hpp>
-#include <vector>
 #include <algorithm>
+#include <boost/mpi/timer.hpp>
 #include <random>
+#include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp"
@@ -16,17 +16,17 @@ std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -100
   std::uniform_int_distribution<> distr(min_int, max_int);
 
   std::vector<int> new_vec(vec_size);
-  std::generate(new_vec.begin(), new_vec.end(), [&] () {return distr(gen);});
+  std::generate(new_vec.begin(), new_vec.end(), [&]() { return distr(gen); });
   return new_vec;
 }
-}  
+}  // namespace suvorov_d_shell_with_ord_merge_mpi
 
 TEST(mpi_example_perf_test, test_pipeline_run) {
   boost::mpi::communicator world;
   std::vector<int> data_to_sort;
   size_t count_of_elems;
   std::vector<int> sorted_result_mpi;
-  
+
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
@@ -39,19 +39,20 @@ TEST(mpi_example_perf_test, test_pipeline_run) {
     taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
   }
 
-  auto ShellSortMpi = std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi);
+  auto ShellSortMpi =
+      std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi);
   ASSERT_EQ(ShellSortMpi->validation(), true);
   ShellSortMpi->pre_processing();
   ShellSortMpi->run();
   ShellSortMpi->post_processing();
-  
+
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
   const boost::mpi::timer current_timer;
   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
-  
+
   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-  
+
   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(ShellSortMpi);
   perfAnalyzer->pipeline_run(perfAttr, perfResults);
   if (world.rank() == 0) {
@@ -65,7 +66,7 @@ TEST(mpi_example_perf_test, test_task_run) {
   std::vector<int> data_to_sort;
   size_t count_of_elems;
   std::vector<int> sorted_result_mpi;
-  
+
   std::shared_ptr<ppc::core::TaskData> taskDataForSortingMpi = std::make_shared<ppc::core::TaskData>();
   int count_of_elems;
   if (world.rank() == 0) {
@@ -78,7 +79,8 @@ TEST(mpi_example_perf_test, test_task_run) {
     taskDataForSortingMpi->outputs_count.emplace_back(sorted_result_mpi.size());
   }
 
-  auto ShellSortMpi = std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi, "+");
+  auto ShellSortMpi =
+      std::make_shared<suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel>(taskDataForSortingMpi, "+");
   ASSERT_EQ(ShellSortMpi->validation(), true);
   ShellSortMpi->pre_processing();
   ShellSortMpi->run();

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
@@ -32,7 +32,9 @@ std::vector<int> suvorov_d_shell_with_ord_merge_mpi::shell_sort(const std::vecto
 
 void suvorov_d_shell_with_ord_merge_mpi::merge_vectors(const std::vector<int>& left, const std::vector<int>& right,
                                                        std::vector<int>& result) {
-  size_t i = 0, j = 0, k = 0;
+  size_t i = 0;
+  size_t j = 0;
+  size_t k = 0;
 
   result.resize(left.size() + right.size());
   while (i < left.size() && j < right.size()) {
@@ -89,7 +91,7 @@ bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel::pre_processing()
   internal_order_test();
 
   if (world.rank() == 0) {
-    size_t data_size = static_cast<size_t>(taskData->inputs_count[0]);
+    auto data_size = static_cast<size_t>(taskData->inputs_count[0]);
     int* data_tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
     data_to_sort.assign(data_tmp_ptr, data_tmp_ptr + data_size);
   }

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
@@ -1,0 +1,171 @@
+// Copyright 2023 Nesterov Alexander
+#include "mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+std::vector<int> suvorov_d_shell_with_ord_merge_mpi::shell_sort(const std::vector<int>& vec_to_sort) {
+  std::vector<int> result_vec = vec_to_sort;
+  size_t n = result_vec.size();
+
+  for (size_t gap = n / 2; gap > 0; gap /= 2) {
+    for (size_t i = gap; i < n; ++i) {
+      int curr_val = result_vec[i];
+      size_t j = i;
+
+      while (j >= gap && result_vec[j - gap] > curr_val) {
+        result_vec[j] = result_vec[j - gap];
+        j -= gap;
+      }
+      result_vec[j] = curr_val;
+    }
+  }
+
+  return result_vec;
+}
+
+void merge_vec(const std::vector<int>& left, const std::vector<int>& right, std::vector<int>& result) {
+  size_t i = 0, j = 0, k = 0;
+
+  result.resize(left.size() + right.size());
+  while (i < left.size() && j < right.size()) {
+    if (left[i] <= right[j]) {
+      result[k++] = left[i++];
+    } else {
+      result[k++] = right[j++];
+    }
+  }
+
+  while (i < left.size()) {
+    result[k++] = left[i++];
+  }
+
+  while (j < right.size()) {
+    result[k++] = right[j++];
+  }
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq::pre_processing() {
+  internal_order_test();
+
+  size_t data_size = static_cast<size_t>(taskData->inputs_count[0]);
+  int* data_tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+  data_to_sort.assign(data_tmp_ptr, data_tmp_ptr + data_size);
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq::validation() {
+  internal_order_test();
+  
+  return taskData->inputs_count[0] > 0 && 
+    taskData->inputs_count.size() == 1 &&
+    taskData->inputs_count[0] == taskData->outputs_count[0] &&
+    taskData->outputs_count.size() == 1;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq::run() {
+  internal_order_test();
+
+  sorted_data = shell_sort(data_to_sort);
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq::post_processing() {
+  internal_order_test();
+  
+  std::copy(sorted_data.begin(), sorted_data.end(), reinterpret_cast<int*>(taskData->outputs[0]));
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel::pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    size_t data_size = static_cast<size_t>(taskData->inputs_count[0]);
+    int* data_tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+    data_to_sort.assign(data_tmp_ptr, data_tmp_ptr + data_size);
+  }
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    return taskData->inputs_count[0] > 0 && 
+        taskData->inputs_count.size() == 1 &&
+        taskData->inputs_count[0] == taskData->outputs_count[0] &&
+        taskData->outputs_count.size() == 1;
+  }
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel::run() {
+  internal_order_test();
+  
+  size_t data_size = 0;
+  if (world_.rank() == 0) {
+    data_size = data_to_sort.size();
+  }
+  mpi::broadcast(world_, data_size, 0);
+
+  size_t uniform_part_size = data_size / world_.size();
+  size_t overflow_size = data_size % world_.size();
+
+  std::vector<int> sizes(world_.size(), uniform_part_size);
+
+  std::transform(sizes.begin(), sizes.begin() + overflow_size, sizes.begin(),
+                [](int size) { return size + 1; });
+
+  std::vector<int> displacements(world_.size(), 0);
+  std::partial_sum(sizes.begin(), sizes.end() - 1, displacements.begin() + 1);
+
+  partial_data.resize(sizes[world.rank()]);
+
+  if (world_.rank() == 0) {
+    mpi::scatterv(world_, data_to_sort.data(), sizes, displacements, local_input.data(), local_size, 0);
+  } else {
+    mpi::scatterv(world_, local_input.data(), local_size, 0);
+  }
+
+  partial_data = shell_sort(partial_data);
+
+  std::vector<int> merge_data;
+  if (world.rank() == 0) {
+    merge_data.resize(n);
+  }
+  boost::mpi::gatherv(world, partial_data.data(), sizes[world.rank()], merge_data.data(), sizes, displacements, 0);
+
+  if (world.rank() == 0) {
+    std::vector<int> tmp_buff; 
+    sorted_data.assign(merge_data.begin(), merge_data.begin() + sizes[0]); 
+
+    for (int i = 1; i < world.size(); ++i) {
+      auto start = merge_data.begin() + displacements[i];
+      auto end = start + sizes[i];
+
+      merge_arrays(sorted_data, std::vector<int>(start, end), tmp_buff);
+
+      sorted_data = std::move(tmp_buff);
+    }
+  }
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    std::copy(sorted_data.begin(), sorted_data.end(), reinterpret_cast<int*>(taskData->outputs[0]));
+  }
+  return true;
+}

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
@@ -1,15 +1,6 @@
 // Copyright 2023 Nesterov Alexander
 #include "mpi/suvorov_d_shell_with_ord_merge/include/ops_mpi.hpp"
 
-#include <algorithm>
-#include <functional>
-#include <random>
-#include <string>
-#include <thread>
-#include <vector>
-
-using namespace std::chrono_literals;
-
 std::vector<int> suvorov_d_shell_with_ord_merge_mpi::shell_sort(const std::vector<int>& vec_to_sort) {
   std::vector<int> result_vec = vec_to_sort;
   size_t n = result_vec.size();

--- a/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
+++ b/tasks/mpi/suvorov_d_shell_with_ord_merge/src/ops_mpi.cpp
@@ -57,7 +57,7 @@ void suvorov_d_shell_with_ord_merge_mpi::merge_vectors(const std::vector<int>& l
 bool suvorov_d_shell_with_ord_merge_mpi::TaskShellSortSeq::pre_processing() {
   internal_order_test();
 
-  size_t data_size = static_cast<size_t>(taskData->inputs_count[0]);
+  auto data_size = static_cast<size_t>(taskData->inputs_count[0]);
   int* data_tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
   data_to_sort.assign(data_tmp_ptr, data_tmp_ptr + data_size);
 

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -1,0 +1,26 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <algorithm>
+
+#include "seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp"
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_unique_elements) {
+  std::vector<int> data_to_sort = {5, 2, 7, 4, 1, 3, 9};
+  size_t count_of_elems = data_to_sort.size();
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
+
+  suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
+  ASSERT_EQ(ShellSortSeq.validation(), true);
+  ShellSortSeq.pre_processing();
+  ShellSortSeq.run();
+  ShellSortSeq.post_processing();
+  EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+}

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -1,13 +1,14 @@
 // Copyright 2023 Nesterov Alexander
 #include <gtest/gtest.h>
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 #include "seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp"
 
-TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_unique_elements) {
-  std::vector<int> data_to_sort = {5, 2, 7, 4, 1, 3, 9};
+namespace suvorov_d_shell_with_ord_merge_seq {
+void check_correctness_cases(const std::vector<int> &correct_test_data) {
+  std::vector<int> data_to_sort = correct_test_data;
   size_t count_of_elems = data_to_sort.size();
   std::vector<int> sorted_result(count_of_elems, 0);
 
@@ -23,4 +24,36 @@ TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_unique_elements) 
   ShellSortSeq.run();
   ShellSortSeq.post_processing();
   EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+}
+}  // namespace suvorov_d_shell_with_ord_merge_seq
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_unique_elements) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({5, 2, 7, 4, 1, 3, 9});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_repeating_elements) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({5, 2, 4, 8, 5, 1, 2, 2, 5, 9, 8});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_a_single_element) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({31});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_negative_elements) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({5, -2, 4, 7, -12, 10, 3, -5});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_an_empty_vector) {
+  std::vector<int> data_to_sort = {};
+  size_t count_of_elems = data_to_sort.size();
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
+
+  suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
+  EXPECT_FALSE(ShellSortSeq.validation());
 }

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/func_tests/main.cpp
@@ -43,6 +43,18 @@ TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_negative_elements
   suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({5, -2, 4, 7, -12, 10, 3, -5});
 }
 
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_an_already_sorted_vector) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({2, 4, 7, 9, 12, 31, 42, 63, 85});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_sorted_in_reverse_order) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({93, 78, 61, 45, 33, 20, 13, 9, 5, 2});
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_a_vector_with_identical_elements) {
+  suvorov_d_shell_with_ord_merge_seq::check_correctness_cases({25, 25, 25, 25, 25, 25, 25, 25, 25});
+}
+
 TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_an_empty_vector) {
   std::vector<int> data_to_sort = {};
   size_t count_of_elems = data_to_sort.size();
@@ -53,6 +65,52 @@ TEST(suvorov_d_shell_with_ord_merge_seq, Sorting_an_empty_vector) {
   taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
   taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
   taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
+
+  suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
+  EXPECT_FALSE(ShellSortSeq.validation());
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Checking_an_attempt_to_transfer_a_zero_input_size_inside_the_task) {
+  std::vector<int> data_to_sort = {5, -2, 4, 7, -12, 10, 3, -5};
+  size_t count_of_elems = data_to_sort.size();
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(0);
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
+
+  suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
+  EXPECT_FALSE(ShellSortSeq.validation());
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, Checking_an_attempt_to_transfer_a_zero_output_size_inside_the_task) {
+  std::vector<int> data_to_sort = {5, -2, 4, 7, -12, 10, 3, -5};
+  size_t count_of_elems = data_to_sort.size();
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(0);
+
+  suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
+  EXPECT_FALSE(ShellSortSeq.validation());
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq,
+     Checking_an_attempt_to_transfer_unequal_input_and_output_sizes_inside_the_task) {
+  std::vector<int> data_to_sort = {5, -2, 4, 7, -12, 10, 3, -5};
+  size_t count_of_elems = data_to_sort.size();
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(data_to_sort.size() + 1);
 
   suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq ShellSortSeq(taskDataForSortingSeq);
   EXPECT_FALSE(ShellSortSeq.validation());

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
@@ -1,7 +1,6 @@
 // Copyright 2023 Nesterov Alexander
 #pragma once
 
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
@@ -23,4 +23,4 @@ class TaskShellSortSeq : public ppc::core::Task {
   std::vector<int> shell_sort(const std::vector<int>&) const;
 };
 
-}  // namespace nesterov_a_test_task_seq
+}  // namespace suvorov_d_shell_with_ord_merge_seq

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
@@ -20,7 +20,7 @@ class TaskShellSortSeq : public ppc::core::Task {
   std::vector<int> data_to_sort;
   std::vector<int> sorted_data;
 
-  std::vector<int> shell_sort(const std::vector<int>&) const;
+  static std::vector<int> shell_sort(const std::vector<int>&) const;
 };
 
 }  // namespace suvorov_d_shell_with_ord_merge_seq

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
@@ -1,0 +1,26 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace suvorov_d_shell_with_ord_merge_seq {
+
+class TaskShellSortSeq : public ppc::core::Task {
+ public:
+  explicit TaskShellSortSeq(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<int> data_to_sort;
+  std::vector<int> sorted_data;
+
+  std::vector<int> shell_sort(const std::vector<int>&) const;
+};
+
+}  // namespace nesterov_a_test_task_seq

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp
@@ -20,7 +20,7 @@ class TaskShellSortSeq : public ppc::core::Task {
   std::vector<int> data_to_sort;
   std::vector<int> sorted_data;
 
-  static std::vector<int> shell_sort(const std::vector<int>&) const;
+  static std::vector<int> shell_sort(const std::vector<int>&);
 };
 
 }  // namespace suvorov_d_shell_with_ord_merge_seq

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -16,12 +16,13 @@ std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -100
 
   std::vector<int> new_vec(vec_size);
   std::generate(new_vec.begin(), new_vec.end(), [&]() { return distr(gen); });
+  std::sort(new_vec.begin(), new_vec.end(), std::greater<>());
   return new_vec;
 }
 }  // namespace suvorov_d_shell_with_ord_merge_seq
 
 TEST(suvorov_d_shell_with_ord_merge_seq, test_pipeline_run) {
-  const size_t count_of_elems = 100000;
+  const size_t count_of_elems = 10000000;
   std::vector<int> data_to_sort = suvorov_d_shell_with_ord_merge_seq::get_rand_vector(count_of_elems);
   std::vector<int> sorted_result(count_of_elems, 0);
 
@@ -51,7 +52,7 @@ TEST(suvorov_d_shell_with_ord_merge_seq, test_pipeline_run) {
 }
 
 TEST(suvorov_d_shell_with_ord_merge_seq, test_task_run) {
-  const size_t count_of_elems = 100000;
+  const size_t count_of_elems = 10000000;
   std::vector<int> data_to_sort = suvorov_d_shell_with_ord_merge_seq::get_rand_vector(count_of_elems);
   std::vector<int> sorted_result(count_of_elems, 0);
 

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -1,9 +1,9 @@
 // Copyright 2023 Nesterov Alexander
 #include <gtest/gtest.h>
 
-#include <vector>
 #include <algorithm>
 #include <random>
+#include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp"
@@ -15,10 +15,10 @@ std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -100
   std::uniform_int_distribution<> distr(min_int, max_int);
 
   std::vector<int> new_vec(vec_size);
-  std::generate(new_vec.begin(), new_vec.end(), [&] () {return distr(gen);});
+  std::generate(new_vec.begin(), new_vec.end(), [&]() { return distr(gen); });
   return new_vec;
 }
-}  
+}  // namespace suvorov_d_shell_with_ord_merge_seq
 
 TEST(suvorov_d_shell_with_ord_merge_seq, test_pipeline_run) {
   const size_t count_of_elems = 100000;
@@ -32,7 +32,7 @@ TEST(suvorov_d_shell_with_ord_merge_seq, test_pipeline_run) {
   taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
 
   auto ShellSortSeq = std::make_shared<suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq>(taskDataForSortingSeq);
-  
+
   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
   perfAttr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/perf_tests/main.cpp
@@ -1,0 +1,81 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <algorithm>
+#include <random>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp"
+
+namespace suvorov_d_shell_with_ord_merge_seq {
+std::vector<int> get_rand_vector(const size_t vec_size, const int min_int = -10000, const int max_int = 10000) {
+  std::random_device r_dev;
+  std::mt19937 gen(r_dev());
+  std::uniform_int_distribution<> distr(min_int, max_int);
+
+  std::vector<int> new_vec(vec_size);
+  std::generate(new_vec.begin(), new_vec.end(), [&] () {return distr(gen);});
+  return new_vec;
+}
+}  
+
+TEST(suvorov_d_shell_with_ord_merge_seq, test_pipeline_run) {
+  const size_t count_of_elems = 100000;
+  std::vector<int> data_to_sort = suvorov_d_shell_with_ord_merge_seq::get_rand_vector(count_of_elems);
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
+
+  auto ShellSortSeq = std::make_shared<suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq>(taskDataForSortingSeq);
+  
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(ShellSortSeq);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+}
+
+TEST(suvorov_d_shell_with_ord_merge_seq, test_task_run) {
+  const size_t count_of_elems = 100000;
+  std::vector<int> data_to_sort = suvorov_d_shell_with_ord_merge_seq::get_rand_vector(count_of_elems);
+  std::vector<int> sorted_result(count_of_elems, 0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataForSortingSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataForSortingSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(data_to_sort.data()));
+  taskDataForSortingSeq->inputs_count.emplace_back(data_to_sort.size());
+  taskDataForSortingSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(sorted_result.data()));
+  taskDataForSortingSeq->outputs_count.emplace_back(sorted_result.size());
+
+  auto ShellSortSeq = std::make_shared<suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq>(taskDataForSortingSeq);
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(ShellSortSeq);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  EXPECT_TRUE(std::is_sorted(sorted_result.begin(), sorted_result.end()));
+}

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
@@ -5,7 +5,8 @@
 
 using namespace std::chrono_literals;
 
-std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sort(const std::vector<int>& vec_to_sort) const {
+std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sort(
+    const std::vector<int>& vec_to_sort) const {
   std::vector<int> result_vec = vec_to_sort;
   size_t n = result_vec.size();
 
@@ -38,10 +39,8 @@ bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::pre_processing() {
 bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::validation() {
   internal_order_test();
   // Check count elements of output
-  return taskData->inputs_count[0] > 0 && 
-    taskData->inputs_count.size() == 1 &&
-    taskData->inputs_count[0] == taskData->outputs_count[0] &&
-    taskData->outputs_count.size() == 1;
+  return taskData->inputs_count[0] > 0 && taskData->outputs_count[0] > 0 && taskData->inputs_count.size() == 1 &&
+         taskData->outputs_count.size() == 1 && taskData->inputs_count[0] == taskData->outputs_count[0];
 }
 
 bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::run() {
@@ -54,7 +53,7 @@ bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::run() {
 
 bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::post_processing() {
   internal_order_test();
-  
+
   std::copy(sorted_data.begin(), sorted_data.end(), reinterpret_cast<int*>(taskData->outputs[0]));
 
   return true;

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
@@ -5,8 +5,7 @@
 
 using namespace std::chrono_literals;
 
-std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sort(
-    const std::vector<int>& vec_to_sort) const {
+std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sort(const std::vector<int>& vec_to_sort) {
   std::vector<int> result_vec = vec_to_sort;
   size_t n = result_vec.size();
 
@@ -29,7 +28,7 @@ std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sor
 bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::pre_processing() {
   internal_order_test();
 
-  size_t data_size = static_cast<size_t>(taskData->inputs_count[0]);
+  auto data_size = static_cast<size_t>(taskData->inputs_count[0]);
   int* data_tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
   data_to_sort.assign(data_tmp_ptr, data_tmp_ptr + data_size);
 

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
@@ -1,10 +1,6 @@
 // Copyright 2024 Nesterov Alexander
 #include "seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp"
 
-#include <thread>
-
-using namespace std::chrono_literals;
-
 std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sort(const std::vector<int>& vec_to_sort) {
   std::vector<int> result_vec = vec_to_sort;
   size_t n = result_vec.size();

--- a/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
+++ b/tasks/seq/suvorov_d_shell_with_ord_merge/src/ops_seq.cpp
@@ -1,0 +1,61 @@
+// Copyright 2024 Nesterov Alexander
+#include "seq/suvorov_d_shell_with_ord_merge/include/ops_seq.hpp"
+
+#include <thread>
+
+using namespace std::chrono_literals;
+
+std::vector<int> suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::shell_sort(const std::vector<int>& vec_to_sort) const {
+  std::vector<int> result_vec = vec_to_sort;
+  size_t n = result_vec.size();
+
+  for (size_t gap = n / 2; gap > 0; gap /= 2) {
+    for (size_t i = gap; i < n; ++i) {
+      int curr_val = result_vec[i];
+      size_t j = i;
+
+      while (j >= gap && result_vec[j - gap] > curr_val) {
+        result_vec[j] = result_vec[j - gap];
+        j -= gap;
+      }
+      result_vec[j] = curr_val;
+    }
+  }
+
+  return result_vec;
+}
+
+bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::pre_processing() {
+  internal_order_test();
+
+  size_t data_size = static_cast<size_t>(taskData->inputs_count[0]);
+  int* data_tmp_ptr = reinterpret_cast<int*>(taskData->inputs[0]);
+  data_to_sort.assign(data_tmp_ptr, data_tmp_ptr + data_size);
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::validation() {
+  internal_order_test();
+  // Check count elements of output
+  return taskData->inputs_count[0] > 0 && 
+    taskData->inputs_count.size() == 1 &&
+    taskData->inputs_count[0] == taskData->outputs_count[0] &&
+    taskData->outputs_count.size() == 1;
+}
+
+bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::run() {
+  internal_order_test();
+
+  sorted_data = shell_sort(data_to_sort);
+
+  return true;
+}
+
+bool suvorov_d_shell_with_ord_merge_seq::TaskShellSortSeq::post_processing() {
+  internal_order_test();
+  
+  std::copy(sorted_data.begin(), sorted_data.end(), reinterpret_cast<int*>(taskData->outputs[0]));
+
+  return true;
+}


### PR DESCRIPTION
Задача "Сортировка Шелла с простым слиянием".
Описание последовательного решения задачи:
В последовательной версией в run() для входного вектора с данными выполняется функция shell_sort, которая реализует сортировку Шелла.
Для проверки корректности были реализованы тесты с следующими вариантами векторов данных:
1. Вектор уникальных элементов.
2. Вектор с повторяющимися элементами.
3. Вектор из 1 элемента.
4. Вектор с отрицательными числами.

Описание решения задачи с использованием MPI:
В параллельном решении входной вектор разбивается на части, части рассылаются вызовом scatterv каждому процессу. Каждый процесс для своей локальной части выполняет сортировку Шелла. Затем все части отправляются с помощью gatherv в 0 процесс. Но в результате все отсортированные части просто устанавливаются подряд друг за другом. Для того чтобы получить результативный отсортированный вектор, выполняется merge для частей получившегося вектора. В итоге мы получаем отсортированный вектор исходных данных.
Тесты для параллельной версии аналогичны указанным выше для последовательного решения.