### PR TITLE
Лысов Иван. Задача 3. Вариант 2. Умножение плотных матриц. Элементы типа double. Блочная схема, алгоритм Фокса.

### DIFF
--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -89,7 +89,9 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Test_Multiplication_0x0) {
   }
 
   lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-  ASSERT_FALSE(testMpiTaskParallel.validation());
+  if (world.rank() == 0) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
 }
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, RandomTestMatrix3x3) {

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -68,6 +68,30 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Test_Multiplication) {
   }
 }
 
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Test_Multiplication_0x0) {
+  boost::mpi::communicator world;
+  int matrix_size = 0;
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C_parallel;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_FALSE(testMpiTaskParallel.validation());
+}
+
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, RandomTestMatrix3x3) {
   boost::mpi::communicator world;
   int matrix_size = 20;

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -3,8 +3,9 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
-#include <vector>
 #include <random>
+#include <vector>
+
 #include "mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp"
 
 static std::vector<double> getRandomVector(int sz) {
@@ -64,7 +65,6 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Test_Multiplication) {
     for (int i = 0; i < matrix_size * matrix_size; ++i) {
       ASSERT_NEAR(C_sequential[i], C_expected[i], 1e-9);
       ASSERT_NEAR(C_parallel[i], C_expected[i], 1e-9);
-      
     }
   }
 }
@@ -217,20 +217,19 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, RandomTest) {
 }
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data) {
-    boost::mpi::communicator world;
-    int matrix_size = 20;
-    std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
-    std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-    if (world.rank() == 0) {
-        taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
-        taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
-        taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
-        taskDataPar->outputs_count.emplace_back(C_parallel.size());
-    }
-    lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-    if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
 }
-
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data2) {
   boost::mpi::communicator world;

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -1,0 +1,287 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+#include <random>
+#include "mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp"
+
+static std::vector<double> getRandomVector(int sz) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+  std::vector<double> vec(sz);
+  for (int i = 0; i < sz; ++i) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Test_Multiplication) {
+  boost::mpi::communicator world;
+  int matrix_size = 2;
+  std::vector<double> A = {1.0, 2.0, 3.0, 4.0};
+  std::vector<double> B = {5.0, 6.0, 7.0, 8.0};
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::vector<double> C_sequential(matrix_size * matrix_size, 0.0);
+  size_t block_size = 1;
+  std::vector<double> C_expected = {19.0, 22.0, 43.0, 50.0};
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C_sequential.data()));
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->outputs_count.emplace_back(matrix_size * matrix_size);
+    lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential matrixMultiplication(taskDataSeq);
+    ASSERT_EQ(matrixMultiplication.validation(), true);
+    matrixMultiplication.pre_processing();
+    matrixMultiplication.run();
+    matrixMultiplication.post_processing();
+    for (int i = 0; i < matrix_size * matrix_size; ++i) {
+      ASSERT_NEAR(C_sequential[i], C_expected[i], 1e-9);
+      ASSERT_NEAR(C_parallel[i], C_expected[i], 1e-9);
+      
+    }
+  }
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, RandomTestMatrix3x3) {
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::vector<double> C_sequential(matrix_size * matrix_size, 0.0);
+  size_t block_size = 1;
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    B = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C_sequential.data()));
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->outputs_count.emplace_back(matrix_size * matrix_size);
+    lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential matrixMultiplication(taskDataSeq);
+    ASSERT_EQ(matrixMultiplication.validation(), true);
+    matrixMultiplication.pre_processing();
+    matrixMultiplication.run();
+    matrixMultiplication.post_processing();
+    for (int i = 0; i < matrix_size * matrix_size; ++i) {
+      ASSERT_NEAR(C_sequential[i], C_parallel[i], 1e-9);
+    }
+  }
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, RandomTestMatrix13x13) {
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::vector<double> C_sequential(matrix_size * matrix_size, 0.0);
+  size_t block_size = 1;
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    B = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C_sequential.data()));
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->outputs_count.emplace_back(matrix_size * matrix_size);
+    lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential matrixMultiplication(taskDataSeq);
+    ASSERT_EQ(matrixMultiplication.validation(), true);
+    matrixMultiplication.pre_processing();
+    matrixMultiplication.run();
+    matrixMultiplication.post_processing();
+    for (int i = 0; i < matrix_size * matrix_size; ++i) {
+      ASSERT_NEAR(C_sequential[i], C_parallel[i], 1e-9);
+    }
+  }
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, RandomTest) {
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::vector<double> C_sequential(matrix_size * matrix_size, 0.0);
+  size_t block_size = 1;
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    B = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C_sequential.data()));
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(matrix_size * matrix_size);
+    taskDataSeq->inputs_count.emplace_back(1);
+    taskDataSeq->outputs_count.emplace_back(matrix_size * matrix_size);
+    lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential matrixMultiplication(taskDataSeq);
+    ASSERT_EQ(matrixMultiplication.validation(), true);
+    matrixMultiplication.pre_processing();
+    matrixMultiplication.run();
+    matrixMultiplication.post_processing();
+    for (int i = 0; i < matrix_size * matrix_size; ++i) {
+      ASSERT_NEAR(C_sequential[i], C_parallel[i], 1e-9);
+    }
+  }
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data) {
+    boost::mpi::communicator world;
+    int matrix_size = 20;
+    std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+    std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+    if (world.rank() == 0) {
+        taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+        taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+        taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+        taskDataPar->outputs_count.emplace_back(C_parallel.size());
+    }
+    lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+    if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+}
+
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data2) {
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> A;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->inputs_count.emplace_back(sizeof(A.size()));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_output_data1) {
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> A;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->inputs_count.emplace_back(sizeof(A.size()));
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_output_data2) {
+  boost::mpi::communicator world;
+  int matrix_size = 20;
+  std::vector<double> A;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->inputs_count.emplace_back(sizeof(A.size()));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+  }
+  lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+
+  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+}

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -228,7 +228,9 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data) {
     taskDataPar->outputs_count.emplace_back(C_parallel.size());
   }
   lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+  if (world.rank()) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
 }
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data2) {
@@ -247,7 +249,9 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_input_data2) {
   }
   lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
 
-  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+  if (world.rank()) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
 }
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_output_data1) {
@@ -264,7 +268,9 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_output_data1) {
   }
   lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
 
-  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+  if (world.rank()) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
 }
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_output_data2) {
@@ -282,5 +288,7 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, Incorrect_output_data2) {
   }
   lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
 
-  if (world.rank()) ASSERT_FALSE(testMpiTaskParallel.validation());
+  if (world.rank()) {
+    ASSERT_FALSE(testMpiTaskParallel.validation());
+  }
 }

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
@@ -5,10 +5,6 @@
 
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <memory>
-#include <numeric>
-#include <string>
-#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
@@ -15,14 +15,6 @@
 
 namespace lysov_i_matrix_multiplication_Fox_algorithm_mpi {
 
-std::vector<int> getRandomVector(int sz);
-static void extract_submatrix_block(const std::vector<double>& matrix, double* block, int total_columns, int block_size,
-                                    int block_row_index, int block_col_index);
-static void multiply_matrix_blocks(const std::vector<double>& A, const std::vector<double>& B, std::vector<double>& C,
-                                   int block_size);
-void perform_fox_algorithm_step(boost::mpi::communicator& my_world, int rank, int cnt_work_process, int K,
-                                std::vector<double>& local_A, std::vector<double>& local_B,
-                                std::vector<double>& local_C);
 class TestMPITaskSequential : public ppc::core::Task {
  public:
   explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
@@ -23,7 +23,7 @@ static void multiply_matrix_blocks(const std::vector<double>& A, const std::vect
 void perform_fox_algorithm_step(boost::mpi::communicator& my_world, int rank, int cnt_work_process, int K,
                                 std::vector<double>& local_A, std::vector<double>& local_B,
                                 std::vector<double>& local_C);
-  class TestMPITaskSequential : public ppc::core::Task {
+class TestMPITaskSequential : public ppc::core::Task {
  public:
   explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
   bool pre_processing() override;

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
@@ -1,0 +1,59 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace lysov_i_matrix_multiplication_Fox_algorithm_mpi {
+
+std::vector<int> getRandomVector(int sz);
+static void extract_submatrix_block(const std::vector<double>& matrix, double* block, int total_columns, int block_size,
+                                    int block_row_index, int block_col_index);
+static void multiply_matrix_blocks(const std::vector<double>& A, const std::vector<double>& B, std::vector<double>& C,
+                                   int block_size);
+void perform_fox_algorithm_step(boost::mpi::communicator& my_world, int rank, int cnt_work_process, int K,
+                                std::vector<double>& local_A, std::vector<double>& local_B,
+                                std::vector<double>& local_C);
+  class TestMPITaskSequential : public ppc::core::Task {
+ public:
+  explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C;
+  int N;
+  std::size_t block_size;
+};
+
+class TestMPITaskParallel : public ppc::core::Task {
+ public:
+  explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  int dimension{}, elements{};
+  std::vector<double> initialMatrixA;
+  std::vector<double> initialMatrixB;
+  std::vector<double> resultC;
+  boost::mpi::communicator world;
+};
+
+}  // namespace lysov_i_matrix_multiplication_Fox_algorithm_mpi

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp
@@ -27,8 +27,8 @@ class TestMPITaskSequential : public ppc::core::Task {
   std::vector<double> A;
   std::vector<double> B;
   std::vector<double> C;
-  int N;
-  std::size_t block_size;
+  int N{};
+  std::size_t block_size{};
 };
 
 class TestMPITaskParallel : public ppc::core::Task {

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
@@ -18,18 +18,14 @@ static std::vector<double> getRandomVector(int sz) {
   }
   return vec;
 }
-
+int matrix_size = 400;
+std::vector<double> A = getRandomVector(matrix_size * matrix_size);
+std::vector<double> B = getRandomVector(matrix_size * matrix_size);
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
-  int matrix_size = 400;
-  std::vector<double> A;
-  std::vector<double> B;
-  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
   if (world.rank() == 0) {
-    A = getRandomVector(matrix_size * matrix_size);
-    B = getRandomVector(matrix_size * matrix_size);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
@@ -62,15 +58,9 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, test_pipeline_run) {
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, taskrun) {
   boost::mpi::communicator world;
-  int matrix_size = 400;
-  std::vector<double> A;
-  std::vector<double> B;
-  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
   if (world.rank() == 0) {
-    A = getRandomVector(matrix_size * matrix_size);
-    B = getRandomVector(matrix_size * matrix_size);
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
     taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
@@ -2,8 +2,9 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi/timer.hpp>
-#include <vector>
 #include <random>
+#include <vector>
+
 #include "core/perf/include/perf.hpp"
 #include "mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp"
 
@@ -17,7 +18,6 @@ static std::vector<double> getRandomVector(int sz) {
   }
   return vec;
 }
-
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, test_pipeline_run) {
   boost::mpi::communicator world;

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
@@ -1,0 +1,104 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <vector>
+#include <random>
+#include "core/perf/include/perf.hpp"
+#include "mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp"
+
+static std::vector<double> getRandomVector(int sz) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+  std::vector<double> vec(sz);
+  for (int i = 0; i < sz; ++i) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  int matrix_size = 400;
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    B = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+  auto testMpiTaskParallel =
+      std::make_shared<lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel>(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_mpi, taskrun) {
+  boost::mpi::communicator world;
+  int matrix_size = 400;
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C_parallel(matrix_size * matrix_size, 0.0);
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    A = getRandomVector(matrix_size * matrix_size);
+    B = getRandomVector(matrix_size * matrix_size);
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(&matrix_size));
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(&C_parallel));
+    taskDataPar->inputs_count.emplace_back(A.size());
+    taskDataPar->inputs_count.emplace_back(B.size());
+    taskDataPar->inputs_count.emplace_back(sizeof(matrix_size));
+    taskDataPar->outputs_count.emplace_back(C_parallel.size());
+  }
+
+  auto testMpiTaskParallel =
+      std::make_shared<lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel>(taskDataPar);
+
+  ASSERT_EQ(testMpiTaskParallel->validation(), true);
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+  }
+}

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
@@ -4,12 +4,8 @@
 #include <mpi.h>
 
 #include <algorithm>
-#include <functional>
 #include <random>
-#include <string>
-#include <thread>
 #include <vector>
-using namespace std::chrono_literals;
 
 static void extract_submatrix_block(const std::vector<double>& matrix, double* block, int total_columns, int block_size,
                                     int block_row_index, int block_col_index) {
@@ -152,7 +148,6 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::valid
     if (dimension <= 0) {
       return false;
     }
-    std::cout << "3" << std::endl;
     if (taskData->inputs_count[2] != sizeof(int)) {
       return false;
     }

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
@@ -1,0 +1,272 @@
+// Copyright 2023 Nesterov Alexander
+#include "mpi/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_mpi.hpp"
+
+#include <mpi.h>
+
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+using namespace std::chrono_literals;
+
+std::vector<int> lysov_i_matrix_multiplication_Fox_algorithm_mpi::getRandomVector(int sz) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<int> vec(sz);
+  for (int i = 0; i < sz; i++) {
+    vec[i] = gen() % 100;
+  }
+  return vec;
+}
+
+static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::extract_submatrix_block(const std::vector<double>& matrix,
+                                                                                     double* block, int total_columns,
+                                                                                     int block_size,
+                                    int block_row_index, int block_col_index) {
+  for (int row = 0; row < block_size; ++row) {
+    for (int col = 0; col < block_size; ++col) {
+      block[row * block_size + col] =
+          matrix[(block_row_index * block_size + row) * total_columns + (block_col_index * block_size + col)];
+    }
+  }
+}
+
+static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::multiply_matrix_blocks(const std::vector<double>& A,
+                                                                                    const std::vector<double>& B,
+                                                                                    std::vector<double>& C,
+                                   int block_size) {
+  for (int row = 0; row < block_size; ++row) {
+    for (int col = 0; col < block_size; ++col) {
+      double sum = 0.0;
+      for (int k = 0; k < block_size; ++k) {
+        sum += A[row * block_size + k] * B[k * block_size + col];
+      }
+      C[row * block_size + col] += sum;
+    }
+  }
+}
+
+void lysov_i_matrix_multiplication_Fox_algorithm_mpi::perform_fox_algorithm_step(boost::mpi::communicator& my_world,
+                                                                                 int rank, int cnt_work_process, int K,
+                                std::vector<double>& local_A, std::vector<double>& local_B,
+                                std::vector<double>& local_C) {
+  std::vector<double> temp_A(K * K);
+  std::vector<double> temp_B(K * K);
+
+  for (int l = 0; l < cnt_work_process; ++l) {
+    boost::mpi::request send_request1;
+    boost::mpi::request recv_request1;
+    boost::mpi::request send_request2;
+    boost::mpi::request recv_request2;
+
+    int row = rank / cnt_work_process;
+    int col = rank % cnt_work_process;
+
+    if (col == (row + l) % cnt_work_process) {
+      for (int target_col = 0; target_col < cnt_work_process; ++target_col) {
+        if (target_col != col) {
+          int target_rank = row * cnt_work_process + target_col;
+          send_request1 = my_world.isend(target_rank, 0, local_A.data(), K * K);
+        }
+      }
+      temp_A = local_A;
+    } else {
+      int sender_rank = row * cnt_work_process + ((row + l) % cnt_work_process);
+      recv_request1 = my_world.irecv(sender_rank, 0, temp_A.data(), K * K);
+    }
+    send_request1.wait();
+    recv_request1.wait();
+    my_world.barrier();
+
+    multiply_matrix_blocks(temp_A, local_B, local_C, K);
+
+    int send_to = ((row - 1 + cnt_work_process) % cnt_work_process) * cnt_work_process + col;
+    int recv_from = ((row + 1) % cnt_work_process) * cnt_work_process + col;
+
+    send_request2 = my_world.isend(send_to, 0, local_B.data(), K * K);
+    recv_request2 = my_world.irecv(recv_from, 0, temp_B.data(), K * K);
+    my_world.barrier();
+    send_request2.wait();
+    recv_request2.wait();
+
+    local_B = temp_B;
+  }
+}
+
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::pre_processing() {
+  internal_order_test();
+  N = reinterpret_cast<std::size_t*>(taskData->inputs[0])[0];
+  block_size = reinterpret_cast<std::size_t*>(taskData->inputs[3])[0];
+  A.resize(N * N);
+  B.resize(N * N);
+  C.resize(N * N, 0.0);
+  std::copy(reinterpret_cast<double*>(taskData->inputs[1]), reinterpret_cast<double*>(taskData->inputs[1]) + N * N,
+            A.begin());
+  std::copy(reinterpret_cast<double*>(taskData->inputs[2]), reinterpret_cast<double*>(taskData->inputs[2]) + N * N,
+            B.begin());
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::validation() {
+  internal_order_test();
+  N = reinterpret_cast<int*>(taskData->inputs[0])[0];
+  block_size = reinterpret_cast<std::size_t*>(taskData->inputs[3])[0];
+  if (taskData->inputs_count.size() != 4 || taskData->outputs_count.size() != 1) {
+    return false;
+  }
+  if (taskData->inputs_count[1] != static_cast<uint32_t>(N * N) ||
+      taskData->inputs_count[2] != static_cast<uint32_t>(N * N)) {
+      return false;
+  }
+  return taskData->outputs_count[0] == static_cast<uint32_t>(N * N) && block_size > 0;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::run() {
+  internal_order_test();
+  for (std::size_t i = 0; i < N; ++i) {
+    for (std::size_t j = 0; j < N; ++j) {
+      double sum = 0.0;
+      for (std::size_t k = 0; k < N; ++k) {
+        double a_ij = A[i * N + k];
+        double b_kj = B[k * N + j];
+        sum += a_ij * b_kj;
+      }
+      C[i * N + j] = sum;
+    }
+  }
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::post_processing() {
+  internal_order_test();
+  std::copy(C.begin(), C.end(), reinterpret_cast<double*>(taskData->outputs[0]));
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::pre_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    auto* A = reinterpret_cast<double*>(taskData->inputs[0]);
+    auto* B = reinterpret_cast<double*>(taskData->inputs[1]);
+    initialMatrixA.assign(A, A + elements);
+    initialMatrixB.assign(B, B + elements);
+    resultC = std::vector<double>(elements);
+  }
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::validation() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    dimension = *reinterpret_cast<int*>(taskData->inputs[2]);
+    elements = dimension * dimension;
+    if (dimension <= 0) {
+      return false;
+    }
+
+    if (taskData->inputs_count[2] != sizeof(int)) {
+      return false;
+    }
+
+    if (taskData->inputs_count[0] != taskData->inputs_count[1]) {
+      return false;
+    }
+
+    if (static_cast<int>(taskData->inputs_count[1]) != elements) {
+      return false;
+    }
+
+    if (taskData->inputs[0] == nullptr || taskData->inputs[1] == nullptr || taskData->outputs[0] == nullptr) {
+      return false;
+    }
+
+    if (static_cast<int>(taskData->outputs_count[0]) != elements) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::run() {
+  internal_order_test();
+
+  int rank = world.rank();
+  int size = world.size();
+
+  boost::mpi::broadcast(world, dimension, 0);
+  boost::mpi::broadcast(world, elements, 0);
+
+   int cnt_work_process = std::floor(std::sqrt(size));
+  while (cnt_work_process > 0) {
+    if (size % cnt_work_process == 0) {
+      break;
+    }
+    --cnt_work_process;
+  }
+  if (cnt_work_process <= 0) {
+    cnt_work_process = 1;
+  }
+  int K = dimension / cnt_work_process;
+  int process_group = (rank < cnt_work_process * cnt_work_process) ? 1 : MPI_UNDEFINED;
+  MPI_Comm computation_comm;
+  MPI_Comm_split(world, process_group, rank, &computation_comm);
+
+  if (process_group == MPI_UNDEFINED) {
+    return true;
+  }
+
+  boost::mpi::communicator my_communicator(computation_comm, boost::mpi::comm_take_ownership);
+  rank = my_communicator.rank();
+  size = my_communicator.size();
+
+  std::vector<double> scatter_A(elements);
+  std::vector<double> scatter_B(elements);
+  if (rank == 0) {
+    int index = 0;
+    for (int block_row = 0; block_row < cnt_work_process; ++block_row) {
+      for (int block_col = 0; block_col < cnt_work_process; ++block_col) {
+        extract_submatrix_block(initialMatrixA, scatter_A.data() + index, dimension, K, block_row, block_col);
+        extract_submatrix_block(initialMatrixB, scatter_B.data() + index, dimension, K, block_row, block_col);
+        index += K * K;
+      }
+    }
+  }
+  std::vector<double> local_matrixA(K * K);
+  boost::mpi::scatter(my_communicator, scatter_A, local_matrixA.data(), K * K, 0);
+  std::vector<double> local_matrixB(K * K);
+  boost::mpi::scatter(my_communicator, scatter_B, local_matrixB.data(), K * K, 0);
+  std::vector<double> local_matrixC(K * K, 0.0);
+  std::vector<double> unfinished_C(elements);
+
+  perform_fox_algorithm_step(my_communicator, rank, cnt_work_process, K, local_matrixA, local_matrixB, local_matrixC);
+  boost::mpi::gather(my_communicator, local_matrixC.data(), local_matrixC.size(), unfinished_C, 0);
+
+if (rank == 0) {
+    for (int block_row = 0; block_row < cnt_work_process; ++block_row) {
+      for (int block_col = 0; block_col < cnt_work_process; ++block_col) {
+        int block_rank = block_row * cnt_work_process + block_col;
+        int block_index = block_rank * K * K;
+
+        for (int i = 0; i < K; ++i) {
+          for (int j = 0; j < K; ++j) {
+            int global_row = block_row * K + i;
+            int global_col = block_col * K + j;
+            resultC[global_row * dimension + global_col] = unfinished_C[block_index + i * K + j];
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    reinterpret_cast<std::vector<double>*>(taskData->outputs[0])[0].assign(resultC.data(), resultC.data() + elements);
+  }
+    return true;
+}

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
@@ -24,7 +24,8 @@ std::vector<int> lysov_i_matrix_multiplication_Fox_algorithm_mpi::getRandomVecto
 static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::extract_submatrix_block(const std::vector<double>& matrix,
                                                                                      double* block, int total_columns,
                                                                                      int block_size,
-                                    int block_row_index, int block_col_index) {
+                                                                                     int block_row_index,
+                                                                                     int block_col_index) {
   for (int row = 0; row < block_size; ++row) {
     for (int col = 0; col < block_size; ++col) {
       block[row * block_size + col] =
@@ -36,7 +37,7 @@ static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::extract_submatrix_b
 static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::multiply_matrix_blocks(const std::vector<double>& A,
                                                                                     const std::vector<double>& B,
                                                                                     std::vector<double>& C,
-                                   int block_size) {
+                                                                                    int block_size) {
   for (int row = 0; row < block_size; ++row) {
     for (int col = 0; col < block_size; ++col) {
       double sum = 0.0;
@@ -50,8 +51,9 @@ static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::multiply_matrix_blo
 
 void lysov_i_matrix_multiplication_Fox_algorithm_mpi::perform_fox_algorithm_step(boost::mpi::communicator& my_world,
                                                                                  int rank, int cnt_work_process, int K,
-                                std::vector<double>& local_A, std::vector<double>& local_B,
-                                std::vector<double>& local_C) {
+                                                                                 std::vector<double>& local_A,
+                                                                                 std::vector<double>& local_B,
+                                                                                 std::vector<double>& local_C) {
   std::vector<double> temp_A(K * K);
   std::vector<double> temp_B(K * K);
 
@@ -95,7 +97,6 @@ void lysov_i_matrix_multiplication_Fox_algorithm_mpi::perform_fox_algorithm_step
   }
 }
 
-
 bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::pre_processing() {
   internal_order_test();
   N = reinterpret_cast<std::size_t*>(taskData->inputs[0])[0];
@@ -119,7 +120,7 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::val
   }
   if (taskData->inputs_count[1] != static_cast<uint32_t>(N * N) ||
       taskData->inputs_count[2] != static_cast<uint32_t>(N * N)) {
-      return false;
+    return false;
   }
   return taskData->outputs_count[0] == static_cast<uint32_t>(N * N) && block_size > 0;
 }
@@ -199,7 +200,7 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::run()
   boost::mpi::broadcast(world, dimension, 0);
   boost::mpi::broadcast(world, elements, 0);
 
-   int cnt_work_process = std::floor(std::sqrt(size));
+  int cnt_work_process = std::floor(std::sqrt(size));
   while (cnt_work_process > 0) {
     if (size % cnt_work_process == 0) {
       break;
@@ -244,7 +245,7 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::run()
   perform_fox_algorithm_step(my_communicator, rank, cnt_work_process, K, local_matrixA, local_matrixB, local_matrixC);
   boost::mpi::gather(my_communicator, local_matrixC.data(), local_matrixC.size(), unfinished_C, 0);
 
-if (rank == 0) {
+  if (rank == 0) {
     for (int block_row = 0; block_row < cnt_work_process; ++block_row) {
       for (int block_col = 0; block_col < cnt_work_process; ++block_col) {
         int block_rank = block_row * cnt_work_process + block_col;
@@ -268,5 +269,5 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::post_
   if (world.rank() == 0) {
     reinterpret_cast<std::vector<double>*>(taskData->outputs[0])[0].assign(resultC.data(), resultC.data() + elements);
   }
-    return true;
+  return true;
 }

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
@@ -127,10 +127,10 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::val
 
 bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskSequential::run() {
   internal_order_test();
-  for (std::size_t i = 0; i < N; ++i) {
-    for (std::size_t j = 0; j < N; ++j) {
+  for (int i = 0; i < N; ++i) {
+    for (int j = 0; j < N; ++j) {
       double sum = 0.0;
-      for (std::size_t k = 0; k < N; ++k) {
+      for (int k = 0; k < N; ++k) {
         double a_ij = A[i * N + k];
         double b_kj = B[k * N + j];
         sum += a_ij * b_kj;

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
@@ -11,21 +11,8 @@
 #include <vector>
 using namespace std::chrono_literals;
 
-std::vector<int> lysov_i_matrix_multiplication_Fox_algorithm_mpi::getRandomVector(int sz) {
-  std::random_device dev;
-  std::mt19937 gen(dev());
-  std::vector<int> vec(sz);
-  for (int i = 0; i < sz; i++) {
-    vec[i] = gen() % 100;
-  }
-  return vec;
-}
-
-static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::extract_submatrix_block(const std::vector<double>& matrix,
-                                                                                     double* block, int total_columns,
-                                                                                     int block_size,
-                                                                                     int block_row_index,
-                                                                                     int block_col_index) {
+static void extract_submatrix_block(const std::vector<double>& matrix, double* block, int total_columns, int block_size,
+                                    int block_row_index, int block_col_index) {
   for (int row = 0; row < block_size; ++row) {
     for (int col = 0; col < block_size; ++col) {
       block[row * block_size + col] =
@@ -34,10 +21,8 @@ static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::extract_submatrix_b
   }
 }
 
-static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::multiply_matrix_blocks(const std::vector<double>& A,
-                                                                                    const std::vector<double>& B,
-                                                                                    std::vector<double>& C,
-                                                                                    int block_size) {
+static void multiply_matrix_blocks(const std::vector<double>& A, const std::vector<double>& B, std::vector<double>& C,
+                                   int block_size) {
   for (int row = 0; row < block_size; ++row) {
     for (int col = 0; col < block_size; ++col) {
       double sum = 0.0;
@@ -49,11 +34,9 @@ static void lysov_i_matrix_multiplication_Fox_algorithm_mpi::multiply_matrix_blo
   }
 }
 
-void lysov_i_matrix_multiplication_Fox_algorithm_mpi::perform_fox_algorithm_step(boost::mpi::communicator& my_world,
-                                                                                 int rank, int cnt_work_process, int K,
-                                                                                 std::vector<double>& local_A,
-                                                                                 std::vector<double>& local_B,
-                                                                                 std::vector<double>& local_C) {
+static void perform_fox_algorithm_step(boost::mpi::communicator& my_world, int rank, int cnt_work_process, int K,
+                                       std::vector<double>& local_A, std::vector<double>& local_B,
+                                       std::vector<double>& local_C) {
   std::vector<double> temp_A(K * K);
   std::vector<double> temp_B(K * K);
 

--- a/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
+++ b/tasks/mpi/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_mpi.cpp
@@ -150,7 +150,7 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::valid
     if (dimension <= 0) {
       return false;
     }
-
+    std::cout << "3" << std::endl;
     if (taskData->inputs_count[2] != sizeof(int)) {
       return false;
     }
@@ -162,11 +162,9 @@ bool lysov_i_matrix_multiplication_Fox_algorithm_mpi::TestMPITaskParallel::valid
     if (static_cast<int>(taskData->inputs_count[1]) != elements) {
       return false;
     }
-
     if (taskData->inputs[0] == nullptr || taskData->inputs[1] == nullptr || taskData->outputs[0] == nullptr) {
       return false;
     }
-
     if (static_cast<int>(taskData->outputs_count[0]) != elements) {
       return false;
     }

--- a/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -36,9 +36,7 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, Test_Matrix_Multiplication
   std::vector<double> A = {2, 3, 1, 4, 0, 5, 1, 2, 3};
   std::vector<double> B = {1, 2, 3, 0, 1, 0, 4, 0, 1};
   std::vector<double> C(N * N, 0);
-  std::vector<double> expected_C = {2 * 1 + 3 * 0 + 1 * 4, 2 * 2 + 3 * 1 + 1 * 0, 2 * 3 + 3 * 0 + 1 * 1,
-                                    4 * 1 + 0 * 0 + 5 * 4, 4 * 2 + 0 * 1 + 5 * 0, 4 * 3 + 0 * 0 + 5 * 1,
-                                    1 * 1 + 2 * 0 + 3 * 4, 1 * 2 + 2 * 1 + 3 * 0, 1 * 3 + 2 * 0 + 3 * 1};
+  std::vector<double> expected_C = {6.0, 7.0, 7.0, 24.0, 8.0, 17.0, 13.0, 4.0, 6.0};
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));

--- a/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
+++ b/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/func_tests/main.cpp
@@ -1,0 +1,119 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "seq/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_seq.hpp"
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, Test_Matrix_Multiplication_Identity) {
+  size_t N = 3;
+  size_t block_size = 1;
+  std::vector<double> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<double> B = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  std::vector<double> C(N * N, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C.data()));
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->outputs_count.emplace_back(N * N);
+  lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential matrixMultiplication(taskDataSeq);
+  ASSERT_EQ(matrixMultiplication.validation(), true);
+  matrixMultiplication.pre_processing();
+  matrixMultiplication.run();
+  matrixMultiplication.post_processing();
+  EXPECT_EQ(C, A);
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, Test_Matrix_Multiplication_Arbitrary_Values) {
+  size_t N = 3;
+  size_t block_size = 1;
+  std::vector<double> A = {2, 3, 1, 4, 0, 5, 1, 2, 3};
+  std::vector<double> B = {1, 2, 3, 0, 1, 0, 4, 0, 1};
+  std::vector<double> C(N * N, 0);
+  std::vector<double> expected_C = {2 * 1 + 3 * 0 + 1 * 4, 2 * 2 + 3 * 1 + 1 * 0, 2 * 3 + 3 * 0 + 1 * 1,
+                                    4 * 1 + 0 * 0 + 5 * 4, 4 * 2 + 0 * 1 + 5 * 0, 4 * 3 + 0 * 0 + 5 * 1,
+                                    1 * 1 + 2 * 0 + 3 * 4, 1 * 2 + 2 * 1 + 3 * 0, 1 * 3 + 2 * 0 + 3 * 1};
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C.data()));
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->outputs_count.emplace_back(N * N);
+  lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential matrixMultiplication(taskDataSeq);
+  ASSERT_EQ(matrixMultiplication.validation(), true);
+  matrixMultiplication.pre_processing();
+  matrixMultiplication.run();
+  matrixMultiplication.post_processing();
+  EXPECT_EQ(C, expected_C);
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, Test_Matrix_Multiplication_Invalid_Inputs) {
+  size_t N = 3;
+  size_t block_size = 1;
+  std::vector<double> A = {2, 3, 1, 4, 0, 5};
+  std::vector<double> B = {1, 2, 3, 0, 1, 0, 4, 0, 1};
+  std::vector<double> C(N * N, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C.data()));
+  taskDataSeq->inputs_count.emplace_back(2 * N);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->outputs_count.emplace_back(N * N);
+  lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential matrixMultiplication(taskDataSeq);
+  ASSERT_EQ(matrixMultiplication.validation(), false);
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, Test_Matrix_Multiplication_Empty_Matrix) {
+  size_t N = 3;
+  size_t block_size = 1;
+  std::vector<double> A;
+  std::vector<double> B = {1, 2, 3, 0, 1, 0, 4, 0, 1};
+  std::vector<double> C(N * N, 0);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(C.data()));
+  taskDataSeq->inputs_count.emplace_back(0);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->outputs_count.emplace_back(N * N);
+  lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential matrixMultiplication(taskDataSeq);
+  ASSERT_EQ(matrixMultiplication.validation(), false);
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, Test_Matrix_Multiplication_IncompleteInput) {
+  size_t N = 3;
+  size_t block_size = 1;
+  std::vector<double> A = {1, 2, 3, 4, 5, 6};
+  std::vector<double> B = {9, 8, 7, 6, 5, 4};
+  std::vector<double> C(N * N, 0);
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(A.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(B.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&block_size));
+  taskDataSeq->inputs_count.emplace_back(3);
+  taskDataSeq->inputs_count.emplace_back(6);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->inputs_count.emplace_back(1);
+  lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential matrixMultiplication(taskDataSeq);
+  ASSERT_EQ(matrixMultiplication.validation(), false);
+}

--- a/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_seq.hpp
+++ b/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_seq.hpp
@@ -1,0 +1,27 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace lysov_i_matrix_multiplication_Fox_algorithm_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  std::vector<double> A;
+  std::vector<double> B;
+  std::vector<double> C;
+  std::size_t N;
+  std::size_t block_size;
+};
+
+}  // namespace lysov_i_matrix_multiplication_Fox_algorithm_seq

--- a/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
+++ b/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
@@ -6,28 +6,23 @@
 
 #include "core/perf/include/perf.hpp"
 #include "seq/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_seq.hpp"
-static void generateMatrix(size_t num_rows, size_t num_cols, std::vector<double> &matrix) {
-  double min_val = -100.0;
-  double max_val = 100.0;
+static std::vector<double> getRandomVector(int sz) {
   std::random_device dev;
   std::mt19937 gen(dev());
-  std::uniform_real_distribution<float> dist(min_val, max_val);
-  matrix.resize(num_rows * num_cols);
-  for (size_t i = 0; i < num_rows; ++i) {
-    for (size_t j = 0; j < num_cols; ++j) {
-      matrix[i * num_cols + j] = dist(gen);
-    }
+  std::uniform_real_distribution<double> dist(-10.0, 10.0);
+  std::vector<double> vec(sz);
+  for (int i = 0; i < sz; ++i) {
+    vec[i] = dist(gen);
   }
+  return vec;
 }
 
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, test_pipeline_run) {
   int N = 400;
   int block_size = 1;
-  std::vector<double> matrixA(N * N, 0.0);
-  std::vector<double> matrixB(N * N, 0.0);
+  std::vector<double> matrixA = getRandomVector(N * N);
+  std::vector<double> matrixB = getRandomVector(N * N);
   std::vector<double> matrixC(N * N, 0.0);
-  generateMatrix(N, N, matrixA);
-  generateMatrix(N, N, matrixB);
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&N));
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(matrixA.data()));
@@ -58,11 +53,9 @@ TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, test_pipeline_run) {
 TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, test_task_run) {
   int N = 400;
   int block_size = 1;
-  std::vector<double> matrixA(N * N, 0.0);
-  std::vector<double> matrixB(N * N, 0.0);
+  std::vector<double> matrixA = getRandomVector(N * N);
+  std::vector<double> matrixB = getRandomVector(N * N);
   std::vector<double> matrixC(N * N, 0.0);
-  generateMatrix(N, N, matrixA);
-  generateMatrix(N, N, matrixB);
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&N));
   taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(matrixA.data()));

--- a/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
+++ b/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/perf_tests/main.cpp
@@ -1,0 +1,91 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_seq.hpp"
+static void generateMatrix(size_t num_rows, size_t num_cols, std::vector<double> &matrix) {
+  double min_val = -100.0;
+  double max_val = 100.0;
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_real_distribution<float> dist(min_val, max_val);
+  matrix.resize(num_rows * num_cols);
+  for (size_t i = 0; i < num_rows; ++i) {
+    for (size_t j = 0; j < num_cols; ++j) {
+      matrix[i * num_cols + j] = dist(gen);
+    }
+  }
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, test_pipeline_run) {
+  int N = 400;
+  int block_size = 1;
+  std::vector<double> matrixA(N * N, 0.0);
+  std::vector<double> matrixB(N * N, 0.0);
+  std::vector<double> matrixC(N * N, 0.0);
+  generateMatrix(N, N, matrixA);
+  generateMatrix(N, N, matrixB);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(matrixA.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(matrixB.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&block_size));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(matrixC.data()));
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->outputs_count.emplace_back(N * N);
+  auto testTaskSequential =
+      std::make_shared<lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential>(taskDataSeq);
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}
+
+TEST(lysov_i_matrix_multiplication_Fox_algorithm_seq, test_task_run) {
+  int N = 400;
+  int block_size = 1;
+  std::vector<double> matrixA(N * N, 0.0);
+  std::vector<double> matrixB(N * N, 0.0);
+  std::vector<double> matrixC(N * N, 0.0);
+  generateMatrix(N, N, matrixA);
+  generateMatrix(N, N, matrixB);
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&N));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(matrixA.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(matrixB.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&block_size));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(matrixC.data()));
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(N * N);
+  taskDataSeq->inputs_count.emplace_back(1);
+  taskDataSeq->outputs_count.emplace_back(N * N);
+  auto testTaskSequential =
+      std::make_shared<lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential>(taskDataSeq);
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}

--- a/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_seq.cpp
+++ b/tasks/seq/lysov_i_matrix_multiplication_Fox_algorithm/src/ops_seq.cpp
@@ -1,0 +1,54 @@
+// Copyright 2024 Nesterov Alexander
+#include "seq/lysov_i_matrix_multiplication_Fox_algorithm/include/ops_seq.hpp"
+
+#include <thread>
+
+using namespace std::chrono_literals;
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential::pre_processing() {
+  internal_order_test();
+  N = reinterpret_cast<std::size_t*>(taskData->inputs[0])[0];
+  block_size = reinterpret_cast<std::size_t*>(taskData->inputs[3])[0];
+  A.resize(N * N);
+  B.resize(N * N);
+  C.resize(N * N, 0.0);
+  std::copy(reinterpret_cast<double*>(taskData->inputs[1]), reinterpret_cast<double*>(taskData->inputs[1]) + N * N,
+            A.begin());
+  std::copy(reinterpret_cast<double*>(taskData->inputs[2]), reinterpret_cast<double*>(taskData->inputs[2]) + N * N,
+            B.begin());
+  return true;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential::validation() {
+  internal_order_test();
+  N = reinterpret_cast<std::size_t*>(taskData->inputs[0])[0];
+  block_size = reinterpret_cast<std::size_t*>(taskData->inputs[3])[0];
+  if (taskData->inputs_count.size() != 4 || taskData->outputs_count.size() != 1) {
+    return false;
+  }
+  if (taskData->inputs_count[1] != N * N || taskData->inputs_count[0] != N * N) {
+    return false;
+  }
+  return taskData->outputs_count[0] == N * N && block_size > 0;
+}
+
+bool lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential::run() {
+  internal_order_test();
+  for (std::size_t i = 0; i < N; ++i) {
+    for (std::size_t j = 0; j < N; ++j) {
+      double sum = 0.0;
+      for (std::size_t k = 0; k < N; ++k) {
+        double a_ij = A[i * N + k];
+        double b_kj = B[k * N + j];
+        sum += a_ij * b_kj;
+      }
+      C[i * N + j] = sum;
+    }
+  }
+  return true;
+}
+bool lysov_i_matrix_multiplication_Fox_algorithm_seq::TestTaskSequential::post_processing() {
+  internal_order_test();
+  std::copy(C.begin(), C.end(), reinterpret_cast<double*>(taskData->outputs[0]));
+  return true;
+}


### PR DESCRIPTION
seq: стандартное умножение матриц
mpi:
<b>Для работы алгоритма требуется \( q^2 \) процессов. Если число доступных процессов больше, лишние процессы остаются неактивными</b>
Алгоритм:
1. **Разделение матриц:**
   - Матрицы \( A \) и \( B \) делятся на блоки размером K х K.

2. **Параллельные вычисления:**
   - Каждый процесс обрабатывает назначенные ему блоки матриц \( A \) и \( B \).
   - На каждом шаге:
     - Блоки \( A \) передаются по строкам решётки процессов.
     - Процессы умножают переданный блок \( A \) на локальный блок \( B \).
     - Блоки \( B \) циклически передаются по столбцам.

3. **Сбор результата:**
   - Локальные результаты процессов собираются для формирования итоговой матрицы \( C \).