### PR TITLE
Резанцева Анастасия. Задача 3. Вариант 7. Вычисление многомерных интегралов методом прямоугольников.

### DIFF
--- a/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -1,0 +1,302 @@
+// Copyright 2023 Nesterov Alexander
+// mpi func tests rectangle method
+// #include <gtest/gtest.h>
+//
+// #include <boost/mpi/communicator.hpp>
+// #include <random>
+// #include <vector>
+//
+// #include "mpi/rezantseva_a_vector_dot_product/include/ops_mpi.hpp"
+//
+// static int offset = 0;
+//
+// std::vector<int> createRandomVector(int v_size) {
+//  std::vector<int> vec(v_size);
+//  std::mt19937 gen;
+//  gen.seed((unsigned)time(nullptr) + ++offset);
+//  for (int i = 0; i < v_size; i++) vec[i] = gen() % 100;
+//  return vec;
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, can_scalar_multiply_vec_size_125) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//  if (world.rank() == 0) {
+//    const int count_size_vector = 125;
+//    std::vector<int> v1 = createRandomVector(count_size_vector);
+//    std::vector<int> v2 = createRandomVector(count_size_vector);
+//
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//  }
+//
+//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  testMpiTaskParallel.pre_processing();
+//  testMpiTaskParallel.run();
+//  testMpiTaskParallel.post_processing();
+//
+//  if (world.rank() == 0) {
+//    // Create data
+//    std::vector<int32_t> reference_res(1, 0);
+//
+//    // Create TaskData
+//    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataSeq->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataSeq->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_res.data()));
+//    taskDataSeq->outputs_count.emplace_back(reference_res.size());
+//
+//    // Create Task
+//    rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+//    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+//    testMpiTaskSequential.pre_processing();
+//    testMpiTaskSequential.run();
+//    testMpiTaskSequential.post_processing();
+//    ASSERT_EQ(reference_res[0], res[0]);
+//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(global_vec[0], global_vec[1]), res[0]);
+//  }
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, can_scalar_multiply_vec_size_300) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    const int count_size_vector = 300;
+//    std::vector<int> v1 = createRandomVector(count_size_vector);
+//    std::vector<int> v2 = createRandomVector(count_size_vector);
+//
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//  }
+//
+//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  testMpiTaskParallel.pre_processing();
+//  testMpiTaskParallel.run();
+//  testMpiTaskParallel.post_processing();
+//
+//  if (world.rank() == 0) {
+//    // Create data
+//    std::vector<int32_t> reference_res(1, 0);
+//
+//    // Create TaskData
+//    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataSeq->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataSeq->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_res.data()));
+//    taskDataSeq->outputs_count.emplace_back(reference_res.size());
+//
+//    // Create Task
+//    rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
+//    ASSERT_EQ(testMpiTaskSequential.validation(), true);
+//    testMpiTaskSequential.pre_processing();
+//    testMpiTaskSequential.run();
+//    testMpiTaskSequential.post_processing();
+//    ASSERT_EQ(reference_res[0], res[0]);
+//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(global_vec[0], global_vec[1]), res[0]);
+//  }
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_vectors_not_equal) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    const int count_size_vector = 120;
+//    std::vector<int> v1 = createRandomVector(count_size_vector);
+//    std::vector<int> v2 = createRandomVector(count_size_vector + 5);
+//
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//    rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//    ASSERT_EQ(testMpiTaskParallel.validation(), false);
+//  }
+//  // Create Task
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_vectors_equal_true) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    const int count_size_vector = 120;
+//    std::vector<int> v1 = createRandomVector(count_size_vector);
+//    std::vector<int> v2 = createRandomVector(count_size_vector);
+//
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//    rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//    ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  }
+//  // Create Task
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_vectorDotProduct_right) {
+//  // Create data
+//  std::vector<int> v1 = {1, 2, 5};
+//  std::vector<int> v2 = {4, 7, 8};
+//  ASSERT_EQ(58, rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2));
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_size_5) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//  std::vector<int> v1 = {1, 2, 5, 6, 3};
+//  std::vector<int> v2 = {4, 7, 8, 9, 5};
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//  }
+//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  testMpiTaskParallel.pre_processing();
+//  testMpiTaskParallel.run();
+//  testMpiTaskParallel.post_processing();
+//  if (world.rank() == 0) {
+//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2), res[0]);
+//  }
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_size_3) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//  std::vector<int> v1 = {1, 2, 5};
+//  std::vector<int> v2 = {4, 7, 8};
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//  }
+//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  testMpiTaskParallel.pre_processing();
+//  testMpiTaskParallel.run();
+//  testMpiTaskParallel.post_processing();
+//  if (world.rank() == 0) {
+//    ASSERT_EQ(58, res[0]);
+//  }
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_size_7) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//  std::vector<int> v1 = {1, 2, 5, 14, 21, 16, 11};
+//  std::vector<int> v2 = {4, 7, 8, 12, 31, 25, 9};
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//  }
+//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  testMpiTaskParallel.pre_processing();
+//  testMpiTaskParallel.run();
+//  testMpiTaskParallel.post_processing();
+//  if (world.rank() == 0) {
+//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2), res[0]);
+//  }
+//}
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_empty) {
+//  boost::mpi::communicator world;
+//  std::vector<std::vector<int>> global_vec;
+//  std::vector<int32_t> res(1, 0);
+//  std::vector<int> v1 = {0, 0, 0};
+//  std::vector<int> v2 = {0, 0, 0};
+//  // Create TaskData
+//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//  if (world.rank() == 0) {
+//    global_vec = {v1, v2};
+//    for (size_t i = 0; i < global_vec.size(); i++) {
+//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//    }
+//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//    taskDataPar->outputs_count.emplace_back(res.size());
+//  }
+//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
+//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+//  testMpiTaskParallel.pre_processing();
+//  testMpiTaskParallel.run();
+//  testMpiTaskParallel.post_processing();
+//  if (world.rank() == 0) {
+//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2), res[0]);
+//  }
+//}

--- a/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -190,9 +190,8 @@ TEST(rezantseva_a_rectangle_method_mpi, check_2_dimension_integral_sin) {
 
   bounds[0] = {-3, 10};
   bounds[1] = {-7, 25};
-  distrib[0] = 1000;
-  distrib[1] = 1000;
-
+  distrib[0] = 100;
+  distrib[1] = 100;
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -432,9 +431,9 @@ TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral_with_cos) {
   bounds[0] = {0, 1};
   bounds[1] = {-13, 5};
   bounds[2] = {3, 7};
-  distrib[0] = 100;
-  distrib[1] = 100;
-  distrib[2] = 100;
+  distrib[0] = 50;
+  distrib[1] = 50;
+  distrib[2] = 50;
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -1,302 +1,357 @@
-// Copyright 2023 Nesterov Alexander
 // mpi func tests rectangle method
-// #include <gtest/gtest.h>
-//
-// #include <boost/mpi/communicator.hpp>
-// #include <random>
-// #include <vector>
-//
-// #include "mpi/rezantseva_a_vector_dot_product/include/ops_mpi.hpp"
-//
-// static int offset = 0;
-//
-// std::vector<int> createRandomVector(int v_size) {
-//  std::vector<int> vec(v_size);
-//  std::mt19937 gen;
-//  gen.seed((unsigned)time(nullptr) + ++offset);
-//  for (int i = 0; i < v_size; i++) vec[i] = gen() % 100;
-//  return vec;
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, can_scalar_multiply_vec_size_125) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//  if (world.rank() == 0) {
-//    const int count_size_vector = 125;
-//    std::vector<int> v1 = createRandomVector(count_size_vector);
-//    std::vector<int> v2 = createRandomVector(count_size_vector);
-//
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//  }
-//
-//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  testMpiTaskParallel.pre_processing();
-//  testMpiTaskParallel.run();
-//  testMpiTaskParallel.post_processing();
-//
-//  if (world.rank() == 0) {
-//    // Create data
-//    std::vector<int32_t> reference_res(1, 0);
-//
-//    // Create TaskData
-//    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataSeq->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataSeq->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_res.data()));
-//    taskDataSeq->outputs_count.emplace_back(reference_res.size());
-//
-//    // Create Task
-//    rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
-//    ASSERT_EQ(testMpiTaskSequential.validation(), true);
-//    testMpiTaskSequential.pre_processing();
-//    testMpiTaskSequential.run();
-//    testMpiTaskSequential.post_processing();
-//    ASSERT_EQ(reference_res[0], res[0]);
-//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(global_vec[0], global_vec[1]), res[0]);
-//  }
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, can_scalar_multiply_vec_size_300) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    const int count_size_vector = 300;
-//    std::vector<int> v1 = createRandomVector(count_size_vector);
-//    std::vector<int> v2 = createRandomVector(count_size_vector);
-//
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//  }
-//
-//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  testMpiTaskParallel.pre_processing();
-//  testMpiTaskParallel.run();
-//  testMpiTaskParallel.post_processing();
-//
-//  if (world.rank() == 0) {
-//    // Create data
-//    std::vector<int32_t> reference_res(1, 0);
-//
-//    // Create TaskData
-//    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataSeq->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataSeq->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(reference_res.data()));
-//    taskDataSeq->outputs_count.emplace_back(reference_res.size());
-//
-//    // Create Task
-//    rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential testMpiTaskSequential(taskDataSeq);
-//    ASSERT_EQ(testMpiTaskSequential.validation(), true);
-//    testMpiTaskSequential.pre_processing();
-//    testMpiTaskSequential.run();
-//    testMpiTaskSequential.post_processing();
-//    ASSERT_EQ(reference_res[0], res[0]);
-//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(global_vec[0], global_vec[1]), res[0]);
-//  }
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_vectors_not_equal) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    const int count_size_vector = 120;
-//    std::vector<int> v1 = createRandomVector(count_size_vector);
-//    std::vector<int> v2 = createRandomVector(count_size_vector + 5);
-//
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//    rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//    ASSERT_EQ(testMpiTaskParallel.validation(), false);
-//  }
-//  // Create Task
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_vectors_equal_true) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    const int count_size_vector = 120;
-//    std::vector<int> v1 = createRandomVector(count_size_vector);
-//    std::vector<int> v2 = createRandomVector(count_size_vector);
-//
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//    rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//    ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  }
-//  // Create Task
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_vectorDotProduct_right) {
-//  // Create data
-//  std::vector<int> v1 = {1, 2, 5};
-//  std::vector<int> v2 = {4, 7, 8};
-//  ASSERT_EQ(58, rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2));
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_size_5) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//  std::vector<int> v1 = {1, 2, 5, 6, 3};
-//  std::vector<int> v2 = {4, 7, 8, 9, 5};
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//  }
-//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  testMpiTaskParallel.pre_processing();
-//  testMpiTaskParallel.run();
-//  testMpiTaskParallel.post_processing();
-//  if (world.rank() == 0) {
-//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2), res[0]);
-//  }
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_size_3) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//  std::vector<int> v1 = {1, 2, 5};
-//  std::vector<int> v2 = {4, 7, 8};
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//  }
-//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  testMpiTaskParallel.pre_processing();
-//  testMpiTaskParallel.run();
-//  testMpiTaskParallel.post_processing();
-//  if (world.rank() == 0) {
-//    ASSERT_EQ(58, res[0]);
-//  }
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_size_7) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//  std::vector<int> v1 = {1, 2, 5, 14, 21, 16, 11};
-//  std::vector<int> v2 = {4, 7, 8, 12, 31, 25, 9};
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//  }
-//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  testMpiTaskParallel.pre_processing();
-//  testMpiTaskParallel.run();
-//  testMpiTaskParallel.post_processing();
-//  if (world.rank() == 0) {
-//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2), res[0]);
-//  }
-//}
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, check_mpi_run_right_empty) {
-//  boost::mpi::communicator world;
-//  std::vector<std::vector<int>> global_vec;
-//  std::vector<int32_t> res(1, 0);
-//  std::vector<int> v1 = {0, 0, 0};
-//  std::vector<int> v2 = {0, 0, 0};
-//  // Create TaskData
-//  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//  if (world.rank() == 0) {
-//    global_vec = {v1, v2};
-//    for (size_t i = 0; i < global_vec.size(); i++) {
-//      taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//    }
-//    taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//    taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//    taskDataPar->outputs_count.emplace_back(res.size());
-//  }
-//  rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel testMpiTaskParallel(taskDataPar);
-//  ASSERT_EQ(testMpiTaskParallel.validation(), true);
-//  testMpiTaskParallel.pre_processing();
-//  testMpiTaskParallel.run();
-//  testMpiTaskParallel.post_processing();
-//  if (world.rank() == 0) {
-//    ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2), res[0]);
-//  }
-//}
+#include <gtest/gtest.h>
+
+#include "mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp"
+
+TEST(rezantseva_a_rectangle_method_mpi, check_1_dimension_integral) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0];  // x^2
+  };
+
+  int n = 1;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  distrib[0] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_linear_func_2_dimension) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0] - 2 * x[1];  // x^2-2y
+  };
+
+  int n = 2;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    bounds[0] = {4, 10};
+    bounds[1] = {1, 56};
+    distrib[0] = 1000;
+    distrib[1] = 1000;
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_1_dimension_integral_sin) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return std::sin(x[0]) + x[0] * x[0] * x[0];  // sinx+x^3
+  };
+
+  int n = 1;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  distrib[0] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_2_dimension_integral_sin) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return std::sin(x[0]) + x[0] * x[0] * x[1];  // sinx + y*x^2
+  };
+
+  int n = 2;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {-3, 10};
+  bounds[1] = {-7, 25};
+  distrib[0] = 1000;
+  distrib[1] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] + x[1] + x[2];  // xyz
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 100};
+  bounds[1] = {1, 156};
+  bounds[2] = {6, 249};
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral_with_exp) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return exp(x[0] + 2 * x[1]) - 2 * cos(x[2]);  // exp(x+2y) - 2cosz + sqrt(4d)
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  bounds[1] = {-7, 3};
+  bounds[2] = {3, 8};
+
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}

--- a/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -300,7 +300,7 @@ TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral_with_exp) {
   double error = 0.0001;
   std::vector<double> out(1, 0.0);
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return exp(x[0] + 2 * x[1]) - 2 * cos(x[2]);  // exp(x+2y) - 2cosz + sqrt(4d)
+    return std::exp(x[0] + 2 * x[1]) - 2 * std::cos(x[2]);  // exp(x+2y) - 2cosz + sqrt(4d)
   };
 
   int n = 3;
@@ -314,6 +314,128 @@ TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral_with_exp) {
   distrib[0] = 100;
   distrib[1] = 100;
   distrib[2] = 100;
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral_with_log) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return (std::log10(2 * x[0] * x[0]) + sqrt(x[2]) + 5 * x[1]);
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {0, 1};
+  bounds[1] = {-13, 5};
+  bounds[2] = {3, 7};
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+  // Create Task
+  rezantseva_a_rectangle_method_mpi::RectangleMethodMPI RectangleMethodMPI(taskDataMPI, function);
+  ASSERT_EQ(RectangleMethodMPI.validation(), true);
+  RectangleMethodMPI.pre_processing();
+  RectangleMethodMPI.run();
+  RectangleMethodMPI.post_processing();
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, check_3_dimension_integral_with_cos) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return (std::log10(2 * x[0] * x[2]) + std::sin(x[1]) + 5 * std::cos(x[2]));
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {0, 1};
+  bounds[1] = {-13, 5};
+  bounds[2] = {3, 7};
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {

--- a/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
@@ -1,0 +1,50 @@
+// Copyright 2023 Nesterov Alexander
+// mpi   rectangle method
+
+// #pragma once
+// #include <gtest/gtest.h>
+
+// #include <boost/mpi/collectives.hpp>
+// #include <boost/mpi/communicator.hpp>
+// #include <memory>
+// #include <numeric>
+// #include <string>
+// #include <utility>
+// #include <vector>
+//
+// #include "core/task/include/task.hpp"
+//
+// namespace rezantseva_a_vector_dot_product_mpi {
+// int vectorDotProduct(const std::vector<int>& v1, const std::vector<int>& v2);
+//
+// class TestMPITaskSequential : public ppc::core::Task {
+//  public:
+//   explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+//   bool pre_processing() override;
+//   bool validation() override;
+//   bool run() override;
+//   bool post_processing() override;
+//
+//  private:
+//   std::vector<std::vector<int>> input_;
+//   int res{};
+// };
+//
+// class TestMPITaskParallel : public ppc::core::Task {
+//  public:
+//   explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+//   bool pre_processing() override;
+//   bool validation() override;
+//   bool run() override;
+//   bool post_processing() override;
+//
+//  private:
+//   std::vector<std::vector<int>> input_{};
+//   std::vector<int> local_input1_{}, local_input2_{};
+//   std::vector<unsigned int> counts_{};
+//   size_t num_processes_ = 0;
+//   int res{};
+//   boost::mpi::communicator world;
+// };
+//
+// }  // namespace rezantseva_a_vector_dot_product_mpi

--- a/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
@@ -6,6 +6,7 @@
 #include <boost/mpi/communicator.hpp>
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/vector.hpp>
+#include <cmath>
 #include <functional>
 #include <vector>
 
@@ -14,6 +15,8 @@
 #define func double(const std::vector<double> &)
 
 namespace rezantseva_a_rectangle_method_mpi {
+
+bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 
 template <class Archive, typename T1, typename T2>
 void serialize(Archive &ar, std::pair<T1, T2> &p, const unsigned int version) {
@@ -24,7 +27,7 @@ void serialize(Archive &ar, std::pair<T1, T2> &p, const unsigned int version) {
 class RectangleMethodSequential : public ppc::core::Task {
  public:
   explicit RectangleMethodSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::function<func> f)
-      : Task(std::move(taskData_)), func_(f) {}
+      : Task(std::move(taskData_)), func_(std::move(f)) {}
 
   bool pre_processing() override;
   bool validation() override;
@@ -36,14 +39,12 @@ class RectangleMethodSequential : public ppc::core::Task {
   std::vector<std::pair<double, double>> integration_bounds_;
   std::vector<int> distribution_;
   std::function<func> func_;
-
-  bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 };
 
 class RectangleMethodMPI : public ppc::core::Task {
  public:
   explicit RectangleMethodMPI(std::shared_ptr<ppc::core::TaskData> taskData_, std::function<func> f)
-      : Task(std::move(taskData_)), func_(f) {}
+      : Task(std::move(taskData_)), func_(std::move(f)) {}
 
   bool pre_processing() override;
   bool validation() override;
@@ -60,7 +61,5 @@ class RectangleMethodMPI : public ppc::core::Task {
   int n_;
   std::vector<double> widths_;
   int total_points_{};
-
-  bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 };
 }  // namespace rezantseva_a_rectangle_method_mpi

--- a/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
@@ -1,50 +1,77 @@
-// Copyright 2023 Nesterov Alexander
 // mpi   rectangle method
+#pragma once
+#include <gtest/gtest.h>
 
-// #pragma once
-// #include <gtest/gtest.h>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
+#include <functional>
+#include <vector>
 
-// #include <boost/mpi/collectives.hpp>
-// #include <boost/mpi/communicator.hpp>
-// #include <memory>
-// #include <numeric>
-// #include <string>
-// #include <utility>
-// #include <vector>
+#include "core/task/include/task.hpp"
+
+#define func double(const std::vector<double> &)
+
+// namespace boost {
+// namespace serialization {
 //
-// #include "core/task/include/task.hpp"
-//
-// namespace rezantseva_a_vector_dot_product_mpi {
-// int vectorDotProduct(const std::vector<int>& v1, const std::vector<int>& v2);
-//
-// class TestMPITaskSequential : public ppc::core::Task {
-//  public:
-//   explicit TestMPITaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
-//   bool pre_processing() override;
-//   bool validation() override;
-//   bool run() override;
-//   bool post_processing() override;
-//
-//  private:
-//   std::vector<std::vector<int>> input_;
-//   int res{};
-// };
-//
-// class TestMPITaskParallel : public ppc::core::Task {
-//  public:
-//   explicit TestMPITaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
-//   bool pre_processing() override;
-//   bool validation() override;
-//   bool run() override;
-//   bool post_processing() override;
-//
-//  private:
-//   std::vector<std::vector<int>> input_{};
-//   std::vector<int> local_input1_{}, local_input2_{};
-//   std::vector<unsigned int> counts_{};
-//   size_t num_processes_ = 0;
-//   int res{};
-//   boost::mpi::communicator world;
-// };
-//
-// }  // namespace rezantseva_a_vector_dot_product_mpi
+// template <class Archive>
+// void serialize(Archive &ar, std::pair<double, double> &p, const unsigned int version) {
+//   ar & p.first;
+//   ar & p.second;
+// }
+// }  // namespace serialization
+// }  // namespace boost
+
+namespace rezantseva_a_rectangle_method_mpi {
+
+template <class Archive, typename T1, typename T2>
+void serialize(Archive &ar, std::pair<T1, T2> &p, const unsigned int version) {
+  ar & p.first;
+  ar & p.second;
+}
+
+class RectangleMethodSequential : public ppc::core::Task {
+ public:
+  explicit RectangleMethodSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::function<func> f)
+      : Task(std::move(taskData_)), func_(f) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  double result_{};
+  std::vector<std::pair<double, double>> integration_bounds_;  // Границы интегрирования
+  std::vector<int> distribution_;  // Разбиение (количество прямоугольников)
+  std::function<func> func_;       // Интегрируемая функция
+
+  bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
+};
+
+class RectangleMethodMPI : public ppc::core::Task {
+ public:
+  explicit RectangleMethodMPI(std::shared_ptr<ppc::core::TaskData> taskData_, std::function<func> f)
+      : Task(std::move(taskData_)), func_(f) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  boost::mpi::communicator world;
+  double result_{};
+  int num_processes_ = 0;
+  std::vector<std::pair<double, double>> integration_bounds_;  // Границы интегрирования
+  std::vector<int> distribution_;  // Разбиение (количество прямоугольников)
+  std::function<func> func_;       // Интегрируемая функция
+  int n_;
+  std::vector<double> widths_;  // Длины отрезков
+  int total_points_{};  // Количество точек в многомерном пространстве, для которых будет вычисляться значение функци
+
+  bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
+};
+}  // namespace rezantseva_a_rectangle_method_mpi

--- a/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp
@@ -13,17 +13,6 @@
 
 #define func double(const std::vector<double> &)
 
-// namespace boost {
-// namespace serialization {
-//
-// template <class Archive>
-// void serialize(Archive &ar, std::pair<double, double> &p, const unsigned int version) {
-//   ar & p.first;
-//   ar & p.second;
-// }
-// }  // namespace serialization
-// }  // namespace boost
-
 namespace rezantseva_a_rectangle_method_mpi {
 
 template <class Archive, typename T1, typename T2>
@@ -44,9 +33,9 @@ class RectangleMethodSequential : public ppc::core::Task {
 
  private:
   double result_{};
-  std::vector<std::pair<double, double>> integration_bounds_;  // Границы интегрирования
-  std::vector<int> distribution_;  // Разбиение (количество прямоугольников)
-  std::function<func> func_;       // Интегрируемая функция
+  std::vector<std::pair<double, double>> integration_bounds_;
+  std::vector<int> distribution_;
+  std::function<func> func_;
 
   bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 };
@@ -65,12 +54,12 @@ class RectangleMethodMPI : public ppc::core::Task {
   boost::mpi::communicator world;
   double result_{};
   int num_processes_ = 0;
-  std::vector<std::pair<double, double>> integration_bounds_;  // Границы интегрирования
-  std::vector<int> distribution_;  // Разбиение (количество прямоугольников)
-  std::function<func> func_;       // Интегрируемая функция
+  std::vector<std::pair<double, double>> integration_bounds_;
+  std::vector<int> distribution_;
+  std::function<func> func_;
   int n_;
-  std::vector<double> widths_;  // Длины отрезков
-  int total_points_{};  // Количество точек в многомерном пространстве, для которых будет вычисляться значение функци
+  std::vector<double> widths_;
+  int total_points_{};
 
   bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 };

--- a/tasks/mpi/rezantseva_a_rectangle_method/perf_tests/main_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/perf_tests/main_rez_a.cpp
@@ -1,111 +1,151 @@
-//// Copyright 2023 Nesterov Alexander
 // mpi perf tests rectangle method
-// #include <gtest/gtest.h>
-//
-// #include <boost/mpi/timer.hpp>
-// #include <random>
-// #include <vector>
-//
-// #include "core/perf/include/perf.hpp"
-// #include "mpi/rezantseva_a_vector_dot_product/include/ops_mpi.hpp"
-//
-// static int offset = 0;
-// const int count_size_vector = 49000000;
-//
-// std::vector<int> createRandomVector(int v_size) {
-//   std::vector<int> vec(v_size);
-//   std::mt19937 gen;
-//   gen.seed((unsigned)time(nullptr) + ++offset);
-//   for (int i = 0; i < v_size; i++) vec[i] = gen() % 100;
-//   return vec;
-// }
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, test_pipeline_run) {
-//   boost::mpi::communicator world;
-//   std::vector<std::vector<int>> global_vec;
-//
-//   std::vector<int> v1 = createRandomVector(count_size_vector);
-//   std::vector<int> v2 = createRandomVector(count_size_vector);
-//
-//   std::vector<int32_t> res(1, 0);
-//   global_vec = {v1, v2};
-//   // Create TaskData
-//   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//
-//   if (world.rank() == 0) {
-//     for (size_t i = 0; i < global_vec.size(); i++) {
-//       taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//     }
-//     taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//     taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//     taskDataPar->outputs_count.emplace_back(res.size());
-//   }
-//
-//   auto testMpiTaskParallel = std::make_shared<rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel>(taskDataPar);
-//   ASSERT_EQ(testMpiTaskParallel->validation(), true);
-//   testMpiTaskParallel->pre_processing();
-//   testMpiTaskParallel->run();
-//   testMpiTaskParallel->post_processing();
-//   // Create Perf attributes
-//   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
-//   perfAttr->num_running = 10;
-//   const boost::mpi::timer current_timer;
-//   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
-//   // Create and init perf results
-//   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-//   int answer = rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2);
-//   //  Create Perf analyzer
-//   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
-//   perfAnalyzer->pipeline_run(perfAttr, perfResults);
-//
-//   if (world.rank() == 0) {
-//     ppc::core::Perf::print_perf_statistic(perfResults);
-//     ASSERT_EQ(answer, res[0]);
-//   }
-// }
-//
-// TEST(rezantseva_a_vector_dot_product_mpi, test_task_run) {
-//   boost::mpi::communicator world;
-//   std::vector<std::vector<int>> global_vec;
-//   std::vector<int32_t> res(1, 0);
-//   std::vector<int> v1 = createRandomVector(count_size_vector);
-//   std::vector<int> v2 = createRandomVector(count_size_vector);
-//   // Create TaskData
-//   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
-//   global_vec = {v1, v2};
-//
-//   if (world.rank() == 0) {
-//     for (size_t i = 0; i < global_vec.size(); i++) {
-//       taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
-//     }
-//     taskDataPar->inputs_count.emplace_back(global_vec[0].size());
-//     taskDataPar->inputs_count.emplace_back(global_vec[1].size());
-//     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
-//     taskDataPar->outputs_count.emplace_back(res.size());
-//   }
-//
-//   auto testMpiTaskParallel = std::make_shared<rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel>(taskDataPar);
-//   ASSERT_EQ(testMpiTaskParallel->validation(), true);
-//   testMpiTaskParallel->pre_processing();
-//   testMpiTaskParallel->run();
-//   testMpiTaskParallel->post_processing();
-//
-//   // Create Perf attributes
-//   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
-//   perfAttr->num_running = 10;
-//   const boost::mpi::timer current_timer;
-//   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
-//
-//   // Create and init perf results
-//   auto perfResults = std::make_shared<ppc::core::PerfResults>();
-//   // int answer = res[0];
-//   //   Create Perf analyzer
-//   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
-//   perfAnalyzer->task_run(perfAttr, perfResults);
-//
-//   if (world.rank() == 0) {
-//     ppc::core::Perf::print_perf_statistic(perfResults);
-//     ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(global_vec[0], global_vec[1]), res[0]);
-//   }
-// }
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp"
+
+TEST(rezantseva_a_rectangle_method_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0] - 2 * x[1] + 8 * x[2];
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {-6, 10};
+  bounds[1] = {5, 27};
+  bounds[2] = {15, 32};
+  distrib[0] = 500;
+  distrib[1] = 250;
+  distrib[2] = 150;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  auto rectanglMethodParallel =
+      std::make_shared<rezantseva_a_rectangle_method_mpi::RectangleMethodMPI>(taskDataMPI, function);
+  ASSERT_EQ(rectanglMethodParallel->validation(), true);
+  rectanglMethodParallel->pre_processing();
+  rectanglMethodParallel->run();
+  rectanglMethodParallel->post_processing();
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  //  Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(rectanglMethodParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}
+
+TEST(rezantseva_a_rectangle_method_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  double error = 0.0001;
+  std::vector<double> out(1, 0.0);
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0] - 2 * x[1] + 8 * x[2];
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {-6, 10};
+  bounds[1] = {5, 27};
+  bounds[2] = {15, 32};
+  distrib[0] = 500;
+  distrib[1] = 250;
+  distrib[2] = 150;
+
+  std::shared_ptr<ppc::core::TaskData> taskDataMPI = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataMPI->inputs_count.emplace_back(bounds.size());
+
+    taskDataMPI->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataMPI->inputs_count.emplace_back(distrib.size());
+
+    taskDataMPI->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataMPI->outputs_count.emplace_back(out.size());
+  }
+
+  auto rectanglMethodParallel =
+      std::make_shared<rezantseva_a_rectangle_method_mpi::RectangleMethodMPI>(taskDataMPI, function);
+  ASSERT_EQ(rectanglMethodParallel->validation(), true);
+  rectanglMethodParallel->pre_processing();
+  rectanglMethodParallel->run();
+  rectanglMethodParallel->post_processing();
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  //  Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(rectanglMethodParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  std::vector<double> seq_out(1, 0.0);
+  if (world.rank() == 0) {
+    std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+    taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+    taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(seq_out.data()));
+    taskDataSeq->outputs_count.emplace_back(seq_out.size());
+
+    // Create Task
+    rezantseva_a_rectangle_method_mpi::RectangleMethodSequential RectangleMethodSeq(taskDataSeq, function);
+    ASSERT_EQ(RectangleMethodSeq.validation(), true);
+    RectangleMethodSeq.pre_processing();
+    RectangleMethodSeq.run();
+    RectangleMethodSeq.post_processing();
+
+    ASSERT_NEAR(seq_out[0], out[0], error);
+  }
+}

--- a/tasks/mpi/rezantseva_a_rectangle_method/perf_tests/main_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/perf_tests/main_rez_a.cpp
@@ -1,0 +1,111 @@
+//// Copyright 2023 Nesterov Alexander
+// mpi perf tests rectangle method
+// #include <gtest/gtest.h>
+//
+// #include <boost/mpi/timer.hpp>
+// #include <random>
+// #include <vector>
+//
+// #include "core/perf/include/perf.hpp"
+// #include "mpi/rezantseva_a_vector_dot_product/include/ops_mpi.hpp"
+//
+// static int offset = 0;
+// const int count_size_vector = 49000000;
+//
+// std::vector<int> createRandomVector(int v_size) {
+//   std::vector<int> vec(v_size);
+//   std::mt19937 gen;
+//   gen.seed((unsigned)time(nullptr) + ++offset);
+//   for (int i = 0; i < v_size; i++) vec[i] = gen() % 100;
+//   return vec;
+// }
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, test_pipeline_run) {
+//   boost::mpi::communicator world;
+//   std::vector<std::vector<int>> global_vec;
+//
+//   std::vector<int> v1 = createRandomVector(count_size_vector);
+//   std::vector<int> v2 = createRandomVector(count_size_vector);
+//
+//   std::vector<int32_t> res(1, 0);
+//   global_vec = {v1, v2};
+//   // Create TaskData
+//   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//
+//   if (world.rank() == 0) {
+//     for (size_t i = 0; i < global_vec.size(); i++) {
+//       taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//     }
+//     taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//     taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//     taskDataPar->outputs_count.emplace_back(res.size());
+//   }
+//
+//   auto testMpiTaskParallel = std::make_shared<rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel>(taskDataPar);
+//   ASSERT_EQ(testMpiTaskParallel->validation(), true);
+//   testMpiTaskParallel->pre_processing();
+//   testMpiTaskParallel->run();
+//   testMpiTaskParallel->post_processing();
+//   // Create Perf attributes
+//   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+//   perfAttr->num_running = 10;
+//   const boost::mpi::timer current_timer;
+//   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+//   // Create and init perf results
+//   auto perfResults = std::make_shared<ppc::core::PerfResults>();
+//   int answer = rezantseva_a_vector_dot_product_mpi::vectorDotProduct(v1, v2);
+//   //  Create Perf analyzer
+//   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+//   perfAnalyzer->pipeline_run(perfAttr, perfResults);
+//
+//   if (world.rank() == 0) {
+//     ppc::core::Perf::print_perf_statistic(perfResults);
+//     ASSERT_EQ(answer, res[0]);
+//   }
+// }
+//
+// TEST(rezantseva_a_vector_dot_product_mpi, test_task_run) {
+//   boost::mpi::communicator world;
+//   std::vector<std::vector<int>> global_vec;
+//   std::vector<int32_t> res(1, 0);
+//   std::vector<int> v1 = createRandomVector(count_size_vector);
+//   std::vector<int> v2 = createRandomVector(count_size_vector);
+//   // Create TaskData
+//   std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+//   global_vec = {v1, v2};
+//
+//   if (world.rank() == 0) {
+//     for (size_t i = 0; i < global_vec.size(); i++) {
+//       taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(global_vec[i].data()));
+//     }
+//     taskDataPar->inputs_count.emplace_back(global_vec[0].size());
+//     taskDataPar->inputs_count.emplace_back(global_vec[1].size());
+//     taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(res.data()));
+//     taskDataPar->outputs_count.emplace_back(res.size());
+//   }
+//
+//   auto testMpiTaskParallel = std::make_shared<rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel>(taskDataPar);
+//   ASSERT_EQ(testMpiTaskParallel->validation(), true);
+//   testMpiTaskParallel->pre_processing();
+//   testMpiTaskParallel->run();
+//   testMpiTaskParallel->post_processing();
+//
+//   // Create Perf attributes
+//   auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+//   perfAttr->num_running = 10;
+//   const boost::mpi::timer current_timer;
+//   perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+//
+//   // Create and init perf results
+//   auto perfResults = std::make_shared<ppc::core::PerfResults>();
+//   // int answer = res[0];
+//   //   Create Perf analyzer
+//   auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+//   perfAnalyzer->task_run(perfAttr, perfResults);
+//
+//   if (world.rank() == 0) {
+//     ppc::core::Perf::print_perf_statistic(perfResults);
+//     ASSERT_EQ(rezantseva_a_vector_dot_product_mpi::vectorDotProduct(global_vec[0], global_vec[1]), res[0]);
+//   }
+// }

--- a/tasks/mpi/rezantseva_a_rectangle_method/src/ops_mpi_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/src/ops_mpi_rez_a.cpp
@@ -1,0 +1,142 @@
+// Copyright 2024 Nesterov Alexander
+// // mpi cpp rectangle method
+// #include "mpi/rezantseva_a_vector_dot_product/include/ops_mpi.hpp"
+//
+// int rezantseva_a_vector_dot_product_mpi::vectorDotProduct(const std::vector<int>& v1, const std::vector<int>& v2) {
+//  long long result = 0;
+//  for (size_t i = 0; i < v1.size(); i++) result += v1[i] * v2[i];
+//  return result;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential::validation() {
+//  internal_order_test();
+//  // Check count elements of output
+//  return (taskData->inputs.size() == taskData->inputs_count.size() && taskData->inputs.size() == 2) &&
+//         (taskData->inputs_count[0] == taskData->inputs_count[1]) &&
+//         (taskData->outputs.size() == taskData->outputs_count.size()) && taskData->outputs.size() == 1 &&
+//         taskData->outputs_count[0] == 1;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential::pre_processing() {
+//  internal_order_test();
+//  // Init value for input and output
+//
+//  input_ = std::vector<std::vector<int>>(taskData->inputs.size());
+//  for (size_t i = 0; i < input_.size(); i++) {
+//    auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[i]);
+//    input_[i] = std::vector<int>(taskData->inputs_count[i]);
+//    for (size_t j = 0; j < taskData->inputs_count[i]; j++) {
+//      input_[i][j] = tmp_ptr[j];
+//    }
+//  }
+//  res = 0;
+//  return true;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential::run() {
+//  internal_order_test();
+//  for (size_t i = 0; i < input_[0].size(); i++) {
+//    res += input_[0][i] * input_[1][i];
+//  }
+//
+//  return true;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskSequential::post_processing() {
+//  internal_order_test();
+//  reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
+//  return true;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel::validation() {
+//  internal_order_test();
+//  if (world.rank() == 0) {
+//    // Check count elements of output
+//    return (taskData->inputs.size() == taskData->inputs_count.size() && taskData->inputs.size() == 2) &&
+//           (taskData->inputs_count[0] == taskData->inputs_count[1]) &&
+//           (taskData->outputs.size() == taskData->outputs_count.size()) && taskData->outputs.size() == 1 &&
+//           taskData->outputs_count[0] == 1;
+//  }
+//  return true;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel::pre_processing() {
+//  internal_order_test();
+//
+//  size_t total_elements = 0;
+//  size_t delta = 0;
+//  size_t remainder = 0;
+//
+//  if (world.rank() == 0) {
+//    total_elements = taskData->inputs_count[0];
+//    num_processes_ = world.size();
+//    delta = total_elements / num_processes_;      // Calculate base size for each process
+//    remainder = total_elements % num_processes_;  // Calculate remaining elements
+//  }
+//  boost::mpi::broadcast(world, num_processes_, 0);
+//
+//  counts_.resize(num_processes_);  // Vector to store counts for each process
+//
+//  if (world.rank() == 0) {
+//    // Distribute sizes to each process
+//    for (unsigned int i = 0; i < num_processes_; ++i) {
+//      counts_[i] = delta + (i < remainder ? 1 : 0);  // Assign 1 additional element to the first 'remainder' processes
+//    }
+//  }
+//  boost::mpi::broadcast(world, counts_.data(), num_processes_, 0);
+//
+//  if (world.rank() == 0) {
+//    input_ = std::vector<std::vector<int>>(taskData->inputs.size());
+//    for (size_t i = 0; i < input_.size(); i++) {
+//      auto* tmp_ptr = reinterpret_cast<int*>(taskData->inputs[i]);
+//      input_[i] = std::vector<int>(taskData->inputs_count[i]);
+//      for (size_t j = 0; j < taskData->inputs_count[i]; j++) {
+//        input_[i][j] = tmp_ptr[j];
+//      }
+//    }
+//  }
+//
+//  res = 0;
+//  return true;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel::run() {
+//  internal_order_test();
+//
+//  if (world.rank() == 0) {
+//    size_t offset_remainder = counts_[0];
+//    for (unsigned int proc = 1; proc < num_processes_; proc++) {
+//      size_t current_count = counts_[proc];
+//      world.send(proc, 0, input_[0].data() + offset_remainder, current_count);
+//      world.send(proc, 1, input_[1].data() + offset_remainder, current_count);
+//      offset_remainder += current_count;
+//    }
+//  }
+//
+//  local_input1_ = std::vector<int>(counts_[world.rank()]);
+//  local_input2_ = std::vector<int>(counts_[world.rank()]);
+//
+//  if (world.rank() > 0) {
+//    world.recv(0, 0, local_input1_.data(), counts_[world.rank()]);
+//    world.recv(0, 1, local_input2_.data(), counts_[world.rank()]);
+//  } else {
+//    local_input1_ = std::vector<int>(input_[0].begin(), input_[0].begin() + counts_[0]);
+//    local_input2_ = std::vector<int>(input_[1].begin(), input_[1].begin() + counts_[0]);
+//  }
+//
+//  int local_res = 0;
+//
+//  for (size_t i = 0; i < local_input1_.size(); i++) {
+//    local_res += local_input1_[i] * local_input2_[i];
+//  }
+//  boost::mpi::reduce(world, local_res, res, std::plus<>(), 0);
+//  return true;
+//}
+//
+// bool rezantseva_a_vector_dot_product_mpi::TestMPITaskParallel::post_processing() {
+//  internal_order_test();
+//  if (world.rank() == 0) {
+//    reinterpret_cast<int*>(taskData->outputs[0])[0] = res;
+//  }
+//  return true;
+//}

--- a/tasks/mpi/rezantseva_a_rectangle_method/src/ops_mpi_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/src/ops_mpi_rez_a.cpp
@@ -1,20 +1,15 @@
 // mpi cpp rectangle method
 #include "mpi/rezantseva_a_rectangle_method/include/ops_mpi_rez_a.hpp"
 
-bool rezantseva_a_rectangle_method_mpi::RectangleMethodSequential::check_integration_bounds(
-    std::vector<std::pair<double, double>>* ib) {
+bool rezantseva_a_rectangle_method_mpi::check_integration_bounds(std::vector<std::pair<double, double>>* ib) {
   if (ib == nullptr) {
     std::cerr << "Error: bounds pointer is null." << std::endl;
     return false;
   }
 
-  for (const auto& bound : *ib) {
-    if (bound.first >= bound.second) {
-      std::cout << "false";
-      return false;
-    }
-  }
-  return true;
+  bool result = std::ranges::all_of(*ib, [](const auto& bound) { return bound.first < bound.second; });
+
+  return result;
 }
 
 bool rezantseva_a_rectangle_method_mpi::RectangleMethodSequential::validation() {
@@ -68,22 +63,6 @@ bool rezantseva_a_rectangle_method_mpi::RectangleMethodSequential::run() {
 bool rezantseva_a_rectangle_method_mpi::RectangleMethodSequential::post_processing() {
   internal_order_test();
   reinterpret_cast<double*>(taskData->outputs[0])[0] = result_;
-  return true;
-}
-
-bool rezantseva_a_rectangle_method_mpi::RectangleMethodMPI::check_integration_bounds(
-    std::vector<std::pair<double, double>>* ib) {
-  if (ib == nullptr) {
-    std::cerr << "Error: bounds pointer is null." << std::endl;
-    return false;
-  }
-
-  for (const auto& bound : *ib) {
-    if (bound.first >= bound.second) {
-      return false;
-    }
-  }
-
   return true;
 }
 
@@ -167,7 +146,7 @@ bool rezantseva_a_rectangle_method_mpi::RectangleMethodMPI::run() {
     }
   }
 
-  boost::mpi::reduce(world, local_sum, result_, std::plus<double>(), 0);
+  boost::mpi::reduce(world, local_sum, result_, std::plus<>(), 0);
   for (int i = 0; i < n_; i++) {
     result_ *= widths_[i];
   }

--- a/tasks/mpi/rezantseva_a_rectangle_method/src/ops_mpi_rez_a.cpp
+++ b/tasks/mpi/rezantseva_a_rectangle_method/src/ops_mpi_rez_a.cpp
@@ -71,8 +71,6 @@ bool rezantseva_a_rectangle_method_mpi::RectangleMethodSequential::post_processi
   return true;
 }
 
-//======================================================================================================\\
-
 bool rezantseva_a_rectangle_method_mpi::RectangleMethodMPI::check_integration_bounds(
     std::vector<std::pair<double, double>>* ib) {
   if (ib == nullptr) {

--- a/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -161,9 +161,9 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
   std::vector<std::pair<double, double>> bounds(n);
   std::vector<int> distrib(n);
 
-  bounds[0] = {4, 100};
-  bounds[1] = {1, 156};
-  bounds[2] = {6, 249};
+  bounds[0] = {4, 60};
+  bounds[1] = {1, 25};
+  bounds[2] = {6, 37};
   distrib[0] = 100;
   distrib[1] = 100;
   distrib[2] = 100;
@@ -187,7 +187,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.001;
-  ASSERT_NEAR(932886720, out[0], error);
+  ASSERT_NEAR(2770656, out[0], error);
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
@@ -202,12 +202,12 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   std::vector<int> distrib(n);
 
   bounds[0] = {4, 10};
-  bounds[1] = {-7, 3};
+  bounds[1] = {-4, 3};
   bounds[2] = {3, 8};
 
-  distrib[0] = 100;
-  distrib[1] = 100;
-  distrib[2] = 100;
+  distrib[0] = 50;
+  distrib[1] = 50;
+  distrib[2] = 50;
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -228,7 +228,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.1;
-  ASSERT_NEAR(22119899.5, out[0], error);
+  ASSERT_NEAR(22074648.4, out[0], error);
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_log) {
@@ -243,11 +243,11 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_log) {
   std::vector<int> distrib(n);
 
   bounds[0] = {0, 1};
-  bounds[1] = {-13, 5};
+  bounds[1] = {-7, 5};
   bounds[2] = {3, 7};
-  distrib[0] = 100;
-  distrib[1] = 100;
-  distrib[2] = 100;
+  distrib[0] = 60;
+  distrib[1] = 60;
+  distrib[2] = 60;
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -268,7 +268,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_log) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.001;
-  ASSERT_NEAR(-1320.7583, out[0], error);
+  ASSERT_NEAR(-160.409, out[0], error);
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_cos) {

--- a/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -20,12 +20,10 @@ TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
   taskDataSeq->inputs_count.emplace_back(bounds.size());
 
-  auto* distrib_data = new std::vector<int>(distrib);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
   taskDataSeq->inputs_count.emplace_back(distrib.size());
 
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
@@ -39,8 +37,6 @@ TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral) {
   RectangleMethodSequential.post_processing();
   double error = 0.0001;
   ASSERT_NEAR(312, out[0], error);
-  delete bounds_data;
-  delete distrib_data;
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_linear_func) {
@@ -62,12 +58,10 @@ TEST(rezantseva_a_rectangle_method_seq, check_linear_func) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
   taskDataSeq->inputs_count.emplace_back(bounds.size());
 
-  auto* distrib_data = new std::vector<int>(distrib);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
   taskDataSeq->inputs_count.emplace_back(distrib.size());
 
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
@@ -81,8 +75,6 @@ TEST(rezantseva_a_rectangle_method_seq, check_linear_func) {
   RectangleMethodSequential.post_processing();
   double error = 0.001;
   ASSERT_NEAR(-1650, out[0], error);
-  delete bounds_data;
-  delete distrib_data;
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral_sin) {
@@ -102,12 +94,10 @@ TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral_sin) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
   taskDataSeq->inputs_count.emplace_back(bounds.size());
 
-  auto* distrib_data = new std::vector<int>(distrib);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
   taskDataSeq->inputs_count.emplace_back(distrib.size());
 
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
@@ -121,8 +111,6 @@ TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral_sin) {
   RectangleMethodSequential.post_processing();
   double error = 0.001;
   ASSERT_NEAR(2436.18542, out[0], error);
-  delete bounds_data;
-  delete distrib_data;
 }
 TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
   std::vector<double> out(1, 0);
@@ -143,12 +131,10 @@ TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
   taskDataSeq->inputs_count.emplace_back(bounds.size());
 
-  auto* distrib_data = new std::vector<int>(distrib);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
   taskDataSeq->inputs_count.emplace_back(distrib.size());
 
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
@@ -162,8 +148,6 @@ TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
   RectangleMethodSequential.post_processing();
   double error = 0.001;
   ASSERT_NEAR(98587.1705290392, out[0], error);
-  delete bounds_data;
-  delete distrib_data;
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
@@ -187,12 +171,10 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
   taskDataSeq->inputs_count.emplace_back(bounds.size());
 
-  auto* distrib_data = new std::vector<int>(distrib);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
   taskDataSeq->inputs_count.emplace_back(distrib.size());
 
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
@@ -206,8 +188,6 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
   RectangleMethodSequential.post_processing();
   double error = 0.001;
   ASSERT_NEAR(932886720.0, out[0], error);
-  delete bounds_data;
-  delete distrib_data;
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
@@ -232,12 +212,10 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
   taskDataSeq->inputs_count.emplace_back(bounds.size());
 
-  auto* distrib_data = new std::vector<int>(distrib);
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
   taskDataSeq->inputs_count.emplace_back(distrib.size());
 
   taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
@@ -251,6 +229,4 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   RectangleMethodSequential.post_processing();
   double error = 0.1;
   ASSERT_NEAR(22154067.07, out[0], error);
-  delete bounds_data;
-  delete distrib_data;
 }

--- a/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -1,0 +1,256 @@
+// FUNC_TEST_SEQ_RECTANGLE
+#include <gtest/gtest.h>
+
+#include "seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp"
+
+TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0];  // x^2
+  };
+
+  int n = 1;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  distrib[0] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.0001;
+  ASSERT_NEAR(312, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}
+
+TEST(rezantseva_a_rectangle_method_seq, check_linear_func) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0] - 2 * x[1];  // x^2-2y
+  };
+
+  int n = 2;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  bounds[1] = {1, 56};
+  distrib[0] = 1000;
+  distrib[1] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.001;
+  ASSERT_NEAR(-1650, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}
+
+TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral_sin) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return std::sin(x[0]) + x[0] * x[0] * x[0];  // sinx+x^3
+  };
+
+  int n = 1;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  distrib[0] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.001;
+  ASSERT_NEAR(2436.18542, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}
+TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return std::sin(x[0]) + x[0] * x[0] * x[1];  // sinx + y*x^2
+  };
+
+  int n = 2;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {-3, 10};
+  bounds[1] = {-7, 25};
+  distrib[0] = 10000;
+  distrib[1] = 1000;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.001;
+  ASSERT_NEAR(98587.1705290392, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}
+
+TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] + x[1] + x[2];  // xyz
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 100};
+  bounds[1] = {1, 156};
+  bounds[2] = {6, 249};
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.001;
+  ASSERT_NEAR(932886720.0, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}
+
+TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return exp(x[0] + 2 * x[1]) - 2 * cos(x[2]);  // exp(x+2y) - 2cosz + sqrt(4d)
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {4, 10};
+  bounds[1] = {-7, 3};
+  bounds[2] = {3, 8};
+
+  distrib[0] = 500;
+  distrib[1] = 250;
+  distrib[2] = 150;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.1;
+  ASSERT_NEAR(22154067.07, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}

--- a/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -7,7 +7,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral) {
   std::vector<double> out(1, 0);
 
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return x[0] * x[0];  // x^2
+    return (x[0] * x[0]);  // x^2
   };
 
   int n = 1;
@@ -43,7 +43,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_linear_func) {
   std::vector<double> out(1, 0);
 
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return x[0] * x[0] - 2 * x[1];  // x^2-2y
+    return (x[0] * x[0] - 2 * x[1]);  // x^2-2y
   };
 
   int n = 2;
@@ -81,7 +81,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_1_dimension_integral_sin) {
   std::vector<double> out(1, 0);
 
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return std::sin(x[0]) + x[0] * x[0] * x[0];  // sinx+x^3
+    return (std::sin(x[0]) + x[0] * x[0] * x[0]);  // sinx+x^3
   };
 
   int n = 1;
@@ -116,7 +116,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
   std::vector<double> out(1, 0);
 
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return std::sin(x[0]) + x[0] * x[0] * x[1];  // sinx + y*x^2
+    return (std::sin(x[0]) + x[0] * x[0] * x[1]);  // sinx + y*x^2
   };
 
   int n = 2;
@@ -154,7 +154,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
   std::vector<double> out(1, 0);
 
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return x[0] + x[1] + x[2];  // xyz
+    return (x[0] + x[1] + x[2]);  // xyz
   };
 
   int n = 3;
@@ -194,7 +194,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   std::vector<double> out(1, 0);
 
   std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
-    return exp(x[0] + 2 * x[1]) - 2 * cos(x[2]);  // exp(x+2y) - 2cosz + sqrt(4d)
+    return (std::exp(x[0] + 2 * x[1]) - 2 * std::cos(x[2]));  // exp(x+2y) - 2cosz + sqrt(4d)
   };
 
   int n = 3;
@@ -205,8 +205,8 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   bounds[1] = {-7, 3};
   bounds[2] = {3, 8};
 
-  distrib[0] = 500;
-  distrib[1] = 250;
+  distrib[0] = 150;
+  distrib[1] = 150;
   distrib[2] = 150;
 
   // Create TaskData
@@ -228,5 +228,85 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.1;
-  ASSERT_NEAR(22154067.07, out[0], error);
+  ASSERT_NEAR(22142225.6501, out[0], error);
+}
+
+TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_log) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return (std::log10(2 * x[0] * x[0]) + sqrt(x[2]) + 5 * x[1]);
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {0, 1};
+  bounds[1] = {-13, 5};
+  bounds[2] = {3, 7};
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.001;
+  ASSERT_NEAR(-1320.7583, out[0], error);
+}
+
+TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_cos) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return (std::log10(2 * x[0] * x[2]) + std::sin(x[1]) + 5 * std::cos(x[2]));
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {0, 1};
+  bounds[1] = {-13, 5};
+  bounds[2] = {3, 7};
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&bounds));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(&distrib));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  rezantseva_a_rectangle_method_seq::RectangleMethodSequential RectangleMethodSequential(taskDataSeq, function);
+  ASSERT_EQ(RectangleMethodSequential.validation(), true);
+  RectangleMethodSequential.pre_processing();
+  RectangleMethodSequential.run();
+  RectangleMethodSequential.post_processing();
+  double error = 0.001;
+  ASSERT_NEAR(88.8914, out[0], error);
 }

--- a/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/func_tests/main_rez_a.cpp
@@ -125,8 +125,8 @@ TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
 
   bounds[0] = {-3, 10};
   bounds[1] = {-7, 25};
-  distrib[0] = 10000;
-  distrib[1] = 1000;
+  distrib[0] = 100;
+  distrib[1] = 100;
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -147,7 +147,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_2_dimension_integral_sin) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.001;
-  ASSERT_NEAR(98587.1705290392, out[0], error);
+  ASSERT_NEAR(98581.894, out[0], error);
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
@@ -187,7 +187,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.001;
-  ASSERT_NEAR(932886720.0, out[0], error);
+  ASSERT_NEAR(932886720, out[0], error);
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
@@ -205,9 +205,9 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   bounds[1] = {-7, 3};
   bounds[2] = {3, 8};
 
-  distrib[0] = 150;
-  distrib[1] = 150;
-  distrib[2] = 150;
+  distrib[0] = 100;
+  distrib[1] = 100;
+  distrib[2] = 100;
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -228,7 +228,7 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_with_exp) {
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
   double error = 0.1;
-  ASSERT_NEAR(22142225.6501, out[0], error);
+  ASSERT_NEAR(22119899.5, out[0], error);
 }
 
 TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_log) {
@@ -285,9 +285,9 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_cos) {
   bounds[0] = {0, 1};
   bounds[1] = {-13, 5};
   bounds[2] = {3, 7};
-  distrib[0] = 100;
-  distrib[1] = 100;
-  distrib[2] = 100;
+  distrib[0] = 50;
+  distrib[1] = 50;
+  distrib[2] = 50;
 
   // Create TaskData
   std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -307,6 +307,6 @@ TEST(rezantseva_a_rectangle_method_seq, check_3_dimension_integral_cos) {
   RectangleMethodSequential.pre_processing();
   RectangleMethodSequential.run();
   RectangleMethodSequential.post_processing();
-  double error = 0.001;
-  ASSERT_NEAR(88.8914, out[0], error);
+  double error = 0.01;
+  ASSERT_NEAR(89.01, out[0], error);
 }

--- a/tasks/seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp
@@ -1,0 +1,30 @@
+// seq hpp rezantseva_a_rectangle_method
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+#define func double(const std::vector<double> &)
+
+namespace rezantseva_a_rectangle_method_seq {
+class RectangleMethodSequential : public ppc::core::Task {
+ public:
+  explicit RectangleMethodSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::function<func> f)
+      : Task(std::move(taskData_)), func_(f) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  double result_{};
+  std::vector<std::pair<double, double>> integration_bounds_;  // Границы интегрирования
+  std::vector<int> distribution_;  // Разбиение (количество прямоугольников)
+  std::function<func> func_;       // Интегрируемая функция
+
+  bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
+};
+}  // namespace rezantseva_a_rectangle_method_seq

--- a/tasks/seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp
@@ -1,6 +1,7 @@
 // seq hpp rezantseva_a_rectangle_method
 #pragma once
 
+#include <cmath>
 #include <functional>
 #include <vector>
 
@@ -12,7 +13,7 @@ namespace rezantseva_a_rectangle_method_seq {
 class RectangleMethodSequential : public ppc::core::Task {
  public:
   explicit RectangleMethodSequential(std::shared_ptr<ppc::core::TaskData> taskData_, std::function<func> f)
-      : Task(std::move(taskData_)), func_(f) {}
+      : Task(std::move(taskData_)), func_(std::move(f)) {}
 
   bool pre_processing() override;
   bool validation() override;
@@ -25,6 +26,6 @@ class RectangleMethodSequential : public ppc::core::Task {
   std::vector<int> distribution_;
   std::function<func> func_;
 
-  bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
+  static bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 };
 }  // namespace rezantseva_a_rectangle_method_seq

--- a/tasks/seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp
@@ -21,9 +21,9 @@ class RectangleMethodSequential : public ppc::core::Task {
 
  private:
   double result_{};
-  std::vector<std::pair<double, double>> integration_bounds_;  // Границы интегрирования
-  std::vector<int> distribution_;  // Разбиение (количество прямоугольников)
-  std::function<func> func_;       // Интегрируемая функция
+  std::vector<std::pair<double, double>> integration_bounds_;
+  std::vector<int> distribution_;
+  std::function<func> func_;
 
   bool check_integration_bounds(std::vector<std::pair<double, double>> *ib);
 };

--- a/tasks/seq/rezantseva_a_rectangle_method/perf_tests/main_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/perf_tests/main_rez_a.cpp
@@ -1,0 +1,133 @@
+// PERF_TEST_SEQ_RECTANGLE
+#include <gtest/gtest.h>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp"
+
+TEST(rezantseva_a_rectangle_method_seq, test_pipeline_run) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0] - 2 * x[1] + 8 * x[2];
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {-6, 10};
+  bounds[1] = {5, 27};
+  bounds[2] = {15, 32};
+  distrib[0] = 500;
+  distrib[1] = 250;
+  distrib[2] = 150;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  auto rectangleMethodSequential =
+      std::make_shared<rezantseva_a_rectangle_method_seq::RectangleMethodSequential>(taskDataSeq, function);
+
+  ASSERT_EQ(rectangleMethodSequential->validation(), true);
+  rectangleMethodSequential->pre_processing();
+  rectangleMethodSequential->run();
+  rectangleMethodSequential->post_processing();
+
+  // Create Perf
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(rectangleMethodSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  double error = 0.01;
+  ASSERT_NEAR(1085098.16, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}
+
+TEST(rezantseva_a_rectangle_method_seq, test_task_run) {
+  std::vector<double> out(1, 0);
+
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return x[0] * x[0] - 2 * x[1] + 8 * x[2];
+  };
+
+  int n = 3;
+  std::vector<std::pair<double, double>> bounds(n);
+  std::vector<int> distrib(n);
+
+  bounds[0] = {-6, 10};
+  bounds[1] = {5, 27};
+  bounds[2] = {15, 32};
+  distrib[0] = 500;
+  distrib[1] = 250;
+  distrib[2] = 150;
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  auto* bounds_data = new std::vector<std::pair<double, double>>(bounds);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(bounds_data));
+  taskDataSeq->inputs_count.emplace_back(bounds.size());
+
+  auto* distrib_data = new std::vector<int>(distrib);
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(distrib_data));
+  taskDataSeq->inputs_count.emplace_back(distrib.size());
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  auto rectangleMethodSequential =
+      std::make_shared<rezantseva_a_rectangle_method_seq::RectangleMethodSequential>(taskDataSeq, function);
+
+  ASSERT_EQ(rectangleMethodSequential->validation(), true);
+  rectangleMethodSequential->pre_processing();
+  rectangleMethodSequential->run();
+  rectangleMethodSequential->post_processing();
+
+  // Create Perf
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(rectangleMethodSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+
+  double error = 0.01;
+  ASSERT_NEAR(1085098.16, out[0], error);
+  delete bounds_data;
+  delete distrib_data;
+}

--- a/tasks/seq/rezantseva_a_rectangle_method/src/ops_seq_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/src/ops_seq_rez_a.cpp
@@ -18,9 +18,6 @@ bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::check_integra
 
 bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::validation() {
   internal_order_test();
-  // на вход два параметра (границы интегрирования, разбиение), на выход 1 результат
-  // количество разбиений равно количесвту границ
-  // нижняя граница интегрирования меньше верхней
 
   auto* bounds = reinterpret_cast<std::vector<std::pair<double, double>>*>(taskData->inputs[0]);
   return (taskData->inputs.size() == 2 && taskData->outputs_count[0] == 1 &&

--- a/tasks/seq/rezantseva_a_rectangle_method/src/ops_seq_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/src/ops_seq_rez_a.cpp
@@ -9,6 +9,7 @@ bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::check_integra
 
   for (const auto& bound : *ib) {
     if (bound.first >= bound.second) {
+      std::cout << "false";
       return false;
     }
   }
@@ -61,7 +62,7 @@ bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::run() {
     }
     result_ += func_(params);
   }
-  for (int i = 0; i < dimension; ++i) {
+  for (int i = 0; i < dimension; i++) {
     result_ *= widths[i];
   }
   return true;

--- a/tasks/seq/rezantseva_a_rectangle_method/src/ops_seq_rez_a.cpp
+++ b/tasks/seq/rezantseva_a_rectangle_method/src/ops_seq_rez_a.cpp
@@ -1,0 +1,74 @@
+#include "seq/rezantseva_a_rectangle_method/include/ops_seq_rez_a.hpp"
+
+bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::check_integration_bounds(
+    std::vector<std::pair<double, double>>* ib) {
+  if (ib == nullptr) {
+    std::cerr << "Error: bounds pointer is null." << std::endl;
+    return false;
+  }
+
+  for (const auto& bound : *ib) {
+    if (bound.first >= bound.second) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::validation() {
+  internal_order_test();
+  // на вход два параметра (границы интегрирования, разбиение), на выход 1 результат
+  // количество разбиений равно количесвту границ
+  // нижняя граница интегрирования меньше верхней
+
+  auto* bounds = reinterpret_cast<std::vector<std::pair<double, double>>*>(taskData->inputs[0]);
+  return (taskData->inputs.size() == 2 && taskData->outputs_count[0] == 1 &&
+          (taskData->inputs_count[0] == taskData->inputs_count[1]) && check_integration_bounds(bounds));
+}
+
+bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::pre_processing() {
+  internal_order_test();
+
+  auto* bounds = reinterpret_cast<std::vector<std::pair<double, double>>*>(taskData->inputs[0]);
+  integration_bounds_.assign(bounds->begin(), bounds->end());
+
+  auto* distribution_ptr = reinterpret_cast<std::vector<int>*>(taskData->inputs[1]);
+  distribution_.assign(distribution_ptr->begin(), distribution_ptr->end());
+
+  result_ = 0.0;
+
+  return true;
+}
+
+bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::run() {
+  internal_order_test();
+  int dimension = distribution_.size();
+  std::vector<double> widths(dimension);
+  int64_t rectangles = 1;
+
+  for (int i = 0; i < dimension; i++) {
+    widths[i] = (integration_bounds_[i].second - integration_bounds_[i].first) / static_cast<double>(distribution_[i]);
+    rectangles *= distribution_[i];
+  }
+  std::vector<double> params(dimension);
+
+  for (int i = 0; i < rectangles; i++) {
+    int x = i;
+    for (int j = 0; j < dimension; j++) {
+      int idDimention = x % distribution_[j];
+      params[j] = integration_bounds_[j].first + idDimention * widths[j] + widths[j] / 2;
+      x /= distribution_[j];
+    }
+    result_ += func_(params);
+  }
+  for (int i = 0; i < dimension; ++i) {
+    result_ *= widths[i];
+  }
+  return true;
+}
+
+bool rezantseva_a_rectangle_method_seq::RectangleMethodSequential::post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = result_;
+  return true;
+}


### PR DESCRIPTION
**Вычисление многомерных интегралов методом прямоугольников (метод Римана)**
Разбиваем область интегрирования на подотрезки, в которых вычисляем значения функции в центрах этих подотрезков и суммируем площади прямоугольников, чтобы получить приближенную площадь под кривой.

Каждый процесс вычисляет свою часть интеграла, обрабатывая определенное количество точек, и суммирует результаты в локальную переменную. Результаты всех процессов объединяются с помощью reduce, для получения общего результата интегрирования.
