### PR TITLE
Белов Артём. Задача 3. Вариант 19. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера..

### DIFF
--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -435,108 +435,6 @@ TEST(belov_a_radix_batcher_mergesort_mpi, test_positive_values_only) {
   }
 }
 
-TEST(belov_a_radix_batcher_mergesort_mpi, test_empty_input_validation_condition1) {
-  boost::mpi::communicator world;
-
-  // zero length, empty input
-  int n = 0;
-  vector<bigint> arr = {};
-
-  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
-
-  if (world.rank() == 0) {
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataPar->inputs_count.emplace_back(arr.size());
-    taskDataPar->inputs_count.emplace_back(n);
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataPar->outputs_count.emplace_back(arr.size());
-  }
-
-  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
-  EXPECT_FALSE(testMpiTaskParallel.validation());
-
-  if (world.rank() == 0) {
-    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
-    vector<bigint> solutionSeq(n);
-    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataSeq->inputs_count.emplace_back(arr.size());
-    taskDataSeq->inputs_count.emplace_back(n);
-    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
-    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
-
-    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
-    EXPECT_FALSE(testMpiTaskSeq.validation());
-  }
-}
-
-TEST(belov_a_radix_batcher_mergesort_mpi, test_empty_input_validation_condition2) {
-  boost::mpi::communicator world;
-
-  // declared length is 5, but empty input
-  int n = 5;
-  vector<bigint> arr = {};
-
-  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
-
-  if (world.rank() == 0) {
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataPar->inputs_count.emplace_back(arr.size());
-    taskDataPar->inputs_count.emplace_back(n);
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataPar->outputs_count.emplace_back(arr.size());
-  }
-
-  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
-  EXPECT_FALSE(testMpiTaskParallel.validation());
-
-  if (world.rank() == 0) {
-    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
-    vector<bigint> solutionSeq(n);
-    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataSeq->inputs_count.emplace_back(arr.size());
-    taskDataSeq->inputs_count.emplace_back(n);
-    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
-    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
-
-    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
-    EXPECT_FALSE(testMpiTaskSeq.validation());
-  }
-}
-
-TEST(belov_a_radix_batcher_mergesort_mpi, test_validation_condition3) {
-  boost::mpi::communicator world;
-
-  // declared length is not equal to real one
-  int n = 8;
-  vector<bigint> arr = {62584567, 0, -1953346};
-
-  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
-
-  if (world.rank() == 0) {
-    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataPar->inputs_count.emplace_back(arr.size());
-    taskDataPar->inputs_count.emplace_back(n);
-    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataPar->outputs_count.emplace_back(arr.size());
-  }
-
-  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
-  EXPECT_FALSE(testMpiTaskParallel.validation());
-
-  if (world.rank() == 0) {
-    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
-    vector<bigint> solutionSeq(n);
-    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-    taskDataSeq->inputs_count.emplace_back(arr.size());
-    taskDataSeq->inputs_count.emplace_back(n);
-    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
-    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
-
-    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
-    EXPECT_FALSE(testMpiTaskSeq.validation());
-  }
-}
-
 TEST(belov_a_radix_batcher_mergesort_mpi, test_one_element_input_array) {
   boost::mpi::communicator world;
 
@@ -575,5 +473,68 @@ TEST(belov_a_radix_batcher_mergesort_mpi, test_one_element_input_array) {
     testMpiTaskSeq.post_processing();
 
     EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_empty_input_validation_condition1) {
+  boost::mpi::communicator world;
+
+  // zero length, empty input
+  int n = 0;
+  vector<bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+
+    RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+    EXPECT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_empty_input_validation_condition2) {
+  boost::mpi::communicator world;
+
+  // declared length is 5, but empty input
+  int n = 5;
+  vector<bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+
+    RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+    EXPECT_FALSE(testMpiTaskParallel.validation());
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_validation_condition3) {
+  boost::mpi::communicator world;
+
+  // declared length is not equal to real one
+  int n = 8;
+  vector<bigint> arr = {62584567, 0, -1953346};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+
+    RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+    EXPECT_FALSE(testMpiTaskParallel.validation());
   }
 }

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -1,0 +1,579 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <random>
+#include <vector>
+
+#include "mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp"
+
+namespace belov_a_radix_batcher_mergesort_mpi {
+vector<bigint> generate_mixed_values_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+
+vector<bigint> generate_int_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+
+vector<bigint> generate_bigint_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<bigint> dist(numeric_limits<bigint>::min() / 2, numeric_limits<bigint>::max() / 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+}  // namespace belov_a_radix_batcher_mergesort_mpi
+
+using namespace belov_a_radix_batcher_mergesort_mpi;
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_random_small_mixedV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 1024;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_random_medium_mixedV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 8192;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_random_large_mixedV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 65536;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_random_small_bigintV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 1024;
+  vector<bigint> arr = generate_bigint_array(n);
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_random_medium_bigintV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 8192;
+  vector<bigint> arr = generate_bigint_array(n);
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_random_large_bigintV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 32768;
+  vector<bigint> arr = generate_bigint_array(n);
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_predefined_intV_vector) {
+  boost::mpi::communicator world;
+
+  int n = 13;
+  vector<bigint> arr = {-2147483648, 2147483647, -1000, 1001, 0, 124, -123, 42, -43, 2, -1, -999999, 999998};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_negative_values_only) {
+  boost::mpi::communicator world;
+
+  int n = 16;
+  vector<bigint> arr = {-5799507787,   -640070325,  -9553275362,  -6878351,     -8042130384, -8443056136,
+                        -2713654083,   -5467368930, -72261888,    -50054111267, -883621556,  -2780342973,
+                        -291923548343, -5485582439, -94518015487, -3833280574};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_positive_values_only) {
+  boost::mpi::communicator world;
+
+  int n = 9;
+  vector<bigint> arr = {7666729877,  20598172788, 7934137,    289,    627274651110,
+                        28942526990, 742923702,   3438922384, 7936973};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  ASSERT_EQ(testMpiTaskParallel.validation(), true);
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    ASSERT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_empty_input_validation_condition1) {
+  boost::mpi::communicator world;
+
+  // zero length, empty input
+  int n = 0;
+  vector<bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  EXPECT_FALSE(testMpiTaskParallel.validation());
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    EXPECT_FALSE(testMpiTaskSeq.validation());
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_empty_input_validation_condition2) {
+  boost::mpi::communicator world;
+
+  // declared length is 5, but empty input
+  int n = 5;
+  vector<bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  EXPECT_FALSE(testMpiTaskParallel.validation());
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    EXPECT_FALSE(testMpiTaskSeq.validation());
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_validation_condition3) {
+  boost::mpi::communicator world;
+
+  // declared length is not equal to real one
+  int n = 8;
+  vector<bigint> arr = {62584567, 0, -1953346};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  EXPECT_FALSE(testMpiTaskParallel.validation());
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    EXPECT_FALSE(testMpiTaskSeq.validation());
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_mpi, test_one_element_input_array) {
+  boost::mpi::communicator world;
+
+  int n = 1;
+  vector<bigint> arr = {64};
+
+  shared_ptr<ppc::core::TaskData> taskDataPar = make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  RadixBatcherMergesortParallel testMpiTaskParallel(taskDataPar);
+  EXPECT_TRUE(testMpiTaskParallel.validation());
+  testMpiTaskParallel.pre_processing();
+  testMpiTaskParallel.run();
+  testMpiTaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    RadixBatcherMergesortSequential testMpiTaskSeq(taskDataSeq);
+    EXPECT_TRUE(testMpiTaskSeq.validation());
+    testMpiTaskSeq.pre_processing();
+    testMpiTaskSeq.run();
+    testMpiTaskSeq.post_processing();
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
@@ -53,7 +53,7 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   bool run() override;
   bool post_processing() override;
 
-  void sort(vector<bigint>& arr);
+  static void sort(vector<bigint>& arr);
 
  private:
   vector<bigint> array;

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
@@ -34,13 +34,13 @@ class RadixBatcherMergesortParallel : public ppc::core::Task {
   vector<bigint> array;  // input unsorted numbers array
   int n = 0;             // array size
 
-  vector<bigint> merge(const vector<bigint>& arr1, const vector<bigint>& arr2);
-  void compare_and_swap(vector<int>& data, int i, int j);
+  static vector<bigint> merge(const vector<bigint>& arr1, const vector<bigint>& arr2);
+  static void compare_and_swap(vector<int>& data, int i, int j);
   void odd_even_merge(vector<int>& data, int low, int high);
 
   void radix_sort(vector<bigint>& arr, bool invert);
-  void counting_sort(vector<bigint>& arr, bigint digit_place);
-  int get_number_digit_capacity(bigint num);
+  static void counting_sort(vector<bigint>& arr, bigint digit_place);
+  static int get_number_digit_capacity(bigint num);
 };
 
 class RadixBatcherMergesortSequential : public ppc::core::Task {
@@ -60,8 +60,8 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   int n = 0;
 
   void radix_sort(vector<bigint>& arr, bool invert);
-  void counting_sort(vector<bigint>& arr, bigint digit_place);
-  int get_number_digit_capacity(bigint num);
+  static void counting_sort(vector<bigint>& arr, bigint digit_place);
+  static int get_number_digit_capacity(bigint num);
 };
 
 }  // namespace belov_a_radix_batcher_mergesort_mpi

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
@@ -1,0 +1,69 @@
+#ifndef OPS_MPI_HPP
+#define OPS_MPI_HPP
+
+#include <mpi.h>
+
+#include <algorithm>
+#include <boost/mpi.hpp>
+#include <boost/mpi/collectives.hpp>
+#include <boost/serialization/vector.hpp>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+using bigint = long long;
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_mpi {
+
+class RadixBatcherMergesortParallel : public ppc::core::Task {
+ public:
+  explicit RadixBatcherMergesortParallel(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+  void sort(vector<bigint>& arr);
+
+ private:
+  boost::mpi::communicator world;
+  vector<bigint> array;  // input unsorted numbers array
+  int n = 0;             // array size
+
+  vector<bigint> merge(const vector<bigint>& arr1, const vector<bigint>& arr2);
+  void compare_and_swap(vector<int>& data, int i, int j);
+  void odd_even_merge(vector<int>& data, int low, int high);
+
+  void radix_sort(vector<bigint>& arr, bool invert);
+  void counting_sort(vector<bigint>& arr, bigint digit_place);
+  int get_number_digit_capacity(bigint num);
+};
+
+class RadixBatcherMergesortSequential : public ppc::core::Task {
+ public:
+  explicit RadixBatcherMergesortSequential(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(std::move(taskData_)) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+  void sort(vector<bigint>& arr);
+
+ private:
+  vector<bigint> array;
+  int n = 0;
+
+  void radix_sort(vector<bigint>& arr, bool invert);
+  void counting_sort(vector<bigint>& arr, bigint digit_place);
+  int get_number_digit_capacity(bigint num);
+};
+
+}  // namespace belov_a_radix_batcher_mergesort_mpi
+
+#endif  // OPS_MPI_HPP

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp
@@ -27,7 +27,7 @@ class RadixBatcherMergesortParallel : public ppc::core::Task {
   bool run() override;
   bool post_processing() override;
 
-  void sort(vector<bigint>& arr);
+  static void sort(vector<bigint>& arr);
 
  private:
   boost::mpi::communicator world;
@@ -36,9 +36,9 @@ class RadixBatcherMergesortParallel : public ppc::core::Task {
 
   static vector<bigint> merge(const vector<bigint>& arr1, const vector<bigint>& arr2);
   static void compare_and_swap(vector<int>& data, int i, int j);
-  void odd_even_merge(vector<int>& data, int low, int high);
+  static vector<bigint> odd_even_merge(const vector<bigint>& left, const vector<bigint>& right);
 
-  void radix_sort(vector<bigint>& arr, bool invert);
+  static void radix_sort(vector<bigint>& arr, bool invert);
   static void counting_sort(vector<bigint>& arr, bigint digit_place);
   static int get_number_digit_capacity(bigint num);
 };
@@ -59,7 +59,7 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   vector<bigint> array;
   int n = 0;
 
-  void radix_sort(vector<bigint>& arr, bool invert);
+  static void radix_sort(vector<bigint>& arr, bool invert);
   static void counting_sort(vector<bigint>& arr, bigint digit_place);
   static int get_number_digit_capacity(bigint num);
 };

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -1,0 +1,188 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_mpi;
+
+namespace belov_a_radix_batcher_mergesort_mpi {
+vector<bigint> generate_mixed_values_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+
+vector<bigint> generate_int_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+
+vector<bigint> generate_bigint_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<bigint> dist(numeric_limits<bigint>::min() / 2, numeric_limits<bigint>::max() / 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+}  // namespace belov_a_radix_batcher_mergesort_mpi
+
+TEST(belov_a_radix_batcher_mergesort_perf_test, test_pipeline_run) {
+  boost::mpi::communicator world;
+
+  int n = 1048576;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  // Create Task
+  auto testMpiTaskParallel =
+      std::make_shared<belov_a_radix_batcher_mergesort_mpi::RadixBatcherMergesortParallel>(taskDataPar);
+
+  ASSERT_TRUE(testMpiTaskParallel->validation());
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    auto testMpiTaskSequential =
+        std::make_shared<belov_a_radix_batcher_mergesort_mpi::RadixBatcherMergesortSequential>(taskDataSeq);
+
+    ASSERT_TRUE(testMpiTaskSequential->validation());
+    testMpiTaskSequential->pre_processing();
+    testMpiTaskSequential->run();
+    testMpiTaskSequential->post_processing();
+
+    ppc::core::Perf::print_perf_statistic(perfResults);
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}
+
+TEST(belov_a_radix_batcher_mergesort_perf_test, test_task_run) {
+  boost::mpi::communicator world;
+
+  int n = 1048576;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataPar = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    taskDataPar->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->inputs_count.emplace_back(arr.size());
+    taskDataPar->inputs_count.emplace_back(n);
+    taskDataPar->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataPar->outputs_count.emplace_back(arr.size());
+  }
+
+  // Create Task
+  auto testMpiTaskParallel =
+      std::make_shared<belov_a_radix_batcher_mergesort_mpi::RadixBatcherMergesortParallel>(taskDataPar);
+
+  ASSERT_TRUE(testMpiTaskParallel->validation());
+  testMpiTaskParallel->pre_processing();
+  testMpiTaskParallel->run();
+  testMpiTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testMpiTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+    vector<bigint> solutionSeq(n);
+    taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+    taskDataSeq->inputs_count.emplace_back(arr.size());
+    taskDataSeq->inputs_count.emplace_back(n);
+    taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(solutionSeq.data()));
+    taskDataSeq->outputs_count.emplace_back(solutionSeq.size());
+
+    auto testMpiTaskSequential =
+        std::make_shared<belov_a_radix_batcher_mergesort_mpi::RadixBatcherMergesortSequential>(taskDataSeq);
+
+    ASSERT_TRUE(testMpiTaskSequential->validation());
+    testMpiTaskSequential->pre_processing();
+    testMpiTaskSequential->run();
+    testMpiTaskSequential->post_processing();
+
+    ppc::core::Perf::print_perf_statistic(perfResults);
+
+    EXPECT_EQ(arr, solutionSeq);
+  }
+}

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -120,8 +120,6 @@ TEST(belov_a_radix_batcher_mergesort_perf_test, test_pipeline_run) {
     testMpiTaskSequential->post_processing();
 
     ppc::core::Perf::print_perf_statistic(perfResults);
-
-    EXPECT_EQ(arr, solutionSeq);
   }
 }
 
@@ -182,7 +180,5 @@ TEST(belov_a_radix_batcher_mergesort_perf_test, test_task_run) {
     testMpiTaskSequential->post_processing();
 
     ppc::core::Perf::print_perf_statistic(perfResults);
-
-    EXPECT_EQ(arr, solutionSeq);
   }
 }

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/src/ops_mpi.cpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/src/ops_mpi.cpp
@@ -1,0 +1,321 @@
+#include "mpi/belov_a_radix_sort_with_batcher_mergesort/include/ops_mpi.hpp"
+
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/vector.hpp>
+
+#include "boost/mpi/detail/broadcast_sc.hpp"
+
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_mpi {
+
+int RadixBatcherMergesortParallel::get_number_digit_capacity(bigint num) {
+  return (num == 0 ? 1 : static_cast<int>(log10(abs(num))) + 1);
+}
+
+void RadixBatcherMergesortParallel::sort(vector<bigint>& arr) {
+  vector<bigint> pos, neg;
+
+  for (const auto& num : arr) {
+    (num >= 0 ? pos : neg).push_back(abs(num));
+  }
+
+  radix_sort(pos, false);
+  radix_sort(neg, true);
+
+  arr.clear();
+  arr.reserve(neg.size() + pos.size());
+  for (const auto& num : neg) arr.push_back(-num);
+  arr.insert(arr.end(), pos.begin(), pos.end());
+}
+
+void RadixBatcherMergesortParallel::radix_sort(vector<bigint>& arr, bool invert) {
+  if (arr.empty()) return;
+
+  bigint max_val = *std::max_element(arr.begin(), arr.end());
+  int max_val_digit_capacity = get_number_digit_capacity(max_val);
+  int iter = 1;
+
+  for (bigint digit_place = 1; iter <= max_val_digit_capacity; digit_place *= 10, ++iter) {
+    counting_sort(arr, digit_place);
+  }
+
+  if (invert) std::reverse(arr.begin(), arr.end());
+}
+
+void RadixBatcherMergesortParallel::counting_sort(vector<bigint>& arr, bigint digit_place) {
+  vector<bigint> output(arr.size());
+  int count[10] = {};
+
+  for (const auto& num : arr) {
+    bigint index = (num / digit_place) % 10;
+    count[index]++;
+  }
+
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+
+  for (int i = arr.size() - 1; i >= 0; i--) {
+    bigint num = arr[i];
+    bigint index = (num / digit_place) % 10;
+    output[--count[index]] = num;
+  }
+
+  std::copy(output.begin(), output.end(), arr.begin());
+}
+
+bool RadixBatcherMergesortParallel::pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    n = taskData->inputs_count[0];
+    auto* input_array_data = reinterpret_cast<bigint*>(taskData->inputs[0]);
+    array.assign(input_array_data, input_array_data + n);
+  }
+  return true;
+}
+
+bool RadixBatcherMergesortParallel::validation() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    return (taskData->inputs.size() == 1 && !(taskData->inputs_count.size() < 2) && taskData->inputs_count[0] != 0 &&
+            (taskData->inputs_count[0] == taskData->inputs_count[1]) && !taskData->outputs.empty());
+  }
+  return true;
+}
+
+vector<int> calculate_sizes(size_t input_size, size_t num_proc) {
+  size_t count = input_size / num_proc;
+  size_t mod = input_size % num_proc;
+  vector<int> sizes(num_proc, count);
+
+  transform(sizes.cbegin(), sizes.cbegin() + mod, sizes.begin(), [](auto i) { return i + 1; });
+
+  return sizes;
+}
+
+vector<int> calculate_displ(size_t input_size, size_t num_proc) {
+  auto sizes = calculate_sizes(input_size, num_proc);
+  vector<int> displ(num_proc, 0);
+
+  for (size_t i = 1; i < num_proc; ++i) {
+    displ[i] = displ[i - 1] + sizes[i - 1];
+  }
+  return displ;
+}
+
+vector<bigint> RadixBatcherMergesortParallel::merge(const vector<bigint>& arr1, const vector<bigint>& arr2) {
+  vector<bigint> merged;
+  merged.reserve(arr1.size() + arr2.size());
+
+  size_t i = 0, j = 0;
+
+  while (i < arr1.size() && j < arr2.size()) {
+    if (arr1[i] <= arr2[j]) {
+      merged.push_back(arr1[i++]);
+    } else {
+      merged.push_back(arr2[j++]);
+    }
+  }
+
+  while (i < arr1.size()) {
+    merged.push_back(arr1[i++]);
+  }
+
+  while (j < arr2.size()) {
+    merged.push_back(arr2[j++]);
+  }
+
+  return merged;
+}
+
+void RadixBatcherMergesortParallel::compare_and_swap(vector<int>& data, int i, int j) {
+  if (data[i] > data[j]) {
+    std::swap(data[i], data[j]);
+  }
+}
+
+void RadixBatcherMergesortParallel::odd_even_merge(vector<int>& data, int low, int high) {
+  int size = high - low + 1;
+  if (size <= 1) return;
+  int mid = size / 2;
+
+  odd_even_merge(data, low, low + mid - 1);
+  odd_even_merge(data, low + mid, high);
+
+  for (int i = low; i + mid <= high; ++i) {
+    compare_and_swap(data, i, i + mid);
+  }
+}
+
+bool RadixBatcherMergesortParallel::run() {
+  internal_order_test();
+  boost::mpi::broadcast(world, n, 0);
+
+  int power_of_2 = 1;
+  while (power_of_2 * 2 <= world.size()) {
+    power_of_2 *= 2;
+  }
+
+  const bool participating = world.rank() < power_of_2;
+
+  if (!participating) {
+    world.split(1);
+    return true;
+  }
+
+  auto com = world.split(0);
+  const int rank = com.rank();
+  const int com_size = com.size();
+
+  vector<bigint> local_data;
+
+  vector<int> sizes(power_of_2);
+  vector<int> displ(power_of_2);
+
+  if (com.rank() == 0) {
+    sizes = calculate_sizes(n, power_of_2);
+    displ = calculate_displ(n, power_of_2);
+
+    local_data.resize(sizes[0]);
+    local_data.assign(array.begin(), array.begin() + sizes[0]);
+    boost::mpi::scatterv(com, array, sizes, displ, local_data.data(), local_data.size(), 0);
+  } else {
+    int cur_size = rank < n % com_size ? (n / com_size + 1) : (n / com_size);
+    local_data.resize(cur_size);
+    boost::mpi::scatterv(com, local_data.data(), cur_size, 0);
+  }
+
+  sort(local_data);
+
+  for (int step = 0; step < com.size(); ++step) {
+    if ((step + com.rank()) % 2 == 0) {
+      if (com.rank() < com.size() - 1) {
+        vector<bigint> neighbor_data;
+        world.send(world.rank() + 1, 0, local_data);
+        world.recv(world.rank() + 1, 0, neighbor_data);
+        local_data = merge(local_data, neighbor_data);
+      }
+    } else {
+      if (com.rank() > 0) {
+        vector<bigint> neighbor_data;
+        world.recv(world.rank() - 1, 0, neighbor_data);
+        world.send(world.rank() - 1, 0, local_data);
+        local_data = merge(neighbor_data, local_data);
+      }
+    }
+  }
+
+  if (com.rank() == 0) {
+    array.clear();
+    array.insert(array.begin(), local_data.begin(), local_data.end());
+    for (int i = 1; i < com.size(); i++) {
+      com.recv(i, 1, local_data);
+      array.insert(array.end(), local_data.begin(), local_data.end());
+    }
+  } else {
+    com.send(0, 1, local_data);
+  }
+
+  return true;
+}
+
+bool RadixBatcherMergesortParallel::post_processing() {
+  internal_order_test();
+  if (world.rank() == 0) {
+    copy(array.begin(), array.begin() + n, reinterpret_cast<bigint*>(taskData->outputs[0]));
+  }
+
+  return true;
+}
+
+int RadixBatcherMergesortSequential::get_number_digit_capacity(bigint num) {
+  return (num == 0 ? 1 : static_cast<int>(log10(abs(num))) + 1);
+}
+
+void RadixBatcherMergesortSequential::sort(vector<bigint>& arr) {
+  vector<bigint> pos, neg;
+
+  for (const auto& num : arr) {
+    (num >= 0 ? pos : neg).push_back(abs(num));
+  }
+
+  radix_sort(pos, false);
+  radix_sort(neg, true);
+
+  arr.clear();
+  arr.reserve(neg.size() + pos.size());
+  for (const auto& num : neg) arr.push_back(-num);
+  arr.insert(arr.end(), pos.begin(), pos.end());
+}
+
+void RadixBatcherMergesortSequential::radix_sort(vector<bigint>& arr, bool invert) {
+  if (arr.empty()) return;
+
+  bigint max_val = *std::max_element(arr.begin(), arr.end());
+  int max_val_digit_capacity = get_number_digit_capacity(max_val);
+  int iter = 1;
+
+  for (bigint digit_place = 1; iter <= max_val_digit_capacity; digit_place *= 10, ++iter) {
+    counting_sort(arr, digit_place);
+  }
+
+  if (invert) std::reverse(arr.begin(), arr.end());
+}
+
+void RadixBatcherMergesortSequential::counting_sort(vector<bigint>& arr, bigint digit_place) {
+  vector<bigint> output(arr.size());
+  int count[10] = {};
+
+  for (const auto& num : arr) {
+    bigint index = (num / digit_place) % 10;
+    count[index]++;
+  }
+
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+
+  for (int i = arr.size() - 1; i >= 0; i--) {
+    bigint num = arr[i];
+    bigint index = (num / digit_place) % 10;
+    output[--count[index]] = num;
+  }
+
+  std::copy(output.begin(), output.end(), arr.begin());
+}
+
+bool RadixBatcherMergesortSequential::pre_processing() {
+  internal_order_test();
+
+  n = taskData->inputs_count[0];
+  auto* input_array_data = reinterpret_cast<bigint*>(taskData->inputs[0]);
+  array.assign(input_array_data, input_array_data + n);
+
+  return true;
+}
+
+bool RadixBatcherMergesortSequential::validation() {
+  internal_order_test();
+
+  return (taskData->inputs.size() == 1 && !(taskData->inputs_count.size() < 2) && taskData->inputs_count[0] != 0 &&
+          (taskData->inputs_count[0] == taskData->inputs_count[1]) && !taskData->outputs.empty());
+}
+
+bool RadixBatcherMergesortSequential::run() {
+  internal_order_test();
+
+  sort(array);
+  return true;
+}
+
+bool RadixBatcherMergesortSequential::post_processing() {
+  internal_order_test();
+
+  copy(array.begin(), array.end(), reinterpret_cast<bigint*>(taskData->outputs[0]));
+  return true;
+}
+
+}  // namespace belov_a_radix_batcher_mergesort_mpi

--- a/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/src/ops_mpi.cpp
+++ b/tasks/mpi/belov_a_radix_sort_with_batcher_mergesort/src/ops_mpi.cpp
@@ -14,7 +14,8 @@ int RadixBatcherMergesortParallel::get_number_digit_capacity(bigint num) {
 }
 
 void RadixBatcherMergesortParallel::sort(vector<bigint>& arr) {
-  vector<bigint> pos, neg;
+  vector<bigint> pos;
+  vector<bigint> neg;
 
   for (const auto& num : arr) {
     (num >= 0 ? pos : neg).push_back(abs(num));
@@ -110,7 +111,8 @@ vector<bigint> RadixBatcherMergesortParallel::merge(const vector<bigint>& arr1, 
   vector<bigint> merged;
   merged.reserve(arr1.size() + arr2.size());
 
-  size_t i = 0, j = 0;
+  size_t i = 0;
+  size_t j = 0;
 
   while (i < arr1.size() && j < arr2.size()) {
     if (arr1[i] <= arr2[j]) {
@@ -236,7 +238,8 @@ int RadixBatcherMergesortSequential::get_number_digit_capacity(bigint num) {
 }
 
 void RadixBatcherMergesortSequential::sort(vector<bigint>& arr) {
-  vector<bigint> pos, neg;
+  vector<bigint> pos;
+  vector<bigint> neg;
 
   for (const auto& num : arr) {
     (num >= 0 ? pos : neg).push_back(abs(num));

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -1,0 +1,379 @@
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_seq;
+
+namespace belov_a_radix_batcher_mergesort_seq {
+vector<bigint> generate_mixed_values_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+
+vector<bigint> generate_int_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+
+vector<bigint> generate_bigint_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<bigint> dist(numeric_limits<bigint>::min() / 2, numeric_limits<bigint>::max() / 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+}  // namespace belov_a_radix_batcher_mergesort_seq
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_bigintV_vector) {
+  int n = 1024;
+  vector<bigint> arr = generate_bigint_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_bigintV_vector) {
+  int n = 32768;
+  vector<bigint> arr = generate_bigint_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_bigintV_vector) {
+  int n = 1048576;
+  vector<bigint> arr = generate_bigint_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_intV_vector) {
+  int n = 1024;
+  vector<bigint> arr = generate_int_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_intV_vector) {
+  int n = 32768;
+  vector<bigint> arr = generate_int_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_intV_vector) {
+  int n = 1048576;
+  vector<bigint> arr = generate_int_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_mixedV_vector) {
+  int n = 2048;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_mixedV_vector) {
+  int n = 65536;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_mixedV_vector) {
+  int n = 2097152;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_predefined_intV_vector) {
+  int n = 16;
+  vector<bigint> arr = {74685421,  -53749, 2147483647, -1000, -2147483648, 1001, 0,       124,
+                        315986930, -123,   42,         -43,   2,           -1,   -999999, 999998};
+
+  vector<bigint> expected_solution = arr;
+  std::sort(expected_solution.begin(), expected_solution.end());
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_one_element_input_bigint) {
+  int n = 1;
+  vector<bigint> arr = {8888};
+
+  vector<bigint> expected_solution = arr;
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+  ASSERT_EQ(testTaskSequential.validation(), true);
+  testTaskSequential.pre_processing();
+  testTaskSequential.run();
+  testTaskSequential.post_processing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_array_size_missmatch) {
+  int n = 3;
+  vector<bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+
+  ASSERT_FALSE(testTaskSequential.validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_invalid_inputs_count) {
+  int n = 3;
+  vector<bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  // taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+
+  ASSERT_FALSE(testTaskSequential.validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_empty_input_validation) {
+  int n = 0;
+  vector<bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+
+  ASSERT_FALSE(testTaskSequential.validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_empty_output_validation) {
+  int n = 3;
+  vector<bigint> arr = {789, 654, 231, 0, 123456789, 792012345678, -22475942, -853960, 59227648};
+
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  // taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
+
+  ASSERT_FALSE(testTaskSequential.validation());
+}

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -108,7 +108,7 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_bigintV_vector) {
 }
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_bigintV_vector) {
-  int n = 1048576;
+  int n = 524288;
   vector<bigint> arr = generate_bigint_array(n);
 
   vector<bigint> expected_solution = arr;
@@ -177,7 +177,7 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_intV_vector) {
 }
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_intV_vector) {
-  int n = 1048576;
+  int n = 524288;
   vector<bigint> arr = generate_int_array(n);
 
   vector<bigint> expected_solution = arr;
@@ -246,7 +246,7 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_mixedV_vector) {
 }
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_mixedV_vector) {
-  int n = 2097152;
+  int n = 524288;
   vector<bigint> arr = generate_mixed_values_array(n);
 
   vector<bigint> expected_solution = arr;
@@ -327,7 +327,7 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_array_size_missmatch) {
 
   RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
 
-  ASSERT_FALSE(testTaskSequential.validation());
+  EXPECT_FALSE(testTaskSequential.validation());
 }
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_invalid_inputs_count) {
@@ -343,7 +343,7 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_invalid_inputs_count) {
 
   RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
 
-  ASSERT_FALSE(testTaskSequential.validation());
+  EXPECT_FALSE(testTaskSequential.validation());
 }
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_empty_input_validation) {
@@ -359,7 +359,7 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_empty_input_validation) {
 
   RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
 
-  ASSERT_FALSE(testTaskSequential.validation());
+  EXPECT_FALSE(testTaskSequential.validation());
 }
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_empty_output_validation) {
@@ -375,5 +375,5 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_empty_output_validation) {
 
   RadixBatcherMergesortSequential testTaskSequential(taskDataSeq);
 
-  ASSERT_FALSE(testTaskSequential.validation());
+  EXPECT_FALSE(testTaskSequential.validation());
 }

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -1,0 +1,41 @@
+#ifndef OPS_SEQ_HPP
+#define OPS_SEQ_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+using bigint = long long;
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_seq {
+
+class RadixBatcherMergesortSequential : public ppc::core::Task {
+ public:
+  explicit RadixBatcherMergesortSequential(std::shared_ptr<ppc::core::TaskData> taskData_)
+      : Task(std::move(taskData_)) {}
+
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+  void sort(vector<bigint>& arr);
+
+ private:
+  vector<bigint> array;  // input unsorted numbers array
+  int n = 0;             // array size
+
+  void radix_sort(vector<bigint>& arr, bool invert);
+  void counting_sort(vector<bigint>& arr, bigint digit_place);
+  int get_number_digit_capacity(bigint num);
+};
+
+}  // namespace belov_a_radix_batcher_mergesort_seq
+
+#endif  // OPS_SEQ_HPP

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -25,7 +25,7 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   bool run() override;
   bool post_processing() override;
 
-  void sort(vector<bigint>& arr);
+  static void sort(vector<bigint>& arr);
 
  private:
   vector<bigint> array;  // input unsorted numbers array

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -31,7 +31,7 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   vector<bigint> array;  // input unsorted numbers array
   int n = 0;             // array size
 
-  void radix_sort(vector<bigint>& arr, bool invert);
+  void static radix_sort(vector<bigint>& arr, bool invert);
   static void counting_sort(vector<bigint>& arr, bigint digit_place);
   static int get_number_digit_capacity(bigint num);
 };

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -32,8 +32,8 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   int n = 0;             // array size
 
   void radix_sort(vector<bigint>& arr, bool invert);
-  void counting_sort(vector<bigint>& arr, bigint digit_place);
-  int get_number_digit_capacity(bigint num);
+  static void counting_sort(vector<bigint>& arr, bigint digit_place);
+  static int get_number_digit_capacity(bigint num);
 };
 
 }  // namespace belov_a_radix_batcher_mergesort_seq

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -1,0 +1,147 @@
+#include <gtest/gtest.h>
+
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_seq;
+
+namespace belov_a_radix_batcher_mergesort_seq {
+vector<bigint> generate_mixed_values_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+
+vector<bigint> generate_int_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+
+vector<bigint> generate_bigint_array(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<bigint> dist(numeric_limits<bigint>::min() / 2, numeric_limits<bigint>::max() / 2);
+
+  vector<bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+}  // namespace belov_a_radix_batcher_mergesort_seq
+
+TEST(belov_a_radix_batcher_mergesort_perf_test, test_pipeline_run) {
+  // Create data
+  int n = 1048576;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  // Create TaskData
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  // Create Task
+  auto testTaskSequential =
+      std::make_shared<belov_a_radix_batcher_mergesort_seq::RadixBatcherMergesortSequential>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  ASSERT_TRUE(testTaskSequential->validation());
+  testTaskSequential->pre_processing();
+  testTaskSequential->run();
+  testTaskSequential->post_processing();
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}
+
+TEST(belov_a_radix_batcher_mergesort_perf_test, test_task_run) {
+  // Create data
+  int n = 1048576;
+  vector<bigint> arr = generate_mixed_values_array(n);
+
+  // Create TaskData
+  shared_ptr<ppc::core::TaskData> taskDataSeq = make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  taskDataSeq->inputs_count.emplace_back(arr.size());
+  taskDataSeq->inputs_count.emplace_back(n);
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  taskDataSeq->outputs_count.emplace_back(arr.size());
+
+  // Create Task
+  auto testTaskSequential =
+      std::make_shared<belov_a_radix_batcher_mergesort_seq::RadixBatcherMergesortSequential>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  ASSERT_TRUE(testTaskSequential->validation());
+  testTaskSequential->pre_processing();
+  testTaskSequential->run();
+  testTaskSequential->post_processing();
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+}

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
@@ -8,7 +8,8 @@ int RadixBatcherMergesortSequential::get_number_digit_capacity(bigint num) {
 }
 
 void RadixBatcherMergesortSequential::sort(vector<bigint>& arr) {
-  vector<bigint> pos, neg;
+  vector<bigint> pos;
+  vector<bigint> neg;
 
   for (const auto& num : arr) {
     (num >= 0 ? pos : neg).push_back(abs(num));

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
@@ -1,0 +1,93 @@
+#include "seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp"
+
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_seq {
+int RadixBatcherMergesortSequential::get_number_digit_capacity(bigint num) {
+  return (num == 0 ? 1 : static_cast<int>(log10(abs(num))) + 1);
+}
+
+void RadixBatcherMergesortSequential::sort(vector<bigint>& arr) {
+  vector<bigint> pos, neg;
+
+  for (const auto& num : arr) {
+    (num >= 0 ? pos : neg).push_back(abs(num));
+  }
+
+  radix_sort(pos, false);
+  radix_sort(neg, true);
+
+  arr.clear();
+  arr.reserve(neg.size() + pos.size());
+  for (const auto& num : neg) arr.push_back(-num);
+  arr.insert(arr.end(), pos.begin(), pos.end());
+}
+
+void RadixBatcherMergesortSequential::radix_sort(vector<bigint>& arr, bool invert) {
+  if (arr.empty()) return;
+
+  bigint max_val = *std::max_element(arr.begin(), arr.end());
+  int max_val_digit_capacity = get_number_digit_capacity(max_val);
+  int iter = 1;
+
+  for (bigint digit_place = 1; iter <= max_val_digit_capacity; digit_place *= 10, ++iter) {
+    counting_sort(arr, digit_place);
+  }
+
+  if (invert) std::reverse(arr.begin(), arr.end());
+}
+
+void RadixBatcherMergesortSequential::counting_sort(vector<bigint>& arr, bigint digit_place) {
+  vector<bigint> output(arr.size());
+  int count[10] = {};
+
+  for (const auto& num : arr) {
+    bigint index = (num / digit_place) % 10;
+    count[index]++;
+  }
+
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+
+  for (int i = arr.size() - 1; i >= 0; i--) {
+    bigint num = arr[i];
+    bigint index = (num / digit_place) % 10;
+    output[--count[index]] = num;
+  }
+
+  std::copy(output.begin(), output.end(), arr.begin());
+}
+
+bool RadixBatcherMergesortSequential::pre_processing() {
+  internal_order_test();
+
+  n = taskData->inputs_count[0];
+  auto* input_array_data = reinterpret_cast<bigint*>(taskData->inputs[0]);
+  array.assign(input_array_data, input_array_data + n);
+
+  return true;
+}
+
+bool RadixBatcherMergesortSequential::validation() {
+  internal_order_test();
+
+  return (taskData->inputs.size() == 1 && !(taskData->inputs_count.size() < 2) && taskData->inputs_count[0] != 0 &&
+          (taskData->inputs_count[0] == taskData->inputs_count[1]) && !taskData->outputs.empty());
+}
+
+bool RadixBatcherMergesortSequential::run() {
+  internal_order_test();
+
+  sort(array);
+  return true;
+}
+
+bool RadixBatcherMergesortSequential::post_processing() {
+  internal_order_test();
+
+  copy(array.begin(), array.end(), reinterpret_cast<bigint*>(taskData->outputs[0]));
+  return true;
+}
+
+}  // namespace belov_a_radix_batcher_mergesort_seq


### PR DESCRIPTION
## Описание последовательной реализации

Последовательная реализация задачи включает только этап поразрядной сортировки (Radix Sort) для целых чисел.  

1. **Поразрядная сортировка (Radix Sort):**  
   С помощью `std::max_element` получаем наибольший элемент массива для определения его разрядности, после чего выполняется сортировка подсчётом для каждого разряда. В качестве типа данных для целых чисел используется `bigint`, фактически представляющий собой `long long`. Это допущение сделано для предотвращения переполнения и расширения диапазона поддерживаемых значений, что позволяет работать с большими числами.  

2. **Особенности работы с отрицательными числами:**  
   Отрицательные числа предварительно инвертируются и сортируются, а затем записываются в обратном порядке с восстановлением знака. Такой подход позволяет использовать единый алгоритм обработки массива независимо от типа чисел.

### Допущения:
- Алгоритм поддерживает работу с массивами любой длины.  
- Использование `bigint` позволяет избежать проблем с переполнением диапазона целых чисел.  
- Чётно-нечётное слияние Бэтчера является алгоритмом параллельной сортировки, поэтому в SEQ версии не используется.

---

## Описание MPI реализации

Параллельная версия задачи использует библиотеку Boost.MPI для распределения данных между процессами и выполнения чётно-нечётного слияния Бэтчера.

1. **Распределение данных:**  
   Входной массив делится на части и распределяется между процессами. Распределение данных выполняется таким образом, чтобы количество процессов (`n`) соответствовало ближайшей левой степени двойки, не превышающей длину массива. Это оптимально для работы алгоритма слияния. Размеры частей и их смещения рассчитываются с помощью функций `calculate_sizes` и `calculate_displ`.

2. **Локальная поразрядная сортировка:**  
   Каждый процесс выполняет локальную поразрядную сортировку своей части массива аналогично последовательной версии. 

3. **Чётно-нечётное слияние Бэтчера:**  
   После локальной сортировки корневой процесс собирает данные от остальных процессов с использованием `Odd-Even Batcher's mergesort`. 

4. **Сбор данных:**  
   После завершения всех этапов слияния каждый процесс отправляет свою отсортированную часть данных корневому процессу. Корневой процесс поочерёдно получает данные от остальных процессов и объединяет их в результирующий массив. Отправка и приём данных осуществляется с помощью функций `send` и `recv` библиотеки MPI.


### Допущения:
- Поддержка работы с отрицательными числами реализована аналогично последовательной версии.  
- Алгоритм рассчитан на распределение данных между процессами с учётом ограничения на степень двойки. 