### PR TITLE
[Fix revert] Калякина Анастасия. Задача 3. Вариант 8. Вычисление многомерных интегралов с использованием многошаговой схемы (метод трапеций).

### DIFF
--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/func_tests/main.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/func_tests/main.cpp
@@ -16,8 +16,7 @@ double function5(std::vector<double> input) { return -(sin(input[0]) * cos(input
 double function6(std::vector<double> input) { return (-3 * pow(input[1], 2) * sin(5 * input[0])) / 2; };
 
 void TestOfValidation(double (*function)(std::vector<double>), std::vector<unsigned int>& count,
-                      std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals,
-                      double answer) {
+                      std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals) {
   boost::mpi::communicator world;
 
   std::vector<double> out(1, 0.0);
@@ -89,8 +88,7 @@ TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_count_of_variab
     count = std::vector<unsigned int>{3};
   }
 
-  TestOfValidation(function1, count, limits, intervals,
-                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+  TestOfValidation(function1, count, limits, intervals);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_size_numbers_of_intervals) {
@@ -106,8 +104,7 @@ TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_size_numbers_of
     count = std::vector<unsigned int>{2};
   }
 
-  TestOfValidation(function1, count, limits, intervals,
-                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+  TestOfValidation(function1, count, limits, intervals);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_size_limits) {
@@ -123,8 +120,7 @@ TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_size_limits) {
     count = std::vector<unsigned int>{2};
   }
 
-  TestOfValidation(function1, count, limits, intervals,
-                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+  TestOfValidation(function1, count, limits, intervals);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_1) {

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/func_tests/main.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/func_tests/main.cpp
@@ -1,0 +1,225 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <cmath>
+#include <vector>
+
+#include "mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp"
+
+double function1(std::vector<double> input) { return pow(input[0], 3) + pow(input[1], 3); };
+double function2(std::vector<double> input) { return sin(input[0]) + sin(input[1]) + sin(input[2]); };
+double function3(std::vector<double> input) { return 8 * input[0] * input[1] * input[2]; };
+double function4(std::vector<double> input) { return -1.0 / sqrt(1 - pow(input[0], 2)); };
+double function5(std::vector<double> input) { return -(sin(input[0]) * cos(input[1])); };
+double function6(std::vector<double> input) { return (-3 * pow(input[1], 2) * sin(5 * input[0])) / 2; };
+
+void TestOfValidation(double (*function)(std::vector<double>), std::vector<unsigned int>& count,
+                      std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals,
+                      double answer) {
+  boost::mpi::communicator world;
+
+  std::vector<double> out(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataParallel = std::make_shared<ppc::core::TaskData>();
+
+  // Create TaskData
+
+  if (world.rank() == 0) {
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+    taskDataParallel->inputs_count.emplace_back(count.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+    taskDataParallel->inputs_count.emplace_back(limits.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+    taskDataParallel->inputs_count.emplace_back(intervals.size());
+    taskDataParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataParallel->outputs_count.emplace_back(out.size());
+  }
+
+  kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel TaskParallel(taskDataParallel, function);
+  if (world.rank() == 0) {
+    ASSERT_EQ(TaskParallel.validation(), false);
+  }
+}
+
+void TestOfFunction(double (*function)(std::vector<double>), std::vector<unsigned int>& count,
+                    std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals,
+                    double answer) {
+  boost::mpi::communicator world;
+
+  std::vector<double> out(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> taskDataParallel = std::make_shared<ppc::core::TaskData>();
+
+  // Create TaskData
+
+  if (world.rank() == 0) {
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+    taskDataParallel->inputs_count.emplace_back(count.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+    taskDataParallel->inputs_count.emplace_back(limits.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+    taskDataParallel->inputs_count.emplace_back(intervals.size());
+    taskDataParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataParallel->outputs_count.emplace_back(out.size());
+  }
+
+  kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel TaskParallel(taskDataParallel, function);
+  ASSERT_EQ(TaskParallel.validation(), true);
+  TaskParallel.pre_processing();
+  TaskParallel.run();
+  TaskParallel.post_processing();
+
+  if (world.rank() == 0) {
+    EXPECT_NEAR(answer, out[0], 0.001);
+  }
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_count_of_variables) {
+  boost::mpi::communicator world;
+
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+  std::vector<unsigned int> count;
+
+  if (world.rank() == 0) {
+    limits = {{2.5, 4.5}, {1.0, 3.2}};
+    intervals = {1000, 1000};
+    count = std::vector<unsigned int>{3};
+  }
+
+  TestOfValidation(function1, count, limits, intervals,
+                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_size_numbers_of_intervals) {
+  boost::mpi::communicator world;
+
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+  std::vector<unsigned int> count;
+
+  if (world.rank() == 0) {
+    limits = {{2.5, 4.5}, {1.0, 3.2}};
+    intervals = {1000};
+    count = std::vector<unsigned int>{2};
+  }
+
+  TestOfValidation(function1, count, limits, intervals,
+                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_validation_size_limits) {
+  boost::mpi::communicator world;
+
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+  std::vector<unsigned int> count;
+
+  if (world.rank() == 0) {
+    limits = {{2.5, 4.5}};
+    intervals = {1000, 1000};
+    count = std::vector<unsigned int>{2};
+  }
+
+  TestOfValidation(function1, count, limits, intervals,
+                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_1) {
+  boost::mpi::communicator world;
+
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+  std::vector<unsigned int> count;
+
+  if (world.rank() == 0) {
+    limits = {{2.5, 4.5}, {1.0, 3.2}};
+    intervals = {1000, 1000};
+    count = std::vector<unsigned int>{2};
+  }
+
+  TestOfFunction(function1, count, limits, intervals,
+                 (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_2) {
+  boost::mpi::communicator world;
+
+  std::vector<unsigned int> count;
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+
+  if (world.rank() == 0) {
+    count = std::vector<unsigned int>{3};
+    limits = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+    intervals = {100, 100, 100};
+  }
+
+  TestOfFunction(function2, count, limits, intervals, -3 * std::cos(1) + 3 * std::cos(0));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_3) {
+  boost::mpi::communicator world;
+
+  std::vector<unsigned int> count;
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+
+  if (world.rank() == 0) {
+    count = std::vector<unsigned int>{3};
+    limits = {{0.0, 3.0}, {0.0, 4.0}, {0.0, 5.0}};
+    intervals = {100, 100, 100};
+  }
+
+  TestOfFunction(function3, count, limits, intervals, pow(3 - 0, 2) * pow(4 - 0, 2) * pow(5 - 0, 2));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_4) {
+  boost::mpi::communicator world;
+
+  std::vector<unsigned int> count;
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+
+  if (world.rank() == 0) {
+    count = std::vector<unsigned int>{1};
+    limits = {{0.0, 0.5}};
+    intervals = {10000};
+  }
+
+  TestOfFunction(function4, count, limits, intervals, acos(0.5) - acos(0));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_5) {
+  boost::mpi::communicator world;
+
+  std::vector<unsigned int> count;
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+
+  if (world.rank() == 0) {
+    count = std::vector<unsigned int>{2};
+    limits = {{0.0, 1.0}, {0.0, 1.0}};
+    intervals = {1000, 1000};
+  }
+
+  TestOfFunction(function5, count, limits, intervals, (sin(1) - sin(0)) * (cos(1) - cos(0)));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_6) {
+  boost::mpi::communicator world;
+
+  std::vector<unsigned int> count;
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+
+  if (world.rank() == 0) {
+    count = std::vector<unsigned int>{2};
+    limits = {{0.0, 1.0}, {4.0, 6.0}};
+    intervals = {1000, 1000};
+  }
+
+  TestOfFunction(function6, count, limits, intervals, (pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10);
+}

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/func_tests/main.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/func_tests/main.cpp
@@ -288,7 +288,7 @@ TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_random_inter
   if (world.rank() == 0) {
     count = std::vector<unsigned int>{2};
     limits = {{0.0, 1.0}, {4.0, 6.0}};
-    intervals = {GetRandomIntegerData(100, 200), GetRandomIntegerData(100, 200)};
+    intervals = {GetRandomIntegerData(100, 150), GetRandomIntegerData(100, 150)};
   }
 
   TestOfFunction(function6, count, limits, intervals);
@@ -304,7 +304,7 @@ TEST(kalyakina_a_trapezoidal_integration_mpi, Test_of_functionality_random_limit
   if (world.rank() == 0) {
     count = std::vector<unsigned int>{3};
     limits = {GetRandomLimit(0.0, 10.0), GetRandomLimit(0.0, 10.0), GetRandomLimit(0.0, 10.0)};
-    intervals = {GetRandomIntegerData(50, 80), GetRandomIntegerData(50, 80), GetRandomIntegerData(50, 80)};
+    intervals = {GetRandomIntegerData(40, 60), GetRandomIntegerData(40, 60), GetRandomIntegerData(40, 60)};
   }
 
   TestOfFunction(function3, count, limits, intervals);

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp
@@ -17,6 +17,27 @@
 
 namespace kalyakina_a_trapezoidal_integration_mpi {
 
+class TrapezoidalIntegrationTaskSequential : public ppc::core::Task {
+  unsigned int CalculationOfCoefficient(const std::vector<double>& point);
+  void Recursive(std::vector<double>& _point, unsigned int& definition, unsigned int divider, unsigned int variable);
+  std::vector<double> GetPointFromNumber(unsigned int number);
+
+ public:
+  explicit TrapezoidalIntegrationTaskSequential(std::shared_ptr<ppc::core::TaskData> taskData_,
+                                                double (*_function)(std::vector<double>))
+      : Task(std::move(taskData_)), function(_function) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  double (*function)(std::vector<double>);
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> number_of_intervals;
+  double result;
+};
+
 class TrapezoidalIntegrationTaskParallel : public ppc::core::Task {
   unsigned int CalculationOfCoefficient(const std::vector<double>& point);
   void Recursive(std::vector<double>& _point, unsigned int& definition, unsigned int divider, unsigned int variable);

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp
@@ -1,0 +1,43 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
+#include <cmath>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kalyakina_a_trapezoidal_integration_mpi {
+
+class TrapezoidalIntegrationTaskParallel : public ppc::core::Task {
+  unsigned int CalculationOfCoefficient(const std::vector<double>& point);
+  void Recursive(std::vector<double>& _point, unsigned int& definition, unsigned int divider, unsigned int variable);
+  std::vector<double> GetPointFromNumber(unsigned int number);
+
+ public:
+  explicit TrapezoidalIntegrationTaskParallel(std::shared_ptr<ppc::core::TaskData> taskData_,
+                                              double (*_function)(std::vector<double>))
+      : Task(std::move(taskData_)), function(_function) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  double (*function)(std::vector<double>);
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> number_of_intervals;
+  double result;
+
+  boost::mpi::communicator world;
+};
+
+}  // namespace kalyakina_a_trapezoidal_integration_mpi

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/perf_tests/main.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/perf_tests/main.cpp
@@ -1,0 +1,112 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <boost/mpi/timer.hpp>
+#include <cmath>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp"
+
+double function(std::vector<double> input) { return (-3 * pow(input[1], 2) * sin(5 * input[0])) / 2; };
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, TrapezoidalIntegrationParallel_pipeline_run) {
+  boost::mpi::communicator world;
+
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+  std::vector<unsigned int> count;
+  std::vector<double> out(1, 0.0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataParallel = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    limits = {{0.0, 1.0}, {4.0, 6.0}};
+    intervals = {500, 500};
+    count = std::vector<unsigned int>{2};
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+    taskDataParallel->inputs_count.emplace_back(count.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+    taskDataParallel->inputs_count.emplace_back(limits.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+    taskDataParallel->inputs_count.emplace_back(intervals.size());
+    taskDataParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataParallel->outputs_count.emplace_back(out.size());
+  }
+
+  auto testTaskParallel = std::make_shared<kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel>(
+      taskDataParallel, function);
+  ASSERT_EQ(testTaskParallel->validation(), true);
+  testTaskParallel->pre_processing();
+  testTaskParallel->run();
+  testTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskParallel);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_NEAR((pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10, out[0], 0.001);
+  }
+}
+
+TEST(kalyakina_a_trapezoidal_integration_mpi, TrapezoidalIntegrationParallel_task_run) {
+  boost::mpi::communicator world;
+
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> intervals;
+  std::vector<unsigned int> count;
+  std::vector<double> out(1, 0.0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataParallel = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    limits = {{0.0, 1.0}, {4.0, 6.0}};
+    intervals = {500, 500};
+    count = std::vector<unsigned int>{2};
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+    taskDataParallel->inputs_count.emplace_back(count.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+    taskDataParallel->inputs_count.emplace_back(limits.size());
+    taskDataParallel->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+    taskDataParallel->inputs_count.emplace_back(intervals.size());
+    taskDataParallel->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+    taskDataParallel->outputs_count.emplace_back(out.size());
+  }
+
+  auto testTaskParallel = std::make_shared<kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel>(
+      taskDataParallel, function);
+  ASSERT_EQ(testTaskParallel->validation(), true);
+  testTaskParallel->pre_processing();
+  testTaskParallel->run();
+  testTaskParallel->post_processing();
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perfAttr->current_timer = [&] { return current_timer.elapsed(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskParallel);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  if (world.rank() == 0) {
+    ppc::core::Perf::print_perf_statistic(perfResults);
+    ASSERT_NEAR((pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10, out[0], 0.001);
+  }
+}

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
@@ -45,11 +45,11 @@ bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel
 
   if (world.rank() == 0) {
     limits = std::vector<std::pair<double, double>>(taskData->inputs_count[1]);
-    std::pair<double, double>* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
+    auto* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
     std::copy(it1, it1 + taskData->inputs_count[1], limits.begin());
 
     number_of_intervals = std::vector<unsigned int>(taskData->inputs_count[2]);
-    unsigned int* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
+    auto* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
     std::copy(it2, it2 + taskData->inputs_count[2], number_of_intervals.begin());
 
     result = 0.0;
@@ -63,11 +63,9 @@ bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel
 
   if (world.rank() == 0) {
     // Check count elements of input and output
-    if ((taskData->inputs_count[0] != 1) ||
-        (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
-        (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1)) {
-      return false;
-    }
+    return !((taskData->inputs_count[0] != 1) ||
+             (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
+             (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1));
   }
 
   return true;
@@ -108,8 +106,8 @@ bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel
     }
   }
 
-  boost::mpi::scatter(world, &count_of_points[0], &local_count_of_points, 1, 0);
-  boost::mpi::scatter(world, &first_point_numbers[0], &local_first_point_numbers, 1, 0);
+  boost::mpi::scatter(world, count_of_points.data(), &local_count_of_points, 1, 0);
+  boost::mpi::scatter(world, first_point_numbers.data(), &local_first_point_numbers, 1, 0);
 
   for (unsigned int i = 0; i < local_count_of_points; i++) {
     std::vector<double> point = GetPointFromNumber(local_first_point_numbers + i);

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 Nesterov Alexander
+#include "mpi/kalyakina_a_trapezoidal_integration_mpi/include/ops_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <thread>
+#include <vector>
+
+unsigned int kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::CalculationOfCoefficient(
+    const std::vector<double>& point) {
+  unsigned int degree = limits.size();
+  for (unsigned int i = 0; i < limits.size(); i++) {
+    if ((limits[i].first == point[i]) || (limits[i].second == point[i])) {
+      degree--;
+    }
+  }
+
+  return pow(2, degree);
+}
+
+void kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::Recursive(std::vector<double>& _point,
+                                                                                            unsigned int& definition,
+                                                                                            unsigned int divider,
+                                                                                            unsigned int variable) {
+  if (variable > 0) {
+    Recursive(_point, definition, divider * (number_of_intervals[variable] + 1), variable - 1);
+  }
+  _point[variable] = limits[variable].first + definition / divider *
+                                                  (limits[variable].second - limits[variable].first) /
+                                                  number_of_intervals[variable];
+  definition = definition % divider;
+}
+
+std::vector<double> kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::GetPointFromNumber(
+    unsigned int number) {
+  std::vector<double> point(limits.size());
+  unsigned int definition = number;
+  Recursive(point, definition, 1, limits.size() - 1);
+
+  return point;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::pre_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    limits = std::vector<std::pair<double, double>>(taskData->inputs_count[1]);
+    std::pair<double, double>* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
+    std::copy(it1, it1 + taskData->inputs_count[1], limits.begin());
+
+    number_of_intervals = std::vector<unsigned int>(taskData->inputs_count[2]);
+    unsigned int* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
+    std::copy(it2, it2 + taskData->inputs_count[2], number_of_intervals.begin());
+
+    result = 0.0;
+  }
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::validation() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    // Check count elements of input and output
+    if ((taskData->inputs_count[0] != 1) ||
+        (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
+        (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::run() {
+  internal_order_test();
+
+  boost::mpi::broadcast(world, limits, 0);
+  boost::mpi::broadcast(world, number_of_intervals, 0);
+
+  std::vector<unsigned int> count_of_points;
+  std::vector<unsigned int> first_point_numbers;
+  unsigned int local_count_of_points;
+  unsigned int local_first_point_numbers;
+  double local_result = 0.0;
+
+  if (world.rank() == 0) {
+    count_of_points.resize(world.size());
+    first_point_numbers.resize(world.size());
+    unsigned int delta = 1;
+    unsigned int current_number = 0;
+    for (unsigned int i = 0; i < number_of_intervals.size(); i++) {
+      delta *= (number_of_intervals[i] + 1);
+    }
+    unsigned int remainder = delta % world.size();
+    delta /= world.size();
+    for (unsigned int i = 0; i < world.size() - remainder; i++) {
+      count_of_points[i] = delta;
+      first_point_numbers[i] = current_number;
+      current_number += delta;
+    }
+    delta++;
+    for (int i = world.size() - remainder; i < world.size(); i++) {
+      count_of_points[i] = delta;
+      first_point_numbers[i] = current_number;
+      current_number += delta;
+    }
+  }
+
+  boost::mpi::scatter(world, &count_of_points[0], &local_count_of_points, 1, 0);
+  boost::mpi::scatter(world, &first_point_numbers[0], &local_first_point_numbers, 1, 0);
+
+  for (unsigned int i = 0; i < local_count_of_points; i++) {
+    std::vector<double> point = GetPointFromNumber(local_first_point_numbers + i);
+    local_result += CalculationOfCoefficient(point) * function(point);
+  }
+
+  boost::mpi::reduce(world, local_result, result, std::plus(), 0);
+
+  if (world.rank() == 0) {
+    for (unsigned int i = 0; i < limits.size(); i++) {
+      result *= (limits[i].second - limits[i].first) / number_of_intervals[i];
+    }
+    result /= pow(2, limits.size());
+  }
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::post_processing() {
+  internal_order_test();
+
+  if (world.rank() == 0) {
+    reinterpret_cast<double*>(taskData->outputs[0])[0] = result;
+  }
+
+  world.barrier();
+  return true;
+}

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
@@ -6,6 +6,92 @@
 #include <thread>
 #include <vector>
 
+unsigned int kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::CalculationOfCoefficient(
+    const std::vector<double>& point) {
+  unsigned int degree = limits.size();
+  for (unsigned int i = 0; i < limits.size(); i++) {
+    if ((limits[i].first == point[i]) || (limits[i].second == point[i])) {
+      degree--;
+    }
+  }
+
+  return pow(2, degree);
+}
+
+void kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::Recursive(
+    std::vector<double>& _point, unsigned int& definition, unsigned int divider, unsigned int variable) {
+  if (variable > 0) {
+    Recursive(_point, definition, divider * (number_of_intervals[variable] + 1), variable - 1);
+  }
+  _point[variable] = limits[variable].first + definition / divider *
+                                                  (limits[variable].second - limits[variable].first) /
+                                                  number_of_intervals[variable];
+  definition = definition % divider;
+}
+
+std::vector<double> kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::GetPointFromNumber(
+    unsigned int number) {
+  std::vector<double> point(limits.size());
+  unsigned int definition = number;
+  Recursive(point, definition, 1, limits.size() - 1);
+
+  return point;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::pre_processing() {
+  internal_order_test();
+
+  limits = std::vector<std::pair<double, double>>(taskData->inputs_count[1]);
+  auto* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
+  std::copy(it1, it1 + taskData->inputs_count[1], limits.begin());
+
+  number_of_intervals = std::vector<unsigned int>(taskData->inputs_count[2]);
+  auto* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
+  std::copy(it2, it2 + taskData->inputs_count[2], number_of_intervals.begin());
+
+  result = 0.0;
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::validation() {
+  internal_order_test();
+
+  return ((taskData->inputs_count[0] == 1) &&
+          (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
+          (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::run() {
+  internal_order_test();
+
+  unsigned int count = 1;
+  for (unsigned int i = 0; i < number_of_intervals.size(); i++) {
+    count *= (number_of_intervals[i] + 1);
+  }
+
+  for (unsigned int i = 0; i < count; i++) {
+    std::vector<double> point = GetPointFromNumber(i);
+    result += CalculationOfCoefficient(point) * function(point);
+  }
+
+  for (unsigned int i = 0; i < limits.size(); i++) {
+    result *= (limits[i].second - limits[i].first) / number_of_intervals[i];
+  }
+
+  result /= pow(2, limits.size());
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::post_processing() {
+  internal_order_test();
+
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = result;
+
+  return true;
+}
+
 unsigned int kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::CalculationOfCoefficient(
     const std::vector<double>& point) {
   unsigned int degree = limits.size();

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
@@ -57,7 +57,7 @@ bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequenti
 bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskSequential::validation() {
   internal_order_test();
 
-  return ((taskData->inputs_count[0] == 1) &&
+  return ((taskData->inputs.size() == 3) && (taskData->inputs_count[0] == 1) &&
           (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
           (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
 }
@@ -147,14 +147,10 @@ bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel
 bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::validation() {
   internal_order_test();
 
-  if (world.rank() == 0) {
-    // Check count elements of input and output
-    return ((taskData->inputs_count[0] == 1) &&
-            (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
-            (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
-  }
-
-  return true;
+  return (world.rank() != 0) ||
+         ((taskData->inputs.size() == 3) && (taskData->inputs_count[0] == 1) &&
+          (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
+          (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
 }
 
 bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel::run() {

--- a/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
+++ b/tasks/mpi/kalyakina_a_trapezoidal_integration_mpi/src/ops_mpi.cpp
@@ -63,9 +63,9 @@ bool kalyakina_a_trapezoidal_integration_mpi::TrapezoidalIntegrationTaskParallel
 
   if (world.rank() == 0) {
     // Check count elements of input and output
-    return !((taskData->inputs_count[0] != 1) ||
-             (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
-             (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1));
+    return ((taskData->inputs_count[0] == 1) &&
+            (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
+            (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
   }
 
   return true;

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -58,13 +58,13 @@ void TestOfFunction(double (*function)(std::vector<double>), std::vector<unsigne
   TaskSequential.run();
   TaskSequential.post_processing();
 
-  EXPECT_NEAR(answer, out[0], 0.001);
+  EXPECT_NEAR(answer, out[0], 0.006);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_count_of_variables) {
   std::vector<unsigned int> count(1, 3);
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
-  std::vector<unsigned int> intervals = {1000, 1000};
+  std::vector<unsigned int> intervals = {100, 100};
 
   TestOfValidation(function1, count, limits, intervals);
 }
@@ -72,7 +72,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_count_of_variab
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_numbers_of_intervals) {
   std::vector<unsigned int> count(1, 2);
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
-  std::vector<unsigned int> intervals = {1000};
+  std::vector<unsigned int> intervals = {100};
 
   TestOfValidation(function1, count, limits, intervals);
 }
@@ -80,7 +80,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_numbers_of
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_limits) {
   std::vector<unsigned int> count(1, 2);
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}};
-  std::vector<unsigned int> intervals = {1000, 1000};
+  std::vector<unsigned int> intervals = {100, 100};
 
   TestOfValidation(function1, count, limits, intervals);
 }
@@ -88,7 +88,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_limits) {
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_1) {
   std::vector<unsigned int> count(1, 2);
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
-  std::vector<unsigned int> intervals = {1000, 1000};
+  std::vector<unsigned int> intervals = {100, 100};
 
   TestOfFunction(function1, count, limits, intervals,
                  (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
@@ -97,7 +97,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_1) {
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_2) {
   std::vector<unsigned int> count(1, 3);
   std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
-  std::vector<unsigned int> intervals = {100, 100, 100};
+  std::vector<unsigned int> intervals = {50, 50, 50};
 
   TestOfFunction(function2, count, limits, intervals, -3 * std::cos(1) + 3 * std::cos(0));
 }
@@ -105,7 +105,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_2) {
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_3) {
   std::vector<unsigned int> count(1, 3);
   std::vector<std::pair<double, double>> limits = {{0.0, 3.0}, {0.0, 4.0}, {0.0, 5.0}};
-  std::vector<unsigned int> intervals = {100, 100, 100};
+  std::vector<unsigned int> intervals = {50, 50, 50};
 
   TestOfFunction(function3, count, limits, intervals, pow(3 - 0, 2) * pow(4 - 0, 2) * pow(5 - 0, 2));
 }
@@ -113,7 +113,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_3) {
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_4) {
   std::vector<unsigned int> count(1, 1);
   std::vector<std::pair<double, double>> limits = {{0.0, 0.5}};
-  std::vector<unsigned int> intervals = {10000};
+  std::vector<unsigned int> intervals = {1000};
 
   TestOfFunction(function4, count, limits, intervals, acos(0.5) - acos(0));
 }
@@ -121,7 +121,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_4) {
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_5) {
   std::vector<unsigned int> count(1, 2);
   std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {0.0, 1.0}};
-  std::vector<unsigned int> intervals = {1000, 1000};
+  std::vector<unsigned int> intervals = {100, 100};
 
   TestOfFunction(function5, count, limits, intervals, (sin(1) - sin(0)) * (cos(1) - cos(0)));
 }
@@ -129,7 +129,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_5) {
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_6) {
   std::vector<unsigned int> count(1, 2);
   std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {4.0, 6.0}};
-  std::vector<unsigned int> intervals = {1000, 1000};
+  std::vector<unsigned int> intervals = {100, 100};
 
   TestOfFunction(function6, count, limits, intervals, (pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10);
 }

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <vector>
 #include <random>
+#include <vector>
 
 #include "seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp"
 

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -14,8 +14,7 @@ double function5(std::vector<double> input) { return -(sin(input[0]) * cos(input
 double function6(std::vector<double> input) { return (-3 * pow(input[1], 2) * sin(5 * input[0])) / 2; };
 
 void TestOfValidation(double (*function)(std::vector<double>), std::vector<unsigned int>& count,
-                      std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals,
-                      double answer) {
+                      std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals) {
   std::vector<double> out(1, 0.0);
 
   // Create TaskData
@@ -67,8 +66,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_count_of_variab
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
   std::vector<unsigned int> intervals = {1000, 1000};
 
-  TestOfValidation(function1, count, limits, intervals,
-                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+  TestOfValidation(function1, count, limits, intervals);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_numbers_of_intervals) {
@@ -76,8 +74,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_numbers_of
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
   std::vector<unsigned int> intervals = {1000};
 
-  TestOfValidation(function1, count, limits, intervals,
-                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+  TestOfValidation(function1, count, limits, intervals);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_limits) {
@@ -85,8 +82,7 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_limits) {
   std::vector<std::pair<double, double>> limits = {{2.5, 4.5}};
   std::vector<unsigned int> intervals = {1000, 1000};
 
-  TestOfValidation(function1, count, limits, intervals,
-                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+  TestOfValidation(function1, count, limits, intervals);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_1) {

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -1,0 +1,139 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp"
+
+double function1(std::vector<double> input) { return pow(input[0], 3) + pow(input[1], 3); };
+double function2(std::vector<double> input) { return sin(input[0]) + sin(input[1]) + sin(input[2]); };
+double function3(std::vector<double> input) { return 8 * input[0] * input[1] * input[2]; };
+double function4(std::vector<double> input) { return -1.0 / sqrt(1 - pow(input[0], 2)); };
+double function5(std::vector<double> input) { return -(sin(input[0]) * cos(input[1])); };
+double function6(std::vector<double> input) { return (-3 * pow(input[1], 2) * sin(5 * input[0])) / 2; };
+
+void TestOfValidation(double (*function)(std::vector<double>), std::vector<unsigned int>& count,
+                      std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals,
+                      double answer) {
+  std::vector<double> out(1, 0.0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSequential = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+  taskDataSequential->inputs_count.emplace_back(count.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+  taskDataSequential->inputs_count.emplace_back(limits.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+  taskDataSequential->inputs_count.emplace_back(intervals.size());
+  taskDataSequential->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSequential->outputs_count.emplace_back(out.size());
+
+  kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask TaskSequential(taskDataSequential, function);
+
+  ASSERT_EQ(TaskSequential.validation(), false);
+}
+
+void TestOfFunction(double (*function)(std::vector<double>), std::vector<unsigned int>& count,
+                    std::vector<std::pair<double, double>>& limits, std::vector<unsigned int>& intervals,
+                    double answer) {
+  std::vector<double> out(1, 0.0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSequential = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+  taskDataSequential->inputs_count.emplace_back(count.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+  taskDataSequential->inputs_count.emplace_back(limits.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+  taskDataSequential->inputs_count.emplace_back(intervals.size());
+  taskDataSequential->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSequential->outputs_count.emplace_back(out.size());
+
+  kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask TaskSequential(taskDataSequential, function);
+
+  ASSERT_EQ(TaskSequential.validation(), true);
+  TaskSequential.pre_processing();
+  TaskSequential.run();
+  TaskSequential.post_processing();
+
+  EXPECT_NEAR(answer, out[0], 0.001);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_count_of_variables) {
+  std::vector<unsigned int> count(1, 3);
+  std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
+  std::vector<unsigned int> intervals = {1000, 1000};
+
+  TestOfValidation(function1, count, limits, intervals,
+                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_numbers_of_intervals) {
+  std::vector<unsigned int> count(1, 2);
+  std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
+  std::vector<unsigned int> intervals = {1000};
+
+  TestOfValidation(function1, count, limits, intervals,
+                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_size_limits) {
+  std::vector<unsigned int> count(1, 2);
+  std::vector<std::pair<double, double>> limits = {{2.5, 4.5}};
+  std::vector<unsigned int> intervals = {1000, 1000};
+
+  TestOfValidation(function1, count, limits, intervals,
+                   (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_1) {
+  std::vector<unsigned int> count(1, 2);
+  std::vector<std::pair<double, double>> limits = {{2.5, 4.5}, {1.0, 3.2}};
+  std::vector<unsigned int> intervals = {1000, 1000};
+
+  TestOfFunction(function1, count, limits, intervals,
+                 (3.2 - 1) * (pow(4.5, 4) - pow(2.5, 4)) / 4 + (4.5 - 2.5) * (pow(3.2, 4) - pow(1, 4)) / 4);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_2) {
+  std::vector<unsigned int> count(1, 3);
+  std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+  std::vector<unsigned int> intervals = {100, 100, 100};
+
+  TestOfFunction(function2, count, limits, intervals, -3 * std::cos(1) + 3 * std::cos(0));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_3) {
+  std::vector<unsigned int> count(1, 3);
+  std::vector<std::pair<double, double>> limits = {{0.0, 3.0}, {0.0, 4.0}, {0.0, 5.0}};
+  std::vector<unsigned int> intervals = {100, 100, 100};
+
+  TestOfFunction(function3, count, limits, intervals, pow(3 - 0, 2) * pow(4 - 0, 2) * pow(5 - 0, 2));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_4) {
+  std::vector<unsigned int> count(1, 1);
+  std::vector<std::pair<double, double>> limits = {{0.0, 0.5}};
+  std::vector<unsigned int> intervals = {10000};
+
+  TestOfFunction(function4, count, limits, intervals, acos(0.5) - acos(0));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_5) {
+  std::vector<unsigned int> count(1, 2);
+  std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {0.0, 1.0}};
+  std::vector<unsigned int> intervals = {1000, 1000};
+
+  TestOfFunction(function5, count, limits, intervals, (sin(1) - sin(0)) * (cos(1) - cos(0)));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_6) {
+  std::vector<unsigned int> count(1, 2);
+  std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {4.0, 6.0}};
+  std::vector<unsigned int> intervals = {1000, 1000};
+
+  TestOfFunction(function6, count, limits, intervals, (pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10);
+}

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -156,8 +156,8 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_6) {
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_random_limits) {
   std::vector<unsigned int> count(1, 3);
-  std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 10.0), GetRandomLimit(0.0, 10.0),
-                                                   GetRandomLimit(0.0, 10.0)};
+  std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 1.0), GetRandomLimit(0.0, 1.0),
+                                                   GetRandomLimit(0.0, 1.0)};
   std::vector<unsigned int> intervals = {50, 50, 50};
 
   TestOfFunction(function3, count, limits, intervals,
@@ -169,18 +169,18 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_random_limit
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_intervals) {
   std::vector<unsigned int> count(1, 3);
   std::vector<std::pair<double, double>> limits = {{0.0, 3.0}, {0.0, 4.0}, {0.0, 5.0}};
-  std::vector<unsigned int> intervals = {GetRandomIntegerData(50, 80), GetRandomIntegerData(50, 80),
-                                         GetRandomIntegerData(50, 80)};
+  std::vector<unsigned int> intervals = {GetRandomIntegerData(40, 60), GetRandomIntegerData(40, 60),
+                                         GetRandomIntegerData(40, 60)};
 
   TestOfFunction(function3, count, limits, intervals, pow(3 - 0, 2) * pow(4 - 0, 2) * pow(5 - 0, 2));
 }
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_limits_and_intervals) {
   std::vector<unsigned int> count(1, 3);
-  std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 10.0), GetRandomLimit(0.0, 10.0),
-                                                   GetRandomLimit(0.0, 10.0)};
-  std::vector<unsigned int> intervals = {GetRandomIntegerData(50, 80), GetRandomIntegerData(50, 80),
-                                         GetRandomIntegerData(50, 80)};
+  std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 1.0), GetRandomLimit(0.0, 1.0),
+                                                   GetRandomLimit(0.0, 1.0)};
+  std::vector<unsigned int> intervals = {GetRandomIntegerData(40, 60), GetRandomIntegerData(40, 60),
+                                         GetRandomIntegerData(40, 60)};
 
   TestOfFunction(function3, count, limits, intervals,
                  (pow(limits[0].second, 2) - pow(limits[0].first, 2)) *

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -78,7 +78,7 @@ void TestOfFunction(double (*function)(std::vector<double>), std::vector<unsigne
   TaskSequential.run();
   TaskSequential.post_processing();
 
-  EXPECT_NEAR(answer, out[0], 0.006);
+  EXPECT_NEAR(answer, out[0], 0.05);
 }
 
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_validation_count_of_variables) {

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -3,8 +3,28 @@
 
 #include <cmath>
 #include <vector>
+#include <random>
 
 #include "seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp"
+
+std::pair<double, double> GetRandomLimit(double min_value, double max_value) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::pair<double, double> result;
+  max_value = max_value * 1000 - 5;
+  min_value *= 1000;
+  result.first = (double)(gen() % (int)(max_value - min_value) + min_value) / 1000;
+  max_value += 5;
+  min_value = result.first * 1000;
+  result.second = (double)(gen() % (int)(max_value - min_value) + min_value) / 1000;
+  return result;
+}
+
+unsigned int GetRandomIntegerData(unsigned int min_value, unsigned int max_value) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  return gen() % (max_value - min_value) + min_value;
+}
 
 double function1(std::vector<double> input) { return pow(input[0], 3) + pow(input[1], 3); };
 double function2(std::vector<double> input) { return sin(input[0]) + sin(input[1]) + sin(input[2]); };
@@ -132,4 +152,38 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_6) {
   std::vector<unsigned int> intervals = {100, 100};
 
   TestOfFunction(function6, count, limits, intervals, (pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_random_limits) {
+  std::vector<unsigned int> count(1, 3);
+  std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 10.0), GetRandomLimit(0.0, 10.0),
+                                                   GetRandomLimit(0.0, 10.0)};
+  std::vector<unsigned int> intervals = {50, 50, 50};
+
+  TestOfFunction(function3, count, limits, intervals,
+                 (pow(limits[0].second, 2) - pow(limits[0].first, 2)) *
+                     (pow(limits[1].second, 2) - pow(limits[1].first, 2)) *
+                     (pow(limits[2].second, 2) - pow(limits[2].first, 2)));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_intervals) {
+  std::vector<unsigned int> count(1, 3);
+  std::vector<std::pair<double, double>> limits = {{0.0, 3.0}, {0.0, 4.0}, {0.0, 5.0}};
+  std::vector<unsigned int> intervals = {GetRandomIntegerData(50, 80), GetRandomIntegerData(50, 80),
+                                         GetRandomIntegerData(50, 80)};
+
+  TestOfFunction(function3, count, limits, intervals, pow(3 - 0, 2) * pow(4 - 0, 2) * pow(5 - 0, 2));
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_limits_and_intervals) {
+  std::vector<unsigned int> count(1, 3);
+  std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 10.0), GetRandomLimit(0.0, 10.0),
+                                                   GetRandomLimit(0.0, 10.0)};
+  std::vector<unsigned int> intervals = {GetRandomIntegerData(50, 80), GetRandomIntegerData(50, 80),
+                                         GetRandomIntegerData(50, 80)};
+
+  TestOfFunction(function3, count, limits, intervals,
+                 (pow(limits[0].second, 2) - pow(limits[0].first, 2)) *
+                     (pow(limits[1].second, 2) - pow(limits[1].first, 2)) *
+                     (pow(limits[2].second, 2) - pow(limits[2].first, 2)));
 }

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/func_tests/main.cpp
@@ -169,8 +169,8 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_random_limit
 TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_intervals) {
   std::vector<unsigned int> count(1, 3);
   std::vector<std::pair<double, double>> limits = {{0.0, 3.0}, {0.0, 4.0}, {0.0, 5.0}};
-  std::vector<unsigned int> intervals = {GetRandomIntegerData(40, 60), GetRandomIntegerData(40, 60),
-                                         GetRandomIntegerData(40, 60)};
+  std::vector<unsigned int> intervals = {GetRandomIntegerData(40, 50), GetRandomIntegerData(40, 50),
+                                         GetRandomIntegerData(40, 50)};
 
   TestOfFunction(function3, count, limits, intervals, pow(3 - 0, 2) * pow(4 - 0, 2) * pow(5 - 0, 2));
 }
@@ -179,8 +179,8 @@ TEST(kalyakina_a_trapezoidal_integration_seq, Test_of_functionality_limits_and_i
   std::vector<unsigned int> count(1, 3);
   std::vector<std::pair<double, double>> limits = {GetRandomLimit(0.0, 1.0), GetRandomLimit(0.0, 1.0),
                                                    GetRandomLimit(0.0, 1.0)};
-  std::vector<unsigned int> intervals = {GetRandomIntegerData(40, 60), GetRandomIntegerData(40, 60),
-                                         GetRandomIntegerData(40, 60)};
+  std::vector<unsigned int> intervals = {GetRandomIntegerData(40, 50), GetRandomIntegerData(40, 50),
+                                         GetRandomIntegerData(40, 50)};
 
   TestOfFunction(function3, count, limits, intervals,
                  (pow(limits[0].second, 2) - pow(limits[0].first, 2)) *

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Nesterov Alexander
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kalyakina_a_trapezoidal_integration_seq {
+
+class TrapezoidalIntegrationTask : public ppc::core::Task {
+  unsigned int CalculationOfCoefficient(const std::vector<double>& point);
+  void Recursive(std::vector<double>& _point, unsigned int& definition, unsigned int divider, unsigned int variable);
+  std::vector<double> GetPointFromNumber(unsigned int number);
+
+ public:
+  explicit TrapezoidalIntegrationTask(std::shared_ptr<ppc::core::TaskData> taskData_,
+                                      double (*_function)(std::vector<double>))
+      : Task(std::move(taskData_)), function(_function) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  double (*function)(std::vector<double>);
+  std::vector<std::pair<double, double>> limits;
+  std::vector<unsigned int> number_of_intervals;
+  double result;
+};
+
+}  // namespace kalyakina_a_trapezoidal_integration_seq

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/perf_tests/main.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/perf_tests/main.cpp
@@ -1,0 +1,98 @@
+// Copyright 2023 Nesterov Alexander
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp"
+
+double function(std::vector<double> input) { return (-3 * pow(input[1], 2) * sin(5 * input[0])) / 2; };
+
+TEST(kalyakina_a_trapezoidal_integration_seq, TrapezoidalIntegrationSequential) {
+  // Create data
+  std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {4.0, 6.0}};
+  std::vector<unsigned int> intervals = {500, 500};
+  std::vector<unsigned int> count(1, 2);
+  std::vector<double> out(1, 0.0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSequential = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+  taskDataSequential->inputs_count.emplace_back(count.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+  taskDataSequential->inputs_count.emplace_back(limits.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+  taskDataSequential->inputs_count.emplace_back(intervals.size());
+  taskDataSequential->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSequential->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto testTaskSequential = std::make_shared<kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask>(
+      taskDataSequential, function);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_NEAR((pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10, out[0], 0.001);
+}
+
+TEST(kalyakina_a_trapezoidal_integration_seq, TrapezoidalIntegrationSequential_task_run) {
+  // Create data
+  std::vector<std::pair<double, double>> limits = {{0.0, 1.0}, {4.0, 6.0}};
+  std::vector<unsigned int> intervals = {500, 500};
+  std::vector<unsigned int> count(1, 2);
+  std::vector<double> out(1, 0.0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSequential = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(count.data()));
+  taskDataSequential->inputs_count.emplace_back(count.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(limits.data()));
+  taskDataSequential->inputs_count.emplace_back(limits.size());
+  taskDataSequential->inputs.emplace_back(reinterpret_cast<uint8_t*>(intervals.data()));
+  taskDataSequential->inputs_count.emplace_back(intervals.size());
+  taskDataSequential->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  taskDataSequential->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto testTaskSequential = std::make_shared<kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask>(
+      taskDataSequential, function);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_NEAR((pow(6.0, 3) - pow(4.0, 3)) * (cos(5 * 1.0) - cos(5 * 0.0)) / 10, out[0], 0.001);
+}

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
@@ -1,0 +1,99 @@
+// Copyright 2023 Nesterov Alexander
+#include "seq/kalyakina_a_trapezoidal_integration_seq/include/ops_seq.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <thread>
+#include <vector>
+
+unsigned int kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::CalculationOfCoefficient(
+    const std::vector<double>& point) {
+  unsigned int degree = limits.size();
+  for (unsigned int i = 0; i < limits.size(); i++) {
+    if ((limits[i].first == point[i]) || (limits[i].second == point[i])) {
+      degree--;
+    }
+  }
+
+  return pow(2, degree);
+}
+
+void kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::Recursive(std::vector<double>& _point,
+                                                                                    unsigned int& definition,
+                                                                                    unsigned int divider,
+                                                                                    unsigned int variable) {
+  if (variable > 0) {
+    Recursive(_point, definition, divider * (number_of_intervals[variable] + 1), variable - 1);
+  }
+  _point[variable] = limits[variable].first + definition / divider *
+                                                  (limits[variable].second - limits[variable].first) /
+                                                  number_of_intervals[variable];
+  definition = definition % divider;
+}
+
+std::vector<double> kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::GetPointFromNumber(
+    unsigned int number) {
+  std::vector<double> point(limits.size());
+  unsigned int definition = number;
+  Recursive(point, definition, 1, limits.size() - 1);
+
+  return point;
+}
+
+bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::pre_processing() {
+  internal_order_test();
+
+  limits = std::vector<std::pair<double, double>>(taskData->inputs_count[1]);
+  std::pair<double, double>* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
+  std::copy(it1, it1 + taskData->inputs_count[1], limits.begin());
+
+  number_of_intervals = std::vector<unsigned int>(taskData->inputs_count[2]);
+  unsigned int* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
+  std::copy(it2, it2 + taskData->inputs_count[2], number_of_intervals.begin());
+
+  result = 0.0;
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::validation() {
+  internal_order_test();
+
+  if ((taskData->inputs_count[0] != 1) ||
+      (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
+      (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::run() {
+  internal_order_test();
+
+  unsigned int count = 1;
+  for (unsigned int i = 0; i < number_of_intervals.size(); i++) {
+    count *= (number_of_intervals[i] + 1);
+  }
+
+  for (unsigned int i = 0; i < count; i++) {
+    std::vector<double> point = GetPointFromNumber(i);
+    result += CalculationOfCoefficient(point) * function(point);
+  }
+
+  for (unsigned int i = 0; i < limits.size(); i++) {
+    result *= (limits[i].second - limits[i].first) / number_of_intervals[i];
+  }
+
+  result /= pow(2, limits.size());
+
+  return true;
+}
+
+bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::post_processing() {
+  internal_order_test();
+
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = result;
+
+  return true;
+}

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
@@ -59,7 +59,7 @@ bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::pre_pr
 bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::validation() {
   internal_order_test();
 
-  return ((taskData->inputs_count[0] == 1) &&
+  return ((taskData->inputs.size() == 3) && (taskData->inputs_count[0] == 1) &&
           (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
           (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
 }

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
@@ -59,9 +59,9 @@ bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::pre_pr
 bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::validation() {
   internal_order_test();
 
-  return !((taskData->inputs_count[0] != 1) ||
-           (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
-           (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1));
+  return ((taskData->inputs_count[0] == 1) &&
+          (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] == taskData->inputs_count[1]) &&
+          (taskData->inputs_count[1] == taskData->inputs_count[2]) && (taskData->outputs_count[0] == 1));
 }
 
 bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::run() {

--- a/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
+++ b/tasks/seq/kalyakina_a_trapezoidal_integration_seq/src/ops_seq.cpp
@@ -44,11 +44,11 @@ bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::pre_pr
   internal_order_test();
 
   limits = std::vector<std::pair<double, double>>(taskData->inputs_count[1]);
-  std::pair<double, double>* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
+  auto* it1 = reinterpret_cast<std::pair<double, double>*>(taskData->inputs[1]);
   std::copy(it1, it1 + taskData->inputs_count[1], limits.begin());
 
   number_of_intervals = std::vector<unsigned int>(taskData->inputs_count[2]);
-  unsigned int* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
+  auto* it2 = reinterpret_cast<unsigned int*>(taskData->inputs[2]);
   std::copy(it2, it2 + taskData->inputs_count[2], number_of_intervals.begin());
 
   result = 0.0;
@@ -59,13 +59,9 @@ bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::pre_pr
 bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::validation() {
   internal_order_test();
 
-  if ((taskData->inputs_count[0] != 1) ||
-      (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
-      (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1)) {
-    return false;
-  }
-
-  return true;
+  return !((taskData->inputs_count[0] != 1) ||
+           (reinterpret_cast<unsigned int*>(taskData->inputs[0])[0] != taskData->inputs_count[1]) ||
+           (taskData->inputs_count[1] != taskData->inputs_count[2]) || (taskData->outputs_count[0] != 1));
 }
 
 bool kalyakina_a_trapezoidal_integration_seq::TrapezoidalIntegrationTask::run() {


### PR DESCRIPTION
Изменены параметры функциональных тестов: понижено количество шагов интегрирования для seq_func_tests для выполнения ограничения по времени. 

Данная реализация имеет одно слабое место: количество подсчетов значения функции, а именно чем больше шагов при интегрировании, тем дольше выполняется программа, несмотря на то, что в каждой точке функция считается ровно один раз, независимо от количества вхождений точки в сумму (это определяется расчетом коэффициента)